### PR TITLE
Shrink package templates in size and complexity

### DIFF
--- a/assets/additional_yaml/ozw.yaml
+++ b/assets/additional_yaml/ozw.yaml
@@ -1,5 +1,5 @@
 input_boolean:
-    allow_automation_execution:
+    keymaster_allow_automation_execution:
         name: 'Allow Automation'
         initial: off
 
@@ -22,7 +22,7 @@ automation:
           to: "off"
       action:
         - service: homeassistant.turn_off
-          entity_id: input_boolean.allow_automation_execution
+          entity_id: input_boolean.keymaster_allow_automation_execution
 
     - alias: open_zwave_network_up
       initial_state: true
@@ -38,4 +38,4 @@ automation:
           state: "on"
       action:
         - service: homeassistant.turn_on
-          entity_id: input_boolean.allow_automation_execution
+          entity_id: input_boolean.keymaster_allow_automation_execution

--- a/assets/additional_yaml/ozw.yaml
+++ b/assets/additional_yaml/ozw.yaml
@@ -3,30 +3,15 @@ input_boolean:
         name: 'Allow Automation'
         initial: off
 
-    system_ready:
-        name: 'System Ready'
-        initial: off
-
 binary_sensor:
 
     - platform: mqtt
       name: ozw_network_status
       state_topic: OpenZWave/1/status/
       value_template: >
-          {{ "ON" if value_json.Status in ["driverAwakeNodesQueried", "driverAllNodesQueriedSomeDead", "driverAllNodesQueried"] else "OFF" }}
+          {{ "on" if value_json.Status in ["driverAwakeNodesQueried", "driverAllNodesQueriedSomeDead", "driverAllNodesQueried"] else "off" }}
       json_attributes_topic: OpenZWave/1/status/
       device_class: "connectivity"
-
-    - platform: template
-      sensors:
-
-        allow_automation:
-          friendly_name: "Allow Automation"
-          value_template: "{{ is_state('input_boolean.allow_automation_execution', 'on') }}"   
-
-        system_ready:
-          friendly_name: "System ready"
-          value_template: "{{ is_state('input_boolean.system_ready', 'on') }}"
 
 automation:
     - alias: open_zwave_network_down

--- a/assets/additional_yaml/zwave.yaml
+++ b/assets/additional_yaml/zwave.yaml
@@ -3,22 +3,6 @@ input_boolean:
         name: 'Allow Automation'
         initial: off
 
-    system_ready:
-        name: 'System Ready'
-        initial: off
-
-binary_sensor:
-    - platform: template
-      sensors:
-
-        allow_automation:
-          friendly_name: "Allow Automation"
-          value_template: "{{ is_state('input_boolean.allow_automation_execution', 'on') }}"    
-
-        system_ready:
-          friendly_name: "System ready"
-          value_template: "{{ is_state('input_boolean.system_ready', 'on') }}"
-
 automation:
     - alias: open_zwave_network_down
       initial_state: true

--- a/assets/additional_yaml/zwave.yaml
+++ b/assets/additional_yaml/zwave.yaml
@@ -1,5 +1,5 @@
 input_boolean:
-    allow_automation_execution:
+    keymaster_allow_automation_execution:
         name: 'Allow Automation'
         initial: off
 
@@ -11,7 +11,7 @@ automation:
         event_type: zwave.network_stop
       action:
         - service: homeassistant.turn_off
-          entity_id: input_boolean.allow_automation_execution
+          entity_id: input_boolean.keymaster_allow_automation_execution
 
     - alias: open_zwave_network_up
       initial_state: true
@@ -24,4 +24,4 @@ automation:
           event_type: zwave.network_complete_some_dead
       action:
         - service: homeassistant.turn_on
-          entity_id: input_boolean.allow_automation_execution
+          entity_id: input_boolean.keymaster_allow_automation_execution

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -256,7 +256,9 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         )
 
         # Unsubscribe to any listeners
-        for unsub_listener in hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []):
+        for unsub_listener in hass.data[DOMAIN][config_entry.entry_id].get(
+            UNSUB_LISTENERS, []
+        ):
             unsub_listener()
         hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []).clear()
 
@@ -357,7 +359,9 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
         handle_state_change(hass, config_entry, changed_entity, old_state, new_state)
 
     # Unsubscribe to any listeners so we can create new ones
-    for unsub_listener in hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []):
+    for unsub_listener in hass.data[DOMAIN][config_entry.entry_id].get(
+        UNSUB_LISTENERS, []
+    ):
         unsub_listener()
     hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []).clear()
 

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -394,7 +394,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
         data = ""
 
         # Build data from entities
-        enabled_bool = f"input_boolean.enabled_{self._lock.lock_name}_{code_slot}"
+        enabled_bool = f"input_boolean.{self._lock.lock_name}_enabled_{code_slot}"
         enabled = self.hass.states.get(enabled_bool)
         pin_data = f"input_text.{self._lock.lock_name}_pin_{code_slot}"
         pin = self.hass.states.get(pin_data)
@@ -497,7 +497,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
 
                 # Build data from entities
                 enabled_bool = (
-                    f"input_boolean.enabled_{self._lock.lock_name}_{value.index}"
+                    f"input_boolean.{self._lock.lock_name}_enabled_{value.index}"
                 )
                 enabled = self.hass.states.get(enabled_bool)
 

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -235,45 +235,7 @@ binary_sensor:
     active_LOCKNAME_TEMPLATENUM:
       friendly_name: "Desired PIN State"
       value_template: >-
-        {% set day = now().strftime('%a') | lower %}
-        {## day_check checks that the day is enabled, and if the day is marked as ##}
-        {## included, we check that either the time is within the specified range or ##}
-        {## no range is specified. If the day is marked as excluded, we check that ##}
-        {## the time is outside the specified range ##}
-        {% set day_check = (
-          is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on')
-          and 
-          (
-            (
-              is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
-              and
-              (
-                states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')
-                or
-                (
-                  now().strftime('%H%M') | int >= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
-                  and
-                  now().strftime('%H%M') | int | int <= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
-                )
-              )
-            )
-            or
-            (
-              is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'off')
-              and
-              now().strftime('%H%M') | int | int <= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
-              and
-              now().strftime('%H%M') | int | int >= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
-            )
-          )
-        ) %}
-        {## access_count_check checks that either the access limit is disabled or ##}
-        {## the access count > 0 ##}
-        {% set access_count_check = (
-          is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off')
-          or
-          states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state | int > 0
-        ) %}
+        {% set day = now().strftime('%a')[0:3] | lower %}
         {## in_date_range checks that the daterange boolean is disabled or the ##}
         {## current date is within the configured date range ##}
         {% set in_date_range_check = (
@@ -285,14 +247,48 @@ binary_sensor:
             now().strftime('%Y%m%d') | int <= states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int
           )
         ) %}
+        {## in_time_range_check checks that the current time is in the appropriate ##}
+        {## depending on whether the day is marked as inclusive or exclusive. ##}
+        {% set in_time_range_check = (
+          (
+            is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
+            and
+            (
+              states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')
+              or
+              (
+                now().strftime('%H%M') | int >= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+                and
+                now().strftime('%H%M') | int <= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+              )
+            )
+          )
+          or
+          (
+            is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'off')
+            and
+            now().strftime('%H%M') | int <= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+            and
+            now().strftime('%H%M') | int >= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+          )
+        ) %}
+        {## access_count_check checks that either the access limit is disabled or ##}
+        {## the access count > 0 ##}
+        {% set access_count_check = (
+          is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off')
+          or
+          states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state | int > 0
+        ) %}
         {{
           is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on')
           and
-          access_count_check
+          is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on')
           and
           in_date_range_check
           and
-          day_check
+          in_time_range_check
+          and
+          access_count_check
         }}
 
     pin_synched_LOCKNAME_TEMPLATENUM:

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -234,8 +234,8 @@ binary_sensor:
     active_LOCKNAME_TEMPLATENUM:
       friendly_name: "Desired PIN State"
       value_template: >-
-        {% set current_day = (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower %}
-        {% set current_date = (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%Y%m%d') | int %}
+        {% set current_day = strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower %}
+        {% set current_date = strptime(states('sensor.date'), '%Y-%m-%d').strftime('%Y%m%d') | int %}
         {% set current_time = states('sensor.time').replace(":","") | int %}
         {% set configured_start_time = (states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
         {% set configured_end_time = (states('input_datetime.' + current_day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
@@ -340,7 +340,7 @@ sensor:
         } %}
         {% set slot_active = states('binary_sensor.active_LOCKNAME_TEMPLATENUM') %}
         {% set pin_synched = states('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM') %}
-        {{ value_map[slot_active][pin_synched] }}
+        {{ value_map.get(slot_active, {}).get(pin_synched) }}
       icon_template: >
         {% set icon_map = {
           'on': {
@@ -354,4 +354,4 @@ sensor:
         } %}
         {% set slot_active = states('binary_sensor.active_LOCKNAME_TEMPLATENUM') %}
         {% set pin_synched = states('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM') %}
-        {{ icon_map[slot_active][pin_synched] }}
+        {{ icon_map.get(slot_active, {}).get(pin_synched) }}

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -174,13 +174,13 @@ automation:
       entity_id: "binary_sensor.LOCKNAME_pin_synched_TEMPLATENUM"
       to: 'off'
     - platform: state
-      entity_id: "input_boolean.allow_automation_execution"
+      entity_id: "input_boolean.keymaster_allow_automation_execution"
       to: 'on'
     - platform: state
       entity_id: "sensor.LOCKNAME_code_slot_TEMPLATENUM"
   condition:
     - condition: state
-      entity_id: "input_boolean.allow_automation_execution"
+      entity_id: "input_boolean.keymaster_allow_automation_execution"
       state: "on"
     - condition: state
       entity_id: "binary_sensor.LOCKNAME_pin_synched_TEMPLATENUM"

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -1,5 +1,5 @@
 
-############  input_number:  #####################  
+############  input_number:  #####################
 input_number:
   accesscount_LOCKNAME_TEMPLATENUM:
     name: 'Unlock events'
@@ -8,7 +8,7 @@ input_number:
     step: 1
     mode: box
 
-#################  input_datetime:  ##############  
+#################  input_datetime:  ##############
 input_datetime:
   end_date_LOCKNAME_TEMPLATENUM:
     name: 'End'
@@ -83,7 +83,7 @@ input_datetime:
     has_date: false
 
 
-####################  input_text:  ###############  
+####################  input_text:  ###############
 input_text:
   LOCKNAME_name_TEMPLATENUM:
     name: 'Name'
@@ -91,7 +91,7 @@ input_text:
     name: 'PIN'
     mode: HIDE_PINS
 
-#################  input_boolean: ################  
+#################  input_boolean:  ################
 input_boolean:
   notify_LOCKNAME_TEMPLATENUM:
     name: 'Notifications'
@@ -164,7 +164,7 @@ input_boolean:
     name: 'include (on)/exclude (off)'
     initial: on
 
-################  automation: #################  
+################  automation:  #################
 automation:
 
 - alias: synchronize_codeslot_LOCKNAME_TEMPLATENUM
@@ -226,7 +226,7 @@ automation:
       data_template:
         code_slot: TEMPLATENUM
       
-################  binary_sensor: #################  
+################  binary_sensor:  #################
 binary_sensor:
 
 - platform: template
@@ -290,7 +290,7 @@ binary_sensor:
     pin_synched_LOCKNAME_TEMPLATENUM:
       friendly_name: 'PIN synchronized with lock'
       value_template: >
-        {% set lockpin = states('sensor.LOCKNAME_code_slot_TEMPLATENUM')  %}
+        {% set lockpin = states('sensor.LOCKNAME_code_slot_TEMPLATENUM') %}
         {% if lockpin == "0000" %}
           {% set lockpin = "" %}
         {% endif %}
@@ -300,7 +300,7 @@ binary_sensor:
           {{ lockpin == "" }}
         {% endif %}
 
-###################  sensor:  ####################  
+###################  sensor:  ####################
 sensor:
 
 - platform: template

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -278,7 +278,7 @@ binary_sensor:
         {% if is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
           {{ is_state('input_text.LOCKNAME_pin_TEMPLATENUM', lockpin) }}
         {% else %}
-          {{ lockpin in ("", "0000" }}
+          {{ lockpin in ("", "0000") }}
         {% endif %}
 
 ###################  sensor:  ####################

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -232,6 +232,7 @@ binary_sensor:
       value_template: >-
         {## This template checks whether the PIN should be considered active based on ##}
         {## all of the different ways the PIN can be conditionally disabled ##}
+
         {% set now = now() %}
 
         {% set current_day = now.strftime('%a')[0:3] | lower %}

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -279,7 +279,8 @@ binary_sensor:
           )
         ) %}
         {{
-          is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on') and
+          is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on')
+          and
           access_count_check
           and
           in_date_range_check

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -239,13 +239,13 @@ binary_sensor:
         {% for day in ('sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat') if not smtwtfs.check %}
           {% if
             is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on') and 
-            (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a')|lower == day) and
+            strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == day and
             is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'on') and
             (
               states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM') or
               (
-                states('sensor.time') >= states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5] and
-                states('sensor.time') <= states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]
+                states('sensor.time').replace(':', '') | int >= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int and
+                states('sensor.time').replace(':', '') | int <= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
               )
             )
           %}
@@ -261,8 +261,8 @@ binary_sensor:
           (
             is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'off') or 
             (
-              states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp|int|timestamp_custom('%Y%m%d', False)|int <= now().strftime('%Y%m%d')|int and 
-              states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp|int|timestamp_custom('%Y%m%d', False)|int >=  now().strftime('%Y%m%d')|int
+              states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int <= now().strftime('%Y%m%d') | int and 
+              states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False)| int >=  now().strftime('%Y%m%d') | int
             )
           ) and
           smtwtfs.check

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -266,7 +266,7 @@ binary_sensor:
         {% set access_count_check = (
           is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off')
           or
-          states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state|int > 0
+          states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state | int > 0
         ) %}
         {% set in_date_range_check = (
           is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'off')
@@ -274,7 +274,7 @@ binary_sensor:
           (
             states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int <= now().strftime('%Y%m%d') | int
             and 
-            states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False)| int >=  now().strftime('%Y%m%d') | int
+            states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int >= now().strftime('%Y%m%d') | int
           )
         ) %}
         {{

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -186,34 +186,30 @@ automation:
       entity_id: "binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM"
       state: "off"
     - condition: template
-      value_template: >-
-        {{ states("sensor.LOCKNAME_code_slot_TEMPLATENUM") != "unavailable" }}
+      value_template: "{{ not is_state('sensor.LOCKNAME_code_slot_TEMPLATENUM', 'unavailable') }}"
   action:
     - choose:
 
         # The code should be added to the lock's slot
         - conditions:
             - condition: template
-              value_template: "{{ is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM','on') }}"
+              value_template: "{{ is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') }}"
           sequence:
             - service: keymaster.add_code
               data_template:
                 entity_id: LOCKENTITYNAME
-                code_slot: >-
-                  {{ TEMPLATENUM }}
-                usercode: >-
-                  {{ states('input_text.LOCKNAME_pin_TEMPLATENUM').strip() }}
+                code_slot: "{{ TEMPLATENUM }}"
+                usercode: "{{ states('input_text.LOCKNAME_pin_TEMPLATENUM').strip() }}"
 
         # The code should be removed from the lock's slot
         - conditions:
             - condition: template
-              value_template: "{{ is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM','off') }}"
+              value_template: "{{ is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'off') }}"
           sequence:
             - service: keymaster.clear_code
               data_template:
                 entity_id: LOCKENTITYNAME
-                code_slot: >-
-                  {{ TEMPLATENUM }}
+                code_slot: "{{ TEMPLATENUM }}"
           
 - alias: reset_codeslot_LOCKNAME_TEMPLATENUM
   trigger:
@@ -236,11 +232,11 @@ binary_sensor:
       value_template: >-
         {% set current_day = strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower %}
         {% set current_date = strptime(states('sensor.date'), '%Y-%m-%d').strftime('%Y%m%d') | int %}
-        {% set current_time = states('sensor.time').replace(":","") | int %}
+        {% set current_time = states('sensor.time').replace(':', '') | int %}
         {% set configured_start_time = (states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
         {% set configured_end_time = (states('input_datetime.' + current_day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
-        {% set configured_start_date = states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int %}
-        {% set configured_end_date = states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int %}
+        {% set configured_start_date = state_attr('input_datetime.start_date_LOCKNAME_TEMPLATENUM', 'timestamp') | int | timestamp_custom('%Y%m%d', False) | int %}
+        {% set configured_end_date = state_attr('input_datetime.end_date_LOCKNAME_TEMPLATENUM', 'timestamp') | int | timestamp_custom('%Y%m%d', False) | int %}
 
         {## in_date_range checks that the daterange boolean is disabled or the ##}
         {## current date is within the configured date range ##}
@@ -263,7 +259,7 @@ binary_sensor:
             is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
             and
             (
-              states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + current_day + '_end_date_LOCKNAME_TEMPLATENUM')
+              configured_start_time == configured_end_time
               or
               (
                 current_time >= configured_start_time
@@ -290,7 +286,7 @@ binary_sensor:
         {% set access_count_check = (
           is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off')
           or
-          states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state | int > 0
+          states('input_number.accesscount_LOCKNAME_TEMPLATENUM') | int > 0
         ) %}
 
         {{
@@ -313,7 +309,7 @@ binary_sensor:
           {% set lockpin = "" %}
         {% endif %}
         {% if is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
-          {{ states('input_text.LOCKNAME_pin_TEMPLATENUM') == lockpin }}
+          {{ is_state('input_text.LOCKNAME_pin_TEMPLATENUM', lockpin) }}
         {% else %}
           {{ lockpin == "" }}
         {% endif %}

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -236,53 +236,55 @@ binary_sensor:
       friendly_name: "Desired PIN State"
       value_template: >-
         {% set smtwtfs = namespace(check=False) %}
-        {% for day in ('sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat') if not smtwtfs.check %}
-          {% if
-            is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on')
-            and 
-            strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == day
-            and
+        {% set day = strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') %}
+        {% set day_check = (
+          is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on')
+          and 
+          (
             (
+              is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
+              and
               (
-                is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
-                and
+                states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')
+                or
                 (
-                  states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')
-                  or
-                  (
-                    states('sensor.time').replace(':', '') | int >= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
-                    and
-                    states('sensor.time').replace(':', '') | int <= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
-                  )
+                  states('sensor.time').replace(':', '') | int >= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+                  and
+                  states('sensor.time').replace(':', '') | int <= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
                 )
               )
-              or
-              (
-                is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'off')
-                and
-                states('sensor.time').replace(':', '') | int <= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
-                and
-                states('sensor.time').replace(':', '') | int >= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
-              )
             )
-          %}
-            {% set smtwtfs.check = True %}
-          {% endif %}
-        {% endfor %}
+            or
+            (
+              is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'off')
+              and
+              states('sensor.time').replace(':', '') | int <= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+              and
+              states('sensor.time').replace(':', '') | int >= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+            )
+          )
+        ) %}
+        {% set access_count_check = (
+          is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off')
+          or
+          states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state|int > 0
+        ) %}
+        {% set in_date_range_check = (
+          is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'off')
+          or 
+          (
+            states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int <= now().strftime('%Y%m%d') | int
+            and 
+            states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False)| int >=  now().strftime('%Y%m%d') | int
+          )
+        ) %}
         {{
           is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on') and
-          (
-            is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off') or
-            states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state|int > 0
-          ) and
-          (
-            is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'off') or 
-            (
-              states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int <= now().strftime('%Y%m%d') | int and 
-              states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False)| int >=  now().strftime('%Y%m%d') | int
-            )
-          ) and
-          smtwtfs.check
+          access_count_check
+          and
+          in_date_range_check
+          and
+          day_check
         }}
 
     pin_synched_LOCKNAME_TEMPLATENUM:

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -243,16 +243,16 @@ binary_sensor:
         {% set is_in_date_range = (current_date >= configured_start_date and current_date <= configured_end_date) %}
 
         {% set is_time_range_enabled = (configured_start_time != configured_end_time) %}
-        {% set is_inclusive = is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set is_time_range_inclusive = is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'on') %}
         {% set is_in_time_range = (
           (
-            is_inclusive
+            is_time_range_inclusive
             and
             current_time >= configured_start_time and current_time <= configured_end_time)
           )
           or
           (
-            not is_inclusive
+            not is_time_range_inclusive
             and
             (current_time < configured_start_time or current_time > configured_end_time)
           )

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -235,7 +235,6 @@ binary_sensor:
     active_LOCKNAME_TEMPLATENUM:
       friendly_name: "Desired PIN State"
       value_template: >-
-        {% set smtwtfs = namespace(check=False) %}
         {% set day = strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') %}
         {% set day_check = (
           is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on')

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -230,41 +230,36 @@ binary_sensor:
     active_LOCKNAME_TEMPLATENUM:
       friendly_name: "Desired PIN State"
       value_template: >-
+        {## This template checks whether the PIN should be considered active based on ##}
+        {## all of the different ways the PIN can be conditionally disabled ##}
         {% set now = now() %}
         {% set current_day = now.strftime('%a')[0:3] | lower %}
         {% set current_date = now.strftime('%Y%m%d') | int %}
         {% set current_time = now.strftime('%H%M') | int %}
-        {% set configured_start_time = (states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
-        {% set configured_end_time = (states('input_datetime.' + current_day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
-        {% set configured_start_date = state_attr('input_datetime.start_date_LOCKNAME_TEMPLATENUM', 'timestamp') | int | timestamp_custom('%Y%m%d', False) | int %}
-        {% set configured_end_date = state_attr('input_datetime.end_date_LOCKNAME_TEMPLATENUM', 'timestamp') | int | timestamp_custom('%Y%m%d', False) | int %}
+        {% set start_date = states('input_datetime.start_date_LOCKNAME_TEMPLATENUM').replace('-', '') | int %}
+        {% set end_date = states('input_datetime.end_date_LOCKNAME_TEMPLATENUM').replace('-', '') | int %}
+        {% set current_day_start_time = (states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
+        {% set current_day_end_time = (states('input_datetime.' + current_day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
+
+        {% set is_slot_active = is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set is_current_day_active = is_state('input_boolean.' + current_day + '_LOCKNAME_TEMPLATENUM', 'on') %}
 
         {% set is_date_range_enabled = is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'on') %}
-        {% set is_in_date_range = (current_date >= configured_start_date and current_date <= configured_end_date) %}
+        {% set is_in_date_range = (current_date >= start_date and current_date <= end_date) %}
 
-        {% set is_time_range_enabled = (configured_start_time != configured_end_time) %}
+        {% set is_time_range_enabled = (current_day_start_time != current_day_end_time) %}
         {% set is_time_range_inclusive = is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'on') %}
         {% set is_in_time_range = (
-          (
-            is_time_range_inclusive
-            and
-            (current_time >= configured_start_time and current_time <= configured_end_time)
-          )
+          (is_time_range_inclusive and (current_time >= current_day_start_time and current_time <= current_day_end_time))
           or
-          (
-            not is_time_range_inclusive
-            and
-            (current_time < configured_start_time or current_time > configured_end_time)
-          )
+          (not is_time_range_inclusive and (current_time < current_day_start_time or current_time > current_day_end_time))
         ) %}
 
         {% set is_access_limit_enabled = is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'on') %}
         {% set is_access_count_valid = states('input_number.accesscount_LOCKNAME_TEMPLATENUM') | int > 0 %}
 
         {{
-          is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on')
-          and
-          is_state('input_boolean.' + current_day + '_LOCKNAME_TEMPLATENUM', 'on')
+          is_slot_active and is_current_day_active
           and
           (not is_date_range_enabled or is_in_date_range)
           and
@@ -277,13 +272,10 @@ binary_sensor:
       friendly_name: 'PIN synchronized with lock'
       value_template: >
         {% set lockpin = states('sensor.LOCKNAME_code_slot_TEMPLATENUM') %}
-        {% if lockpin == "0000" %}
-          {% set lockpin = "" %}
-        {% endif %}
         {% if is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
           {{ is_state('input_text.LOCKNAME_pin_TEMPLATENUM', lockpin) }}
         {% else %}
-          {{ lockpin == "" }}
+          {{ lockpin in ("", "0000" }}
         {% endif %}
 
 ###################  sensor:  ####################

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -235,7 +235,11 @@ binary_sensor:
     active_LOCKNAME_TEMPLATENUM:
       friendly_name: "Desired PIN State"
       value_template: >-
-        {% set day = strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') %}
+        {% set day = now().strftime('%a') | lower %}
+        {## day_check checks that the day is enabled, and if the day is marked as ##}
+        {## included, we check that either the time is within the specified range or ##}
+        {## no range is specified. If the day is marked as excluded, we check that ##}
+        {## the time is outside the specified range ##}
         {% set day_check = (
           is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on')
           and 
@@ -247,9 +251,9 @@ binary_sensor:
                 states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')
                 or
                 (
-                  states('sensor.time').replace(':', '') | int >= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+                  now().strftime('%H%M') | int >= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
                   and
-                  states('sensor.time').replace(':', '') | int <= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+                  now().strftime('%H%M') | int | int <= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
                 )
               )
             )
@@ -257,24 +261,28 @@ binary_sensor:
             (
               is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'off')
               and
-              states('sensor.time').replace(':', '') | int <= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+              now().strftime('%H%M') | int | int <= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
               and
-              states('sensor.time').replace(':', '') | int >= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+              now().strftime('%H%M') | int | int >= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
             )
           )
         ) %}
+        {## access_count_check checks that either the access limit is disabled or ##}
+        {## the access count > 0 ##}
         {% set access_count_check = (
           is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off')
           or
           states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state | int > 0
         ) %}
+        {## in_date_range checks that the daterange boolean is disabled or the ##}
+        {## current date is within the configured date range ##}
         {% set in_date_range_check = (
           is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'off')
           or 
           (
-            states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int <= now().strftime('%Y%m%d') | int
+            now().strftime('%Y%m%d') | int >= states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int
             and 
-            states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int >= now().strftime('%Y%m%d') | int
+            now().strftime('%Y%m%d') | int <= states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int
           )
         ) %}
         {{

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -202,8 +202,7 @@ automation:
                 code_slot: >-
                   {{ TEMPLATENUM }}
                 usercode: >-
-                  {% set object = states('input_text.LOCKNAME_pin_TEMPLATENUM') %}
-                  {{ object.strip() }}
+                  {{ states('input_text.LOCKNAME_pin_TEMPLATENUM').strip() }}
 
         # The code should be removed from the lock's slot
         - conditions:
@@ -235,43 +234,54 @@ binary_sensor:
     active_LOCKNAME_TEMPLATENUM:
       friendly_name: "Desired PIN State"
       value_template: >-
-        {% set day = now().strftime('%a')[0:3] | lower %}
+        {% set current_day = (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a')[0:3] | lower %}
+        {% set current_date = (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%Y%m%d') | int %}
+        {% set current_time = states('sensor.time').replace(":","") | int %}
+        {% set configured_start_time = (states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
+        {% set configured_end_time = (states('input_datetime.' + current_day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
+        {% set configured_start_date = states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int %}
+        {% set configured_end_date = states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int %}
+
         {## in_date_range checks that the daterange boolean is disabled or the ##}
         {## current date is within the configured date range ##}
         {% set in_date_range_check = (
           is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'off')
           or 
           (
-            now().strftime('%Y%m%d') | int >= states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int
+            current_date >= configured_start_date
             and 
-            now().strftime('%Y%m%d') | int <= states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp | int | timestamp_custom('%Y%m%d', False) | int
+            current_date <= configured_end_date
           )
         ) %}
+
         {## in_time_range_check checks that the current time is in the appropriate ##}
         {## depending on whether the range is marked as inclusive or exclusive. ##}
         {% set in_time_range_check = (
           (
-            is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
+            is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
             and
             (
-              states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')
+              states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + current_day + '_end_date_LOCKNAME_TEMPLATENUM')
               or
               (
-                now().strftime('%H%M') | int >= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+                current_time >= configured_start_time
                 and
-                now().strftime('%H%M') | int <= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+                current_time <= configured_end_time
               )
             )
           )
           or
           (
-            is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'off')
+            is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'off')
             and
-            now().strftime('%H%M') | int < (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
-            and
-            now().strftime('%H%M') | int > (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+            (
+              current_time < configured_start_time
+              or
+              current_time > configured_end_time
+            )
           )
         ) %}
+
         {## access_count_check checks that either the access limit is disabled or ##}
         {## the access count > 0 ##}
         {% set access_count_check = (
@@ -279,10 +289,11 @@ binary_sensor:
           or
           states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state | int > 0
         ) %}
+
         {{
           is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on')
           and
-          is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on')
+          is_state('input_boolean.' + current_day + '_LOCKNAME_TEMPLATENUM', 'on')
           and
           in_date_range_check
           and

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -238,14 +238,31 @@ binary_sensor:
         {% set smtwtfs = namespace(check=False) %}
         {% for day in ('sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat') if not smtwtfs.check %}
           {% if
-            is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on') and 
-            strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == day and
-            is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'on') and
+            is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on')
+            and 
+            strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == day
+            and
             (
-              states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM') or
               (
-                states('sensor.time').replace(':', '') | int >= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int and
-                states('sensor.time').replace(':', '') | int <= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+                is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
+                and
+                (
+                  states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')
+                  or
+                  (
+                    states('sensor.time').replace(':', '') | int >= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+                    and
+                    states('sensor.time').replace(':', '') | int <= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+                  )
+                )
+              )
+              or
+              (
+                is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'off')
+                and
+                states('sensor.time').replace(':', '') | int <= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+                and
+                states('sensor.time').replace(':', '') | int >= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
               )
             )
           %}
@@ -292,29 +309,30 @@ sensor:
       # icon: mdi:glassdoor
       friendly_name: "PIN Status"
       value_template: >-
-        {% set syncstatus = states('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM')  %}      
-        {% if is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
-          {% set prefix = 'C' %}
-        {% else %}
-          {% set prefix = 'Disc' %}
-        {% endif %}
-        {% if syncstatus == 'on' %}
-          {{ prefix + 'onnected' }}
-        {% else %}
-          {{ prefix + 'onnecting' }}
-        {% endif %}
+        {% set value_map = {
+          'on': {
+            'on': 'Connected',
+            'off': 'Connecting',
+          },
+          'off': {
+            'on': 'Disconnected',
+            'off': 'Disconnecting',
+          },
+        } %}
+        {% set slot_active = states('binary_sensor.active_LOCKNAME_TEMPLATENUM') %}
+        {% set pin_synched = states('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM') %}
+        {{ value_map[slot_active][pin_synched] }}
       icon_template: >
-        {% set syncstatus = states('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM')  %}      
-        {% if is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
-          {% if syncstatus == 'on' %}
-            mdi:folder-key
-          {% else %}
-            mdi:folder-key-network
-          {% endif %}
-        {% else %}
-          {% if syncstatus == 'on' %}
-            mdi:folder-open
-          {% else %}
-            mdi:wiper-wash
-          {% endif %}
-        {% endif %}
+        {% set icon_map = {
+          'on': {
+            'on': 'mdi:folder-key',
+            'off': 'mdi:folder-key-network',
+          },
+          'off': {
+            'on': 'mdi:folder-open',
+            'off': 'mdi:wiper-watch',
+          },
+        } %}
+        {% set slot_active = states('binary_sensor.active_LOCKNAME_TEMPLATENUM') %}
+        {% set pin_synched = states('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM') %}
+        {{ icon_map[slot_active][pin_synched] }}

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -248,7 +248,7 @@ binary_sensor:
           )
         ) %}
         {## in_time_range_check checks that the current time is in the appropriate ##}
-        {## depending on whether the day is marked as inclusive or exclusive. ##}
+        {## depending on whether the range is marked as inclusive or exclusive. ##}
         {% set in_time_range_check = (
           (
             is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
@@ -267,9 +267,9 @@ binary_sensor:
           (
             is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'off')
             and
-            now().strftime('%H%M') | int <= (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+            now().strftime('%H%M') | int < (states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
             and
-            now().strftime('%H%M') | int >= (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
+            now().strftime('%H%M') | int > (states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int
           )
         ) %}
         {## access_count_check checks that either the access limit is disabled or ##}

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -230,9 +230,10 @@ binary_sensor:
     active_LOCKNAME_TEMPLATENUM:
       friendly_name: "Desired PIN State"
       value_template: >-
-        {% set current_day = strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower %}
-        {% set current_date = strptime(states('sensor.date'), '%Y-%m-%d').strftime('%Y%m%d') | int %}
-        {% set current_time = states('sensor.time').replace(':', '') | int %}
+        {% set now = now() %}
+        {% set current_day = now.strftime('%a')[0:3] | lower %}
+        {% set current_date = now.strftime('%Y%m%d') | int %}
+        {% set current_time = now.strftime('%H%M') | int %}
         {% set configured_start_time = (states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
         {% set configured_end_time = (states('input_datetime.' + current_day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
         {% set configured_start_date = state_attr('input_datetime.start_date_LOCKNAME_TEMPLATENUM', 'timestamp') | int | timestamp_custom('%Y%m%d', False) | int %}

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -234,7 +234,7 @@ binary_sensor:
     active_LOCKNAME_TEMPLATENUM:
       friendly_name: "Desired PIN State"
       value_template: >-
-        {% set current_day = (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a')[0:3] | lower %}
+        {% set current_day = (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower %}
         {% set current_date = (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%Y%m%d') | int %}
         {% set current_time = states('sensor.time').replace(":","") | int %}
         {% set configured_start_time = (states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
@@ -244,6 +244,7 @@ binary_sensor:
 
         {## in_date_range checks that the daterange boolean is disabled or the ##}
         {## current date is within the configured date range ##}
+
         {% set in_date_range_check = (
           is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'off')
           or 
@@ -256,6 +257,7 @@ binary_sensor:
 
         {## in_time_range_check checks that the current time is in the appropriate ##}
         {## depending on whether the range is marked as inclusive or exclusive. ##}
+
         {% set in_time_range_check = (
           (
             is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
@@ -284,6 +286,7 @@ binary_sensor:
 
         {## access_count_check checks that either the access limit is disabled or ##}
         {## the access count > 0 ##}
+
         {% set access_count_check = (
           is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off')
           or

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -231,7 +231,7 @@ binary_sensor:
       friendly_name: "Desired PIN State"
       value_template: >-
         {## This template checks whether the PIN should be considered active based on ##}
-        {## all of the different ways the PIN can be conditionally disabled ##}
+        {## all of the different ways the PIN can be conditionally enabled/disabled ##}
 
         {% set now = now() %}
 

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -174,13 +174,13 @@ automation:
       entity_id: "binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM"
       to: 'off'
     - platform: state
-      entity_id: "binary_sensor.allow_automation"
+      entity_id: "input_boolean.allow_automation_execution"
       to: 'on'
     - platform: state
       entity_id: "sensor.LOCKNAME_code_slot_TEMPLATENUM"
   condition:
     - condition: state
-      entity_id: "binary_sensor.allow_automation"
+      entity_id: "input_boolean.allow_automation_execution"
       state: "on"
     - condition: state
       entity_id: "binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM"
@@ -222,136 +222,9 @@ automation:
     platform: state
     to: 'on'
   action:
-    - service: input_text.set_value
+    - service: script.reset_codeslot_LOCKNAME
       data_template:
-        entity_id: input_text.LOCKNAME_name_TEMPLATENUM
-        value: ""
-    - service: input_text.set_value
-      data_template:
-        entity_id: input_text.LOCKNAME_pin_TEMPLATENUM
-        value: ""
-    - service: input_boolean.turn_off
-      entity_id: input_boolean.notify_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_off
-      entity_id: input_boolean.enabled_LOCKNAME_TEMPLATENUM
-    - service: input_number.set_value
-      data_template:
-        entity_id: input_number.accesscount_LOCKNAME_TEMPLATENUM
-        value: "0"
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.sun_start_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.sun_end_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.mon_start_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.mon_end_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.tue_start_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.tue_end_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.wed_start_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.wed_end_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.thu_start_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.thu_end_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.fri_start_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.fri_end_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.sat_start_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.sat_end_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        time: >
-          {{  (("00:00")  | timestamp_custom("%H:%M"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.start_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        date: >
-          {{  (("1980-01-01")  | timestamp_custom("%Y %m %d"))  }}      
-    - service: input_datetime.set_datetime
-      entity_id: input_datetime.end_date_LOCKNAME_TEMPLATENUM
-      data_template:
-        date: >
-          {{  (("1980-01-01")  | timestamp_custom("%Y %m %d"))  }}      
-    - service: input_boolean.turn_off
-      entity_id: input_boolean.daterange_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_off
-      entity_id: input_boolean.accesslimit_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_off
-      entity_id: input_boolean.reset_codeslot_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.sun_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.mon_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.tue_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.wed_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.thu_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.fri_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.sat_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.sun_inc_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.mon_inc_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.tue_inc_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.wed_inc_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.thu_inc_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.fri_inc_LOCKNAME_TEMPLATENUM
-    - service: input_boolean.turn_on
-      entity_id: input_boolean.sat_inc_LOCKNAME_TEMPLATENUM
+        code_slot: TEMPLATENUM
       
 ################  binary_sensor: #################  
 binary_sensor:
@@ -359,80 +232,53 @@ binary_sensor:
 - platform: template
   sensors:
 
-    enabled_LOCKNAME_TEMPLATENUM:
-      value_template: "{{ is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on') }}"
-
-    daterange_LOCKNAME_TEMPLATENUM:
-      value_template: "{{ (is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'off') or ((states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp| int | timestamp_custom('%Y%m%d', False)|int)|string <= now().strftime('%Y%m%d')) and (states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp| int | timestamp_custom('%Y%m%d', False)|int)|string >=  now().strftime('%Y%m%d'))}}"
-
-    sun_LOCKNAME_TEMPLATENUM:
-      value_template: "{{ (( is_state('input_boolean.sun_LOCKNAME_TEMPLATENUM', 'on'))) and (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == 'sun') and (is_state('input_boolean.sun_inc_LOCKNAME_TEMPLATENUM', 'on')) == ((states.input_datetime.sun_start_date_LOCKNAME_TEMPLATENUM.state == states.input_datetime.sun_end_date_LOCKNAME_TEMPLATENUM.state) or ((states('sensor.time') >= states('input_datetime.sun_start_date_LOCKNAME_TEMPLATENUM')[0:5]) and (states('sensor.time') <= states('input_datetime.sun_end_date_LOCKNAME_TEMPLATENUM')[0:5])) )}}"
-
-    mon_LOCKNAME_TEMPLATENUM:
-      value_template: "{{ (( is_state('input_boolean.mon_LOCKNAME_TEMPLATENUM', 'on'))) and (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == 'mon') and (is_state('input_boolean.mon_inc_LOCKNAME_TEMPLATENUM', 'on')) == ((states.input_datetime.mon_start_date_LOCKNAME_TEMPLATENUM.state == states.input_datetime.mon_end_date_LOCKNAME_TEMPLATENUM.state) or ((states('sensor.time') >= states('input_datetime.mon_start_date_LOCKNAME_TEMPLATENUM')[0:5]) and (states('sensor.time') <= states('input_datetime.mon_end_date_LOCKNAME_TEMPLATENUM')[0:5])) )}}"
-
-    tue_LOCKNAME_TEMPLATENUM:
-      value_template: "{{ (( is_state('input_boolean.tue_LOCKNAME_TEMPLATENUM', 'on'))) and (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == 'tue') and (is_state('input_boolean.tue_inc_LOCKNAME_TEMPLATENUM', 'on')) == ((states.input_datetime.tue_start_date_LOCKNAME_TEMPLATENUM.state == states.input_datetime.tue_end_date_LOCKNAME_TEMPLATENUM.state) or ((states('sensor.time') >= states('input_datetime.tue_start_date_LOCKNAME_TEMPLATENUM')[0:5]) and (states('sensor.time') <= states('input_datetime.tue_end_date_LOCKNAME_TEMPLATENUM')[0:5])) )}}"
-
-    wed_LOCKNAME_TEMPLATENUM:
-      value_template: "{{ (( is_state('input_boolean.wed_LOCKNAME_TEMPLATENUM', 'on'))) and (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == 'wed') and (is_state('input_boolean.wed_inc_LOCKNAME_TEMPLATENUM', 'on')) == ((states.input_datetime.wed_start_date_LOCKNAME_TEMPLATENUM.state == states.input_datetime.wed_end_date_LOCKNAME_TEMPLATENUM.state) or ((states('sensor.time') >= states('input_datetime.wed_start_date_LOCKNAME_TEMPLATENUM')[0:5]) and (states('sensor.time') <= states('input_datetime.wed_end_date_LOCKNAME_TEMPLATENUM')[0:5])) )}}"
-
-    thu_LOCKNAME_TEMPLATENUM:
-      value_template: "{{ (( is_state('input_boolean.thu_LOCKNAME_TEMPLATENUM', 'on'))) and (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == 'thu') and (is_state('input_boolean.thu_inc_LOCKNAME_TEMPLATENUM', 'on')) == ((states.input_datetime.thu_start_date_LOCKNAME_TEMPLATENUM.state == states.input_datetime.thu_end_date_LOCKNAME_TEMPLATENUM.state) or ((states('sensor.time') >= states('input_datetime.thu_start_date_LOCKNAME_TEMPLATENUM')[0:5]) and (states('sensor.time') <= states('input_datetime.thu_end_date_LOCKNAME_TEMPLATENUM')[0:5])) )}}"
-
-    fri_LOCKNAME_TEMPLATENUM:
-      value_template: "{{ (( is_state('input_boolean.fri_LOCKNAME_TEMPLATENUM', 'on'))) and (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == 'fri') and (is_state('input_boolean.fri_inc_LOCKNAME_TEMPLATENUM', 'on')) == ((states.input_datetime.fri_start_date_LOCKNAME_TEMPLATENUM.state == states.input_datetime.fri_end_date_LOCKNAME_TEMPLATENUM.state) or ((states('sensor.time') >= states('input_datetime.fri_start_date_LOCKNAME_TEMPLATENUM')[0:5]) and (states('sensor.time') <= states('input_datetime.fri_end_date_LOCKNAME_TEMPLATENUM')[0:5])) )}}"
-
-    sat_LOCKNAME_TEMPLATENUM:
-      value_template: "{{ (( is_state('input_boolean.sat_LOCKNAME_TEMPLATENUM', 'on'))) and (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a') | lower == 'sat') and (is_state('input_boolean.sat_inc_LOCKNAME_TEMPLATENUM', 'on')) == ((states.input_datetime.sat_start_date_LOCKNAME_TEMPLATENUM.state == states.input_datetime.sat_end_date_LOCKNAME_TEMPLATENUM.state) or ((states('sensor.time') >= states('input_datetime.sat_start_date_LOCKNAME_TEMPLATENUM')[0:5]) and (states('sensor.time') <= states('input_datetime.sat_end_date_LOCKNAME_TEMPLATENUM')[0:5])) )}}"
-
-    smtwtfs_LOCKNAME_TEMPLATENUM:
-      friendly_name: "Status"
-      value_template: >- 
-         {{
-            is_state('binary_sensor.sun_LOCKNAME_TEMPLATENUM', 'on')  or  
-            is_state('binary_sensor.mon_LOCKNAME_TEMPLATENUM', 'on')  or  
-            is_state('binary_sensor.tue_LOCKNAME_TEMPLATENUM', 'on')  or  
-            is_state('binary_sensor.wed_LOCKNAME_TEMPLATENUM', 'on')  or  
-            is_state('binary_sensor.thu_LOCKNAME_TEMPLATENUM', 'on')  or  
-            is_state('binary_sensor.fri_LOCKNAME_TEMPLATENUM', 'on')  or  
-            is_state('binary_sensor.sat_LOCKNAME_TEMPLATENUM', 'on')   
-         }}
-    
-    access_count_LOCKNAME_TEMPLATENUM:
-      friendly_name: "Access Count"
-      value_template: >-
-         {{
-            (is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off'))  or  
-            (states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state | int > 0)
-         }}
-
     active_LOCKNAME_TEMPLATENUM:
       friendly_name: "Desired PIN State"
       value_template: >-
-         {{
-            is_state('binary_sensor.enabled_LOCKNAME_TEMPLATENUM', 'on')  and  
-            is_state('binary_sensor.access_count_LOCKNAME_TEMPLATENUM', 'on')  and  
-            is_state('binary_sensor.daterange_LOCKNAME_TEMPLATENUM', 'on') and
-            is_state('binary_sensor.smtwtfs_LOCKNAME_TEMPLATENUM', 'on')  
-         }}
+        {% set smtwtfs = namespace(check=False) %}
+        {% for day in ('sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat') if not smtwtfs.check %}
+          {% if
+            is_state('input_boolean.' + day + '_LOCKNAME_TEMPLATENUM', 'on') and 
+            (strptime(states('sensor.date'), '%Y-%m-%d').strftime('%a')|lower == day) and
+            is_state('input_boolean.' + day + '_inc_LOCKNAME_TEMPLATENUM', 'on') and
+            (
+              states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM') == states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM') or
+              (
+                states('sensor.time') >= states('input_datetime.' + day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5] and
+                states('sensor.time') <= states('input_datetime.' + day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]
+              )
+            )
+          %}
+            {% set smtwtfs.check = True %}
+          {% endif %}
+        {% endfor %}
+        {{
+          is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on') and
+          (
+            is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off') or
+            states.input_number.accesscount_LOCKNAME_TEMPLATENUM.state|int > 0
+          ) and
+          (
+            is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'off') or 
+            (
+              states.input_datetime.start_date_LOCKNAME_TEMPLATENUM.attributes.timestamp|int|timestamp_custom('%Y%m%d', False)|int <= now().strftime('%Y%m%d')|int and 
+              states.input_datetime.end_date_LOCKNAME_TEMPLATENUM.attributes.timestamp|int|timestamp_custom('%Y%m%d', False)|int >=  now().strftime('%Y%m%d')|int
+            )
+          ) and
+          smtwtfs.check
+        }}
 
     pin_synched_LOCKNAME_TEMPLATENUM:
       friendly_name: 'PIN synchronized with lock'
       value_template: >
-        {% set lock = 'sensor.LOCKNAME_code_slot_TEMPLATENUM' %}
-        {% set local = 'input_text.LOCKNAME_pin_TEMPLATENUM' %}
-        {% set status = 'binary_sensor.active_LOCKNAME_TEMPLATENUM' %}
-        {% set lockpin = states(lock).strip()  %}
-        {% set localpin = states(local).strip()  %}
-        {% set pinstatus = states(status)  %}
+        {% set lockpin = states('sensor.LOCKNAME_code_slot_TEMPLATENUM')  %}
         {% if lockpin == "0000" %}
-        {%   set lockpin = "" %}
+          {% set lockpin = "" %}
         {% endif %}
-        {% if pinstatus == 'on' %}
-        {% set correct = localpin == lockpin %}
+        {% if is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
+          {% set correct = states('input_text.LOCKNAME_pin_TEMPLATENUM') == lockpin %}
         {% else %}
-        {% set correct = lockpin == "" %}
+          {% set correct = lockpin == "" %}
         {% endif %}
         {{ correct }}
 
@@ -446,31 +292,29 @@ sensor:
       # icon: mdi:glassdoor
       friendly_name: "PIN Status"
       value_template: >-
-        {% set pinstatus = states('binary_sensor.active_LOCKNAME_TEMPLATENUM')  %}      
         {% set syncstatus = states('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM')  %}      
-        {% if pinstatus == 'on' %}
+        {% if is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
+          {% set prefix = 'C' %}
+        {% else %}
+          {% set prefix = 'Disc' %}
+        {% endif %}
+        {% if syncstatus == 'on' %}
+          {{ prefix + 'onnected' }}
+        {% else %}
+          {{ prefix + 'onnecting' }}
+        {% endif %}
+      icon_template: >
+        {% set syncstatus = states('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM')  %}      
+        {% if is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
           {% if syncstatus == 'on' %}
-            {% set report = 'Connected' %}
+            mdi:folder-key
           {% else %}
-            {% set report = 'Connecting' %}
+            mdi:folder-key-network
           {% endif %}
         {% else %}
           {% if syncstatus == 'on' %}
-            {% set report = 'Disconnected' %}
+            mdi:folder-open
           {% else %}
-            {% set report = 'Disconnecting' %}
+            mdi:wiper-wash
           {% endif %}
-        {% endif %}
-        {{
-          report
-        }}
-      icon_template: >
-        {% if (states('sensor.connected_LOCKNAME_TEMPLATENUM') | lower) == 'connected' %}
-          mdi:folder-key
-        {% elif (states('sensor.connected_LOCKNAME_TEMPLATENUM') | lower) == 'connecting' %}
-          mdi:folder-key-network
-        {% elif (states('sensor.connected_LOCKNAME_TEMPLATENUM') | lower) == 'disconnected' %}
-          mdi:folder-open
-        {% elif (states('sensor.connected_LOCKNAME_TEMPLATENUM') | lower) == 'disconnecting' %}
-          mdi:wiper-wash
         {% endif %}

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -292,29 +292,29 @@ sensor:
       friendly_name: "PIN Status"
       value_template: >-
         {% set value_map = {
-          'on': {
-            'on': 'Connected',
-            'off': 'Connecting',
+          True: {
+            True: 'Connected',
+            False: 'Connecting',
           },
-          'off': {
-            'on': 'Disconnected',
-            'off': 'Disconnecting',
+          False: {
+            True: 'Disconnected',
+            False: 'Disconnecting',
           },
         } %}
-        {% set slot_active = states('binary_sensor.active_LOCKNAME_TEMPLATENUM') %}
-        {% set pin_synched = states('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM') %}
-        {{ value_map.get(slot_active, {}).get(pin_synched) }}
+        {% set slot_active = is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set pin_synched = is_state('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM', 'on') %}
+        {{ value_map[slot_active][pin_synched] }}
       icon_template: >
         {% set icon_map = {
-          'on': {
-            'on': 'mdi:folder-key',
-            'off': 'mdi:folder-key-network',
+          True: {
+            True: 'mdi:folder-key',
+            False: 'mdi:folder-key-network',
           },
-          'off': {
-            'on': 'mdi:folder-open',
-            'off': 'mdi:wiper-watch',
+          False: {
+            True: 'mdi:folder-open',
+            False: 'mdi:wiper-watch',
           },
         } %}
-        {% set slot_active = states('binary_sensor.active_LOCKNAME_TEMPLATENUM') %}
-        {% set pin_synched = states('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM') %}
-        {{ icon_map.get(slot_active, {}).get(pin_synched) }}
+        {% set slot_active = is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set pin_synched = is_state('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM', 'on') %}
+        {{ icon_map[slot_active][pin_synched] }}

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -239,67 +239,38 @@ binary_sensor:
         {% set configured_start_date = state_attr('input_datetime.start_date_LOCKNAME_TEMPLATENUM', 'timestamp') | int | timestamp_custom('%Y%m%d', False) | int %}
         {% set configured_end_date = state_attr('input_datetime.end_date_LOCKNAME_TEMPLATENUM', 'timestamp') | int | timestamp_custom('%Y%m%d', False) | int %}
 
-        {## in_date_range checks that the daterange boolean is disabled or the ##}
-        {## current date is within the configured date range ##}
+        {% set is_date_range_enabled = is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set is_in_date_range = (current_date >= configured_start_date and current_date <= configured_end_date) %}
 
-        {% set in_date_range_check = (
-          is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'off')
-          or 
+        {% set is_time_range_enabled = (configured_start_time != configured_end_time) %}
+        {% set is_inclusive = is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set is_in_time_range = (
           (
-            current_date >= configured_start_date
-            and 
-            current_date <= configured_end_date
-          )
-        ) %}
-
-        {## in_time_range_check checks that the current time is in the appropriate ##}
-        {## depending on whether the range is marked as inclusive or exclusive. ##}
-
-        {% set in_time_range_check = (
-          (
-            is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'on')
+            is_inclusive
             and
-            (
-              configured_start_time == configured_end_time
-              or
-              (
-                current_time >= configured_start_time
-                and
-                current_time <= configured_end_time
-              )
-            )
+            current_time >= configured_start_time and current_time <= configured_end_time)
           )
           or
           (
-            is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'off')
+            not is_inclusive
             and
-            (
-              current_time < configured_start_time
-              or
-              current_time > configured_end_time
-            )
+            (current_time < configured_start_time or current_time > configured_end_time)
           )
         ) %}
 
-        {## access_count_check checks that either the access limit is disabled or ##}
-        {## the access count > 0 ##}
-
-        {% set access_count_check = (
-          is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'off')
-          or
-          states('input_number.accesscount_LOCKNAME_TEMPLATENUM') | int > 0
-        ) %}
+        {% is_access_limit_enabled = is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set is_access_count_valid = states('input_number.accesscount_LOCKNAME_TEMPLATENUM') | int > 0 %}
 
         {{
           is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on')
           and
           is_state('input_boolean.' + current_day + '_LOCKNAME_TEMPLATENUM', 'on')
           and
-          in_date_range_check
+          (not is_date_range_enabled or is_in_date_range)
           and
-          in_time_range_check
+          (not is_time_range_enabled or is_in_time_range)
           and
-          access_count_check
+          (not is_access_limit_enabled or is_access_count_valid)
         }}
 
     pin_synched_LOCKNAME_TEMPLATENUM:

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -233,9 +233,11 @@ binary_sensor:
         {## This template checks whether the PIN should be considered active based on ##}
         {## all of the different ways the PIN can be conditionally disabled ##}
         {% set now = now() %}
+
         {% set current_day = now.strftime('%a')[0:3] | lower %}
         {% set current_date = now.strftime('%Y%m%d') | int %}
         {% set current_time = now.strftime('%H%M') | int %}
+
         {% set start_date = states('input_datetime.start_date_LOCKNAME_TEMPLATENUM').replace('-', '') | int %}
         {% set end_date = states('input_datetime.end_date_LOCKNAME_TEMPLATENUM').replace('-', '') | int %}
         {% set current_day_start_time = (states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -296,11 +296,10 @@ binary_sensor:
           {% set lockpin = "" %}
         {% endif %}
         {% if is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
-          {% set correct = states('input_text.LOCKNAME_pin_TEMPLATENUM') == lockpin %}
+          {{ states('input_text.LOCKNAME_pin_TEMPLATENUM') == lockpin }}
         {% else %}
-          {% set correct = lockpin == "" %}
+          {{ lockpin == "" }}
         {% endif %}
-        {{ correct }}
 
 ###################  sensor:  ####################  
 sensor:

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -1,7 +1,7 @@
 
 ############  input_number:  #####################
 input_number:
-  accesscount_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_accesscount_TEMPLATENUM:
     name: 'Unlock events'
     min: 0
     max: 100
@@ -10,74 +10,74 @@ input_number:
 
 #################  input_datetime:  ##############
 input_datetime:
-  end_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_end_date_TEMPLATENUM:
     name: 'End'
     has_time: false
     has_date: true
-  start_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_start_date_TEMPLATENUM:
     name: 'Start'
     has_time: false
     has_date: true
 
-  sun_start_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_sun_start_date_TEMPLATENUM:
     name: 'Start'
     has_time: true
     has_date: false
-  sun_end_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_sun_end_date_TEMPLATENUM:
     name: 'End'
     has_time: true
     has_date: false
 
-  mon_start_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_mon_start_date_TEMPLATENUM:
     name: 'Start'
     has_time: true
     has_date: false
-  mon_end_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_mon_end_date_TEMPLATENUM:
     name: 'End'
     has_time: true
     has_date: false
 
-  tue_start_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_tue_start_date_TEMPLATENUM:
     name: 'Start'
     has_time: true
     has_date: false
-  tue_end_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_tue_end_date_TEMPLATENUM:
     name: 'End'
     has_time: true
     has_date: false
 
-  wed_start_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_wed_start_date_TEMPLATENUM:
     name: 'Start'
     has_time: true
     has_date: false
-  wed_end_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_wed_end_date_TEMPLATENUM:
     name: 'End'
     has_time: true
     has_date: false
 
-  thu_start_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_thu_start_date_TEMPLATENUM:
     name: 'Start'
     has_time: true
     has_date: false
-  thu_end_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_thu_end_date_TEMPLATENUM:
     name: 'End'
     has_time: true
     has_date: false
 
-  fri_start_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_fri_start_date_TEMPLATENUM:
     name: 'Start'
     has_time: true
     has_date: false
-  fri_end_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_fri_end_date_TEMPLATENUM:
     name: 'End'
     has_time: true
     has_date: false
 
-  sat_start_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_sat_start_date_TEMPLATENUM:
     name: 'Start'
     has_time: true
     has_date: false
-  sat_end_date_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_sat_end_date_TEMPLATENUM:
     name: 'End'
     has_time: true
     has_date: false
@@ -93,85 +93,85 @@ input_text:
 
 #################  input_boolean:  ################
 input_boolean:
-  notify_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_notify_TEMPLATENUM:
     name: 'Notifications'
-  daterange_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_daterange_TEMPLATENUM:
     name: 'Use Date Range'
-  smtwtfs_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_smtwtfs_TEMPLATENUM:
     name: 'Use SMTWTFS'
-  enabled_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_enabled_TEMPLATENUM:
     name: 'Enabled'
-  accesslimit_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_accesslimit_TEMPLATENUM:
     name: 'Enforce PIN limit'
     initial: off
-  reset_codeslot_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_reset_codeslot_TEMPLATENUM:
     name: 'Reset Code Slot'
     initial: off
 
-  sun_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_sun_TEMPLATENUM:
     name: 'Sunday'
     initial: on
 
-  mon_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_mon_TEMPLATENUM:
     name: 'Monday'
     initial: on
 
-  tue_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_tue_TEMPLATENUM:
     name: 'Tuesday'
     initial: on
 
-  wed_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_wed_TEMPLATENUM:
     name: 'Wednesday'
     initial: on
 
-  thu_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_thu_TEMPLATENUM:
     name: 'Thursday'
     initial: on
 
-  fri_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_fri_TEMPLATENUM:
     name: 'Friday'
     initial: on
 
-  sat_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_sat_TEMPLATENUM:
     name: 'Saturday'
     initial: on
 
-  sun_inc_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_sun_inc_TEMPLATENUM:
     name: 'include (on)/exclude (off)'
     initial: on
 
-  mon_inc_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_mon_inc_TEMPLATENUM:
     name: 'include (on)/exclude (off)'
     initial: on
 
-  tue_inc_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_tue_inc_TEMPLATENUM:
     name: 'include (on)/exclude (off)'
     initial: on
 
-  wed_inc_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_wed_inc_TEMPLATENUM:
     name: 'include (on)/exclude (off)'
     initial: on
 
-  thu_inc_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_thu_inc_TEMPLATENUM:
     name: 'include (on)/exclude (off)'
     initial: on
 
-  fri_inc_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_fri_inc_TEMPLATENUM:
     name: 'include (on)/exclude (off)'
     initial: on
 
-  sat_inc_LOCKNAME_TEMPLATENUM:
+  LOCKNAME_sat_inc_TEMPLATENUM:
     name: 'include (on)/exclude (off)'
     initial: on
 
 ################  automation:  #################
 automation:
 
-- alias: synchronize_codeslot_LOCKNAME_TEMPLATENUM
+- alias: LOCKNAME_synchronize_codeslot_TEMPLATENUM
   initial_state: true
   trigger:
     - platform: state
-      entity_id: "binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM"
+      entity_id: "binary_sensor.LOCKNAME_pin_synched_TEMPLATENUM"
       to: 'off'
     - platform: state
       entity_id: "input_boolean.allow_automation_execution"
@@ -183,7 +183,7 @@ automation:
       entity_id: "input_boolean.allow_automation_execution"
       state: "on"
     - condition: state
-      entity_id: "binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM"
+      entity_id: "binary_sensor.LOCKNAME_pin_synched_TEMPLATENUM"
       state: "off"
     - condition: template
       value_template: "{{ not is_state('sensor.LOCKNAME_code_slot_TEMPLATENUM', 'unavailable') }}"
@@ -193,7 +193,7 @@ automation:
         # The code should be added to the lock's slot
         - conditions:
             - condition: template
-              value_template: "{{ is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') }}"
+              value_template: "{{ is_state('binary_sensor.LOCKNAME_active_TEMPLATENUM', 'on') }}"
           sequence:
             - service: keymaster.add_code
               data_template:
@@ -204,20 +204,20 @@ automation:
         # The code should be removed from the lock's slot
         - conditions:
             - condition: template
-              value_template: "{{ is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'off') }}"
+              value_template: "{{ is_state('binary_sensor.LOCKNAME_active_TEMPLATENUM', 'off') }}"
           sequence:
             - service: keymaster.clear_code
               data_template:
                 entity_id: LOCKENTITYNAME
                 code_slot: "{{ TEMPLATENUM }}"
           
-- alias: reset_codeslot_LOCKNAME_TEMPLATENUM
+- alias: LOCKNAME_reset_codeslot_TEMPLATENUM
   trigger:
-    entity_id: input_boolean.reset_codeslot_LOCKNAME_TEMPLATENUM
+    entity_id: input_boolean.LOCKNAME_reset_codeslot_TEMPLATENUM
     platform: state
     to: 'on'
   action:
-    - service: script.reset_codeslot_LOCKNAME
+    - service: script.LOCKNAME_reset_codeslot
       data_template:
         code_slot: TEMPLATENUM
       
@@ -227,7 +227,7 @@ binary_sensor:
 - platform: template
   sensors:
 
-    active_LOCKNAME_TEMPLATENUM:
+    LOCKNAME_active_TEMPLATENUM:
       friendly_name: "Desired PIN State"
       value_template: >-
         {## This template checks whether the PIN should be considered active based on ##}
@@ -239,27 +239,27 @@ binary_sensor:
         {% set current_date = now.strftime('%Y%m%d') | int %}
         {% set current_time = now.strftime('%H%M') | int %}
 
-        {% set start_date = states('input_datetime.start_date_LOCKNAME_TEMPLATENUM').replace('-', '') | int %}
-        {% set end_date = states('input_datetime.end_date_LOCKNAME_TEMPLATENUM').replace('-', '') | int %}
-        {% set current_day_start_time = (states('input_datetime.' + current_day + '_start_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
-        {% set current_day_end_time = (states('input_datetime.' + current_day + '_end_date_LOCKNAME_TEMPLATENUM')[0:5]).replace(':', '') | int %}
+        {% set start_date = states('input_datetime.LOCKNAME_start_date_TEMPLATENUM').replace('-', '') | int %}
+        {% set end_date = states('input_datetime.LOCKNAME_end_date_TEMPLATENUM').replace('-', '') | int %}
+        {% set current_day_start_time = (states('input_datetime.LOCKNAME_' + current_day + '_start_date_TEMPLATENUM')[0:5]).replace(':', '') | int %}
+        {% set current_day_end_time = (states('input_datetime.LOCKNAME_' + current_day + '_end_date_TEMPLATENUM')[0:5]).replace(':', '') | int %}
 
-        {% set is_slot_active = is_state('input_boolean.enabled_LOCKNAME_TEMPLATENUM', 'on') %}
-        {% set is_current_day_active = is_state('input_boolean.' + current_day + '_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set is_slot_active = is_state('input_boolean.LOCKNAME_enabled_TEMPLATENUM', 'on') %}
+        {% set is_current_day_active = is_state('input_boolean.LOCKNAME_' + current_day + '_TEMPLATENUM', 'on') %}
 
-        {% set is_date_range_enabled = is_state('input_boolean.daterange_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set is_date_range_enabled = is_state('input_boolean.LOCKNAME_daterange_TEMPLATENUM', 'on') %}
         {% set is_in_date_range = (current_date >= start_date and current_date <= end_date) %}
 
         {% set is_time_range_enabled = (current_day_start_time != current_day_end_time) %}
-        {% set is_time_range_inclusive = is_state('input_boolean.' + current_day + '_inc_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set is_time_range_inclusive = is_state('input_boolean.LOCKNAME_' + current_day + '_inc_TEMPLATENUM', 'on') %}
         {% set is_in_time_range = (
           (is_time_range_inclusive and (current_time >= current_day_start_time and current_time <= current_day_end_time))
           or
           (not is_time_range_inclusive and (current_time < current_day_start_time or current_time > current_day_end_time))
         ) %}
 
-        {% set is_access_limit_enabled = is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'on') %}
-        {% set is_access_count_valid = states('input_number.accesscount_LOCKNAME_TEMPLATENUM') | int > 0 %}
+        {% set is_access_limit_enabled = is_state('input_boolean.LOCKNAME_accesslimit_TEMPLATENUM', 'on') %}
+        {% set is_access_count_valid = states('input_number.LOCKNAME_accesscount_TEMPLATENUM') | int > 0 %}
 
         {{
           is_slot_active and is_current_day_active
@@ -271,11 +271,11 @@ binary_sensor:
           (not is_access_limit_enabled or is_access_count_valid)
         }}
 
-    pin_synched_LOCKNAME_TEMPLATENUM:
+    LOCKNAME_pin_synched_TEMPLATENUM:
       friendly_name: 'PIN synchronized with lock'
       value_template: >
         {% set lockpin = states('sensor.LOCKNAME_code_slot_TEMPLATENUM') %}
-        {% if is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% if is_state('binary_sensor.LOCKNAME_active_TEMPLATENUM', 'on') %}
           {{ is_state('input_text.LOCKNAME_pin_TEMPLATENUM', lockpin) }}
         {% else %}
           {{ lockpin in ("", "0000") }}
@@ -287,7 +287,7 @@ sensor:
 - platform: template
   sensors:
   
-    connected_LOCKNAME_TEMPLATENUM:
+    LOCKNAME_connected_TEMPLATENUM:
       # icon: mdi:glassdoor
       friendly_name: "PIN Status"
       value_template: >-
@@ -301,8 +301,8 @@ sensor:
             False: 'Disconnecting',
           },
         } %}
-        {% set slot_active = is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
-        {% set pin_synched = is_state('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set slot_active = is_state('binary_sensor.LOCKNAME_active_TEMPLATENUM', 'on') %}
+        {% set pin_synched = is_state('binary_sensor.LOCKNAME_pin_synched_TEMPLATENUM', 'on') %}
         {{ value_map[slot_active][pin_synched] }}
       icon_template: >
         {% set icon_map = {
@@ -315,6 +315,6 @@ sensor:
             False: 'mdi:wiper-watch',
           },
         } %}
-        {% set slot_active = is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on') %}
-        {% set pin_synched = is_state('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set slot_active = is_state('binary_sensor.LOCKNAME_active_TEMPLATENUM', 'on') %}
+        {% set pin_synched = is_state('binary_sensor.LOCKNAME_pin_synched_TEMPLATENUM', 'on') %}
         {{ icon_map[slot_active][pin_synched] }}

--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -248,7 +248,7 @@ binary_sensor:
           (
             is_time_range_inclusive
             and
-            current_time >= configured_start_time and current_time <= configured_end_time)
+            (current_time >= configured_start_time and current_time <= configured_end_time)
           )
           or
           (
@@ -258,7 +258,7 @@ binary_sensor:
           )
         ) %}
 
-        {% is_access_limit_enabled = is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'on') %}
+        {% set is_access_limit_enabled = is_state('input_boolean.accesslimit_LOCKNAME_TEMPLATENUM', 'on') %}
         {% set is_access_count_valid = states('input_number.accesscount_LOCKNAME_TEMPLATENUM') | int > 0 %}
 
         {{

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -12,8 +12,6 @@ input_boolean:
     name: CASE_LOCK_NAME Lock Notifications
   LOCKNAME_dooraccess_notifications:
     name: CASE_LOCK_NAME Door Notifications
-  LOCKNAME_garageacess_notifications:
-    name: CASE_LOCK_NAME Garage Notifications
   LOCKNAME_reset_lock:
     name: CASE_LOCK_NAME reset lock
 
@@ -33,21 +31,6 @@ script:
           title: "reset"
           message: "LOCKNAME"
 
-  LOCKNAME_conditional_notify:
-    sequence:
-      - condition: template
-        value_template: >-
-          {% set inputbool = boolean %}
-          {% if states(inputbool) == 'on'%}
-            true
-          {% else %}
-            false
-          {% endif %}
-      - service: script.LOCKNAME_manual_notify
-        data_template:
-          title: "{{title}}"
-          message: "{{message}}"
-
   LOCKNAME_refreshnodeinfo:
     description:  'Send MQTT RefreshNodeInfo command'
     sequence:
@@ -62,6 +45,66 @@ script:
             {% set node_id = state_attr('LOCKENTITYNAME','node_id') %}
             { "node": {{ node_id }} }
           retain: true
+
+  reset_codeslot_LOCKNAME:
+    variables:
+      days: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
+      code_slot: 1
+    sequence:
+      - service: input_text.set_value
+        data_template:
+          entity_id: "input_text.LOCKNAME_name_{{ code_slot | string }}"
+          value: ""
+      - service: input_text.set_value
+        data_template:
+          entity_id: "input_text.LOCKNAME_pin_{{ code_slot | string }}"
+          value: ""
+      - service: input_boolean.turn_off
+        data_template:
+          entity_id: "input_boolean.notify_LOCKNAME_{{ code_slot | string }}"
+      - service: input_boolean.turn_off
+        data_template:
+          entity_id: "input_boolean.enabled_LOCKNAME_{{ code_slot | string }}"
+      - service: input_number.set_value
+        data_template:
+          entity_id: "input_number.accesscount_LOCKNAME_{{ code_slot | string }}"
+          value: "0"
+      - service: input_datetime.set_datetime
+        data_template:
+          entity_id: "input_datetime.start_date_LOCKNAME_{{ code_slot | string }}"
+          date: >
+            {{  (("1980-01-01")  | timestamp_custom("%Y %m %d"))  }}      
+      - service: input_datetime.set_datetime
+        data_template:
+          entity_id: "input_datetime.end_date_LOCKNAME_{{ code_slot | string }}"
+          date: >
+            {{  (("1980-01-01")  | timestamp_custom("%Y %m %d"))  }} 
+      - service: input_boolean.turn_off
+        data_template:
+          entity_id: "input_boolean.daterange_LOCKNAME_{{ code_slot | string }}"
+      - service: input_boolean.turn_off
+        data_template:
+          entity_id: "input_boolean.accesslimit_LOCKNAME_{{ code_slot | string }}"
+      - service: input_boolean.turn_off
+        data_template:
+          entity_id: "input_boolean.reset_codeslot_LOCKNAME_{{ code_slot | string }}"
+      - repeat:
+          count: 7
+          sequence:
+            - service: input_datetime.set_datetime
+              data_template:
+                entity_id: "input_datetime.{{ days[repeat.index - 1] }}_start_date_LOCKNAME_{{ code_slot | string }}"
+                time: "{{ '00:00' | timestamp_custom('%H:%M') }}"
+            - service: input_datetime.set_datetime
+              data_template:
+                entity_id: "input_datetime.{{ days[repeat.index - 1] }}_end_date_LOCKNAME_{{ code_slot | string }}"
+                time: "{{ '00:00' | timestamp_custom('%H:%M') }}"
+            - service: input_boolean.turn_on
+              data_template:
+                entity_id: "input_boolean.{{ days[repeat.index - 1] }}_LOCKNAME_{{ code_slot | string }}"
+            - service: input_boolean.turn_on
+              data_template:
+                entity_id: "input_boolean.{{ days[repeat.index - 1] }}_inc_LOCKNAME_{{ code_slot | string }}"
           
 ###################  automation:  ####################
 automation:
@@ -73,12 +116,14 @@ automation:
         lockname: LOCKNAME
     condition:
       - condition: state
-        entity_id: "binary_sensor.allow_automation"
+        entity_id: "input_boolean.allow_automation_execution"
+        state: "on"
+      - condition: state
+        entity_id: "input_boolean.LOCKNAME_lock_notifications"
         state: "on"
     action:
-      - service: script.LOCKNAME_conditional_notify
+      - service: script.LOCKNAME_manual_notify
         data_template:
-          boolean: input_boolean.LOCKNAME_lock_notifications
           title: CASE_LOCK_NAME
           message: "{{ trigger.event.data.action_text }}"
 
@@ -90,7 +135,7 @@ automation:
         lockname: LOCKNAME
     condition:
       - condition: state
-        entity_id: "binary_sensor.allow_automation"
+        entity_id: "input_boolean.allow_automation_execution"
         state: "on"
       - condition: template
         value_template: "{{ trigger.event.data.code_slot > 0 }}"
@@ -102,35 +147,39 @@ automation:
           title: "{{ trigger.event.data.action_text }}"
           message: "{{ trigger.event.data.code_slot_name }}"
 
-  - alias: CASE_LOCK_NAME Sensor Close
-    condition:
-      - condition: state
-        entity_id: "binary_sensor.allow_automation"
-        state: "on"
+  - alias: CASE_LOCK_NAME Sensor Closed
     trigger:
       entity_id: DOORSENSORENTITYNAME
       platform: state
       to: "off"
+    condition:
+      - condition: state
+        entity_id: "input_boolean.allow_automation_execution"
+        state: "on"
+      - condition: state
+        entity_id: "input_boolean.LOCKNAME_dooraccess_notifications"
+        state: "on"
     action:
-      - service: script.LOCKNAME_conditional_notify
+      - service: script.LOCKNAME_manual_notify
         data_template:
-          boolean: input_boolean.LOCKNAME_dooraccess_notifications
           title: CASE_LOCK_NAME
           message: "Closed"
 
   - alias: CASE_LOCK_NAME Sensor Opened
-    condition:
-      - condition: state
-        entity_id: "binary_sensor.allow_automation"
-        state: "on"
     trigger:
       entity_id: DOORSENSORENTITYNAME
       platform: state
       to: "on"
+    condition:
+      - condition: state
+        entity_id: "input_boolean.allow_automation_execution"
+        state: "on"
+      - condition: state
+        entity_id: "input_boolean.LOCKNAME_dooraccess_notifications"
+        state: "on"
     action:
-      - service: script.LOCKNAME_conditional_notify
+      - service: script.LOCKNAME_manual_notify
         data_template:
-          boolean: input_boolean.LOCKNAME_dooraccess_notifications
           title: CASE_LOCK_NAME
           message: "Opened"
 
@@ -140,7 +189,7 @@ automation:
       platform: state
     condition:
       - condition: state
-        entity_id: "binary_sensor.allow_automation"
+        entity_id: "input_boolean.allow_automation_execution"
         state: "on"
       - condition: template
         value_template: >-
@@ -169,7 +218,7 @@ automation:
   - alias: CASE_LOCK_NAME Reset
     condition:
       - condition: state
-        entity_id: "binary_sensor.allow_automation"
+        entity_id: "input_boolean.allow_automation_execution"
         state: "on"
     trigger:
       entity_id: input_boolean.LOCKNAME_reset_lock
@@ -189,7 +238,7 @@ automation:
         lockname: LOCKNAME
     condition:
       - condition: state
-        entity_id: "binary_sensor.allow_automation"
+        entity_id: "input_boolean.allow_automation_execution"
         state: "on"
       - condition: template
         # make sure decrementing access entries is enabled 

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -15,6 +15,13 @@ input_boolean:
   LOCKNAME_reset_lock:
     name: CASE_LOCK_NAME reset lock
 
+###################  sensor:  ####################
+sensor:	
+  - platform: time_date	
+    display_options:	
+      - "time"	
+      - "date"
+
 ###################  script:  ####################
 script:
   LOCKNAME_reset_lock:

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -39,6 +39,7 @@ script:
           retain: true
 
   reset_codeslot_LOCKNAME:
+    mode: queued
     fields:
       code_slot:
         description: The code slot to reset

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -198,27 +198,17 @@ automation:
         state: "on"
       - condition: template
         value_template: >-
-          {% set object_id = trigger.to_state.object_id %}
-          {% set index = object_id.rfind('_') + 1 %}
-          {% set code_slot = object_id[index:] %}
-          {% set b = 'input_boolean.enabled_LOCKNAME_' + code_slot | string %}
-          {{ is_state(b, 'on') and (trigger.from_state.state != trigger.to_state.state)}}
+          {{ is_state('input_boolean.enabled_LOCKNAME_' + trigger.entity_id.split('_')[-1:], 'on') and (trigger.from_state.state != trigger.to_state.state)}}
     action:
       - service: persistent_notification.create
         data_template:
           title: CASE_LOCK_NAME LOCK MANAGER
           message: >-
-            {% set object_id = trigger.to_state.object_id %}
-            {% set index = object_id.rfind('_') + 1 %}
-            {% set code_slot = object_id[index:] %}
-            {{ 'You changed the PIN for code  ' + code_slot | string + '. Please enable it in order to make it active.'}}
+            {{ 'You changed the PIN for code  ' + trigger.entity_id.split('_')[-1:] + '. Please enable it in order to make it active.'}}
       - service: input_boolean.turn_off
         data_template:
           entity_id: >-
-            {% set object_id = trigger.to_state.object_id %}
-            {% set index = object_id.rfind('_') + 1 %}
-            {% set code_slot = object_id[index:] %}
-            {{ 'input_boolean.enabled_LOCKNAME_' + code_slot | string }}
+            {{ 'input_boolean.enabled_LOCKNAME_' + trigger.entity_id.split('_')[-1:] }}
 
   - alias: CASE_LOCK_NAME Reset
     condition:

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -31,7 +31,7 @@ script:
             { "node": {{ state_attr('LOCKENTITYNAME','node_id') }} }
           retain: true
 
-  reset_codeslot_LOCKNAME:
+  LOCKNAME_reset_codeslot:
     mode: queued
     fields:
       code_slot:
@@ -43,7 +43,7 @@ script:
     sequence:
       - service: input_boolean.turn_off
         data_template:
-          entity_id: "input_boolean.enabled_LOCKNAME_{{ code_slot | string }}"
+          entity_id: "input_boolean.LOCKNAME_enabled_{{ code_slot | string }}"
       - service: input_text.set_value
         data_template:
           entity_id: "input_text.LOCKNAME_name_{{ code_slot | string }}"
@@ -54,48 +54,48 @@ script:
           value: ""
       - service: input_boolean.turn_off
         data_template:
-          entity_id: "input_boolean.notify_LOCKNAME_{{ code_slot | string }}"
+          entity_id: "input_boolean.LOCKNAME_notify_{{ code_slot | string }}"
       - service: input_number.set_value
         data_template:
-          entity_id: "input_number.accesscount_LOCKNAME_{{ code_slot | string }}"
+          entity_id: "input_number.LOCKNAME_accesscount_{{ code_slot | string }}"
           value: "0"
       - service: input_datetime.set_datetime
         data_template:
-          entity_id: "input_datetime.start_date_LOCKNAME_{{ code_slot | string }}"
+          entity_id: "input_datetime.LOCKNAME_start_date_{{ code_slot | string }}"
           date: >
             {{ (("1980-01-01") | timestamp_custom("%Y %m %d")) }}
       - service: input_datetime.set_datetime
         data_template:
-          entity_id: "input_datetime.end_date_LOCKNAME_{{ code_slot | string }}"
+          entity_id: "input_datetime.LOCKNAME_end_date_{{ code_slot | string }}"
           date: >
             {{ (("1980-01-01") | timestamp_custom("%Y %m %d")) }} 
       - service: input_boolean.turn_off
         data_template:
-          entity_id: "input_boolean.daterange_LOCKNAME_{{ code_slot | string }}"
+          entity_id: "input_boolean.LOCKNAME_daterange_{{ code_slot | string }}"
       - service: input_boolean.turn_off
         data_template:
-          entity_id: "input_boolean.accesslimit_LOCKNAME_{{ code_slot | string }}"
+          entity_id: "input_boolean.LOCKNAME_accesslimit_{{ code_slot | string }}"
       - service: input_boolean.turn_off
         data_template:
-          entity_id: "input_boolean.reset_codeslot_LOCKNAME_{{ code_slot | string }}"
+          entity_id: "input_boolean.LOCKNAME_reset_codeslot_{{ code_slot | string }}"
       # Loop through each day of the week and reset the entities related to each one
       - repeat:
           count: 7
           sequence:
             - service: input_datetime.set_datetime
               data_template:
-                entity_id: "input_datetime.{{ days[repeat.index - 1] }}_start_date_LOCKNAME_{{ code_slot | string }}"
+                entity_id: "input_datetime.LOCKNAME_{{ days[repeat.index - 1] }}_start_date_{{ code_slot | string }}"
                 time: "{{ '00:00' | timestamp_custom('%H:%M') }}"
             - service: input_datetime.set_datetime
               data_template:
-                entity_id: "input_datetime.{{ days[repeat.index - 1] }}_end_date_LOCKNAME_{{ code_slot | string }}"
+                entity_id: "input_datetime.LOCKNAME_{{ days[repeat.index - 1] }}_end_date_{{ code_slot | string }}"
                 time: "{{ '00:00' | timestamp_custom('%H:%M') }}"
             - service: input_boolean.turn_on
               data_template:
-                entity_id: "input_boolean.{{ days[repeat.index - 1] }}_LOCKNAME_{{ code_slot | string }}"
+                entity_id: "input_boolean.LOCKNAME_{{ days[repeat.index - 1] }}_{{ code_slot | string }}"
             - service: input_boolean.turn_on
               data_template:
-                entity_id: "input_boolean.{{ days[repeat.index - 1] }}_inc_LOCKNAME_{{ code_slot | string }}"
+                entity_id: "input_boolean.LOCKNAME_{{ days[repeat.index - 1] }}_inc_{{ code_slot | string }}"
           
 ###################  automation:  ####################
 automation:
@@ -131,7 +131,7 @@ automation:
       - condition: template
         value_template: "{{ trigger.event.data.code_slot > 0 }}"
       - condition: template
-        value_template: "{{ is_state('input_boolean.notify_LOCKNAME_' + trigger.event.data.code_slot | string, 'on') }}"
+        value_template: "{{ is_state('input_boolean.LOCKNAME_notify_' + trigger.event.data.code_slot | string, 'on') }}"
     action:
       - service: script.LOCKNAME_manual_notify
         data_template:
@@ -185,7 +185,7 @@ automation:
       - condition: template
         value_template: >-
           {{
-            is_state('input_boolean.enabled_LOCKNAME_' + trigger.entity_id.split('_')[-1:], 'on')
+            is_state('input_boolean.LOCKNAME_enabled_' + trigger.entity_id.split('_')[-1:], 'on')
             and
             (trigger.from_state.state != trigger.to_state.state)
           }}
@@ -198,7 +198,7 @@ automation:
       - service: input_boolean.turn_off
         data_template:
           entity_id: >-
-            {{ 'input_boolean.enabled_LOCKNAME_' + trigger.entity_id.split('_')[-1:] }}
+            {{ 'input_boolean.LOCKNAME_enabled_' + trigger.entity_id.split('_')[-1:] }}
 
   - alias: CASE_LOCK_NAME Reset
     variables:
@@ -216,7 +216,7 @@ automation:
     action:
       - repeat:
           sequence:
-            - service: script.reset_codeslot_LOCKNAME
+            - service: script.LOCKNAME_reset_codeslot
               data_template:
                 code_slot: "{{ code_slots[repeat.index - 1] | string }}"
           until: "{{ repeat.index == code_slots | length }}"
@@ -235,11 +235,11 @@ automation:
         state: "on"
       - condition: template
         # make sure decrementing access entries is enabled 
-        value_template: "{{ is_state('input_boolean.accesslimit_LOCKNAME_' + trigger.event.data.code_slot | string, 'on') }}"
+        value_template: "{{ is_state('input_boolean.LOCKNAME_accesslimit_' + trigger.event.data.code_slot | string, 'on') }}"
       - condition: template
         # Check for Keypad Unlock code
         value_template: "{{ trigger.event.data.code_slot > 0 and trigger.event.data.action_code in (6, 19)}}"
     action:
       - service: input_number.decrement
         data_template:
-          entity_id: "{{ 'input_number.accesscount_LOCKNAME_' + trigger.event.data.code_slot | string }}"
+          entity_id: "{{ 'input_number.LOCKNAME_accesscount_' + trigger.event.data.code_slot | string }}"

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -15,13 +15,6 @@ input_boolean:
   LOCKNAME_reset_lock:
     name: CASE_LOCK_NAME reset lock
 
-###################  sensor:  ####################
-sensor:
-  - platform: time_date
-    display_options:
-      - "time"
-      - "date"
-
 ###################  script:  ####################
 script:
   LOCKNAME_reset_lock:

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -17,13 +17,6 @@ input_boolean:
 
 ###################  script:  ####################
 script:
-  LOCKNAME_reset_lock:
-    sequence:
-      - service: script.LOCKNAME_manual_notify
-        data_template:
-          title: "reset"
-          message: "LOCKNAME"
-
   LOCKNAME_refreshnodeinfo:
     description: 'Send MQTT RefreshNodeInfo command'
     sequence:
@@ -208,6 +201,9 @@ automation:
             {{ 'input_boolean.enabled_LOCKNAME_' + trigger.entity_id.split('_')[-1:] }}
 
   - alias: CASE_LOCK_NAME Reset
+    variables:
+      # Constant used to loop through resetting all code slots
+      code_slots: [ALL_CODE_SLOTS]
     condition:
       - condition: state
         entity_id: "input_boolean.allow_automation_execution"
@@ -218,7 +214,12 @@ automation:
       from: "off"
       to: "on"
     action:
-      - service: script.LOCKNAME_reset_lock
+      - repeat:
+          sequence:
+            - service: script.reset_codeslot_LOCKNAME
+              data_template:
+                code_slot: "{{ code_slots[repeat.index - 1] | string }}"
+          until: "{{ repeat.index == code_slots | length }}"
       - service: input_boolean.turn_off
         entity_id: input_boolean.LOCKNAME_reset_lock
 

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -42,8 +42,7 @@ script:
         data:
           topic: 'OpenZWave/1/command/refreshnodeinfo/'
           payload: >-
-            {% set node_id = state_attr('LOCKENTITYNAME','node_id') %}
-            { "node": {{ node_id }} }
+            { "node": {{ state_attr('LOCKENTITYNAME','node_id') }} }
           retain: true
 
   reset_codeslot_LOCKNAME:

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -16,10 +16,10 @@ input_boolean:
     name: CASE_LOCK_NAME reset lock
 
 ###################  sensor:  ####################
-sensor:	
-  - platform: time_date	
-    display_options:	
-      - "time"	
+sensor:
+  - platform: time_date
+    display_options:
+      - "time"
       - "date"
 
 ###################  script:  ####################

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -144,7 +144,7 @@ automation:
       - condition: template
         value_template: "{{ trigger.event.data.code_slot > 0 }}"
       - condition: template
-        value_template: "{{ states['input_boolean']['notify_LOCKNAME_' + trigger.event.data.code_slot | string].state == 'on' }}"
+        value_template: "{{ is_state('input_boolean.notify_LOCKNAME_' + trigger.event.data.code_slot | string, 'on') }}"
     action:
       - service: script.LOCKNAME_manual_notify
         data_template:
@@ -240,7 +240,7 @@ automation:
         state: "on"
       - condition: template
         # make sure decrementing access entries is enabled 
-        value_template: "{{ states('input_boolean.accesslimit_LOCKNAME_' + trigger.event.data.code_slot | string)=='on' }}"
+        value_template: "{{ is_state('input_boolean.accesslimit_LOCKNAME_' + trigger.event.data.code_slot | string, 'on') }}"
       - condition: template
         # Check for Keypad Unlock code
         value_template: "{{ trigger.event.data.code_slot > 0 and trigger.event.data.action_code in (6, 19)}}"

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -47,9 +47,13 @@ script:
           retain: true
 
   reset_codeslot_LOCKNAME:
+    fields:
+      code_slot:
+        description: The code slot to reset
+        example: 1
     variables:
+      # Constant used later to loop through day specific entities
       days: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
-      code_slot: 1
     sequence:
       - service: input_text.set_value
         data_template:
@@ -88,6 +92,7 @@ script:
       - service: input_boolean.turn_off
         data_template:
           entity_id: "input_boolean.reset_codeslot_LOCKNAME_{{ code_slot | string }}"
+      # Loop through each day of the week and reset the entities related to each one
       - repeat:
           count: 7
           sequence:

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -135,8 +135,8 @@ automation:
     action:
       - service: script.LOCKNAME_manual_notify
         data_template:
-          title: "{{ trigger.event.data.action_text }}"
-          message: "{{ trigger.event.data.code_slot_name }}"
+          title: CASE_LOCK_NAME
+          message: "{{ trigger.event.data.action_text }} by {{ trigger.event.data.code_slot_name }}"
 
   - alias: CASE_LOCK_NAME Sensor Closed
     trigger:

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -36,7 +36,7 @@ script:
     sequence:
       - service: system_log.write
         data_template:
-          message: "LOCKNAME_TEMPLATENUM started noderefreshinfo: {{ now() }}"
+          message: "LOCKNAME started noderefreshinfo: {{ now() }}"
           level: debug  
       - service: mqtt.publish
         data:

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -22,7 +22,7 @@ sensor:
       - "time"
       - "date"
 
-###################  script    :  ####################
+###################  script:  ####################
 script:
   LOCKNAME_reset_lock:
     sequence:
@@ -32,12 +32,12 @@ script:
           message: "LOCKNAME"
 
   LOCKNAME_refreshnodeinfo:
-    description:  'Send MQTT RefreshNodeInfo command'
+    description: 'Send MQTT RefreshNodeInfo command'
     sequence:
       - service: system_log.write
         data_template:
           message: "LOCKNAME started noderefreshinfo: {{ now() }}"
-          level: debug  
+          level: debug
       - service: mqtt.publish
         data:
           topic: 'OpenZWave/1/command/refreshnodeinfo/'
@@ -76,12 +76,12 @@ script:
         data_template:
           entity_id: "input_datetime.start_date_LOCKNAME_{{ code_slot | string }}"
           date: >
-            {{  (("1980-01-01")  | timestamp_custom("%Y %m %d"))  }}      
+            {{ (("1980-01-01") | timestamp_custom("%Y %m %d")) }}
       - service: input_datetime.set_datetime
         data_template:
           entity_id: "input_datetime.end_date_LOCKNAME_{{ code_slot | string }}"
           date: >
-            {{  (("1980-01-01")  | timestamp_custom("%Y %m %d"))  }} 
+            {{ (("1980-01-01") | timestamp_custom("%Y %m %d")) }} 
       - service: input_boolean.turn_off
         data_template:
           entity_id: "input_boolean.daterange_LOCKNAME_{{ code_slot | string }}"
@@ -197,13 +197,17 @@ automation:
         state: "on"
       - condition: template
         value_template: >-
-          {{ is_state('input_boolean.enabled_LOCKNAME_' + trigger.entity_id.split('_')[-1:], 'on') and (trigger.from_state.state != trigger.to_state.state)}}
+          {{
+            is_state('input_boolean.enabled_LOCKNAME_' + trigger.entity_id.split('_')[-1:], 'on')
+            and
+            (trigger.from_state.state != trigger.to_state.state)
+          }}
     action:
       - service: persistent_notification.create
         data_template:
           title: CASE_LOCK_NAME LOCK MANAGER
           message: >-
-            {{ 'You changed the PIN for code  ' + trigger.entity_id.split('_')[-1:] + '. Please enable it in order to make it active.'}}
+            {{ 'You changed the PIN for code ' + trigger.entity_id.split('_')[-1:] + '. Please enable it in order to make it active.'}}
       - service: input_boolean.turn_off
         data_template:
           entity_id: >-

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -107,7 +107,7 @@ automation:
         lockname: LOCKNAME
     condition:
       - condition: state
-        entity_id: "input_boolean.allow_automation_execution"
+        entity_id: "input_boolean.keymaster_allow_automation_execution"
         state: "on"
       - condition: state
         entity_id: "input_boolean.LOCKNAME_lock_notifications"
@@ -126,7 +126,7 @@ automation:
         lockname: LOCKNAME
     condition:
       - condition: state
-        entity_id: "input_boolean.allow_automation_execution"
+        entity_id: "input_boolean.keymaster_allow_automation_execution"
         state: "on"
       - condition: template
         value_template: "{{ trigger.event.data.code_slot > 0 }}"
@@ -145,7 +145,7 @@ automation:
       to: "off"
     condition:
       - condition: state
-        entity_id: "input_boolean.allow_automation_execution"
+        entity_id: "input_boolean.keymaster_allow_automation_execution"
         state: "on"
       - condition: state
         entity_id: "input_boolean.LOCKNAME_dooraccess_notifications"
@@ -163,7 +163,7 @@ automation:
       to: "on"
     condition:
       - condition: state
-        entity_id: "input_boolean.allow_automation_execution"
+        entity_id: "input_boolean.keymaster_allow_automation_execution"
         state: "on"
       - condition: state
         entity_id: "input_boolean.LOCKNAME_dooraccess_notifications"
@@ -180,7 +180,7 @@ automation:
       platform: state
     condition:
       - condition: state
-        entity_id: "input_boolean.allow_automation_execution"
+        entity_id: "input_boolean.keymaster_allow_automation_execution"
         state: "on"
       - condition: template
         value_template: >-
@@ -206,7 +206,7 @@ automation:
       code_slots: [ALL_CODE_SLOTS]
     condition:
       - condition: state
-        entity_id: "input_boolean.allow_automation_execution"
+        entity_id: "input_boolean.keymaster_allow_automation_execution"
         state: "on"
     trigger:
       entity_id: input_boolean.LOCKNAME_reset_lock
@@ -231,7 +231,7 @@ automation:
         lockname: LOCKNAME
     condition:
       - condition: state
-        entity_id: "input_boolean.allow_automation_execution"
+        entity_id: "input_boolean.keymaster_allow_automation_execution"
         state: "on"
       - condition: template
         # make sure decrementing access entries is enabled 

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -41,6 +41,9 @@ script:
       # Constant used later to loop through day specific entities
       days: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
     sequence:
+      - service: input_boolean.turn_off
+        data_template:
+          entity_id: "input_boolean.enabled_LOCKNAME_{{ code_slot | string }}"
       - service: input_text.set_value
         data_template:
           entity_id: "input_text.LOCKNAME_name_{{ code_slot | string }}"
@@ -52,9 +55,6 @@ script:
       - service: input_boolean.turn_off
         data_template:
           entity_id: "input_boolean.notify_LOCKNAME_{{ code_slot | string }}"
-      - service: input_boolean.turn_off
-        data_template:
-          entity_id: "input_boolean.enabled_LOCKNAME_{{ code_slot | string }}"
       - service: input_number.set_value
         data_template:
           entity_id: "input_number.accesscount_LOCKNAME_{{ code_slot | string }}"

--- a/custom_components/keymaster/lovelace.code
+++ b/custom_components/keymaster/lovelace.code
@@ -8,63 +8,63 @@
             entities:
               - entity: input_text.LOCKNAME_name_TEMPLATENUM
               - entity: input_text.LOCKNAME_pin_TEMPLATENUM
-              - entity: input_boolean.enabled_LOCKNAME_TEMPLATENUM
-              - entity: input_boolean.notify_LOCKNAME_TEMPLATENUM
+              - entity: input_boolean.LOCKNAME_enabled_TEMPLATENUM
+              - entity: input_boolean.LOCKNAME_notify_TEMPLATENUM
               - type: divider
-              - entity: sensor.connected_LOCKNAME_TEMPLATENUM
+              - entity: sensor.LOCKNAME_connected_TEMPLATENUM
                 state_color: true
-              - entity: binary_sensor.active_LOCKNAME_TEMPLATENUM
+              - entity: binary_sensor.LOCKNAME_active_TEMPLATENUM
                 state_color: true
-              - entity: binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM
+              - entity: binary_sensor.LOCKNAME_pin_synched_TEMPLATENUM
                 state_color: true
               - type: 'custom:fold-entity-row'
                 head:
                   type: section
                   label: Advanced Options
                 entities:
-                  - entity: input_boolean.reset_codeslot_LOCKNAME_TEMPLATENUM
+                  - entity: input_boolean.LOCKNAME_reset_codeslot_TEMPLATENUM
                   - type: divider
-                  - entity: input_boolean.accesslimit_LOCKNAME_TEMPLATENUM
-                  - entity: input_number.accesscount_LOCKNAME_TEMPLATENUM
+                  - entity: input_boolean.LOCKNAME_accesslimit_TEMPLATENUM
+                  - entity: input_number.LOCKNAME_accesscount_TEMPLATENUM
                     type: 'custom:numberbox-card'
                     icon: 'mdi:key-variant'
                     speed: 250
                   - type: divider
-                  - entity: input_boolean.daterange_LOCKNAME_TEMPLATENUM
-                  - entity: input_datetime.start_date_LOCKNAME_TEMPLATENUM
-                  - entity: input_datetime.end_date_LOCKNAME_TEMPLATENUM
+                  - entity: input_boolean.LOCKNAME_daterange_TEMPLATENUM
+                  - entity: input_datetime.LOCKNAME_start_date_TEMPLATENUM
+                  - entity: input_datetime.LOCKNAME_end_date_TEMPLATENUM
                   - type: divider
-                  - input_boolean.sun_LOCKNAME_TEMPLATENUM
-                  - input_boolean.sun_inc_LOCKNAME_TEMPLATENUM
-                  - input_datetime.sun_start_date_LOCKNAME_TEMPLATENUM
-                  - input_datetime.sun_end_date_LOCKNAME_TEMPLATENUM
+                  - input_boolean.LOCKNAME_sun_TEMPLATENUM
+                  - input_boolean.LOCKNAME_sun_inc_TEMPLATENUM
+                  - input_datetime.LOCKNAME_sun_start_date_TEMPLATENUM
+                  - input_datetime.LOCKNAME_sun_end_date_TEMPLATENUM
                   - type: divider
-                  - input_boolean.mon_LOCKNAME_TEMPLATENUM
-                  - input_boolean.mon_inc_LOCKNAME_TEMPLATENUM
-                  - input_datetime.mon_start_date_LOCKNAME_TEMPLATENUM
-                  - input_datetime.mon_end_date_LOCKNAME_TEMPLATENUM
+                  - input_boolean.LOCKNAME_mon_TEMPLATENUM
+                  - input_boolean.LOCKNAME_mon_inc_TEMPLATENUM
+                  - input_datetime.LOCKNAME_mon_start_date_TEMPLATENUM
+                  - input_datetime.LOCKNAME_mon_end_date_TEMPLATENUM
                   - type: divider
-                  - input_boolean.tue_LOCKNAME_TEMPLATENUM
-                  - input_boolean.tue_inc_LOCKNAME_TEMPLATENUM
-                  - input_datetime.tue_start_date_LOCKNAME_TEMPLATENUM
-                  - input_datetime.tue_end_date_LOCKNAME_TEMPLATENUM
+                  - input_boolean.LOCKNAME_tue_TEMPLATENUM
+                  - input_boolean.LOCKNAME_tue_inc_TEMPLATENUM
+                  - input_datetime.LOCKNAME_tue_start_date_TEMPLATENUM
+                  - input_datetime.LOCKNAME_tue_end_date_TEMPLATENUM
                   - type: divider
-                  - input_boolean.wed_LOCKNAME_TEMPLATENUM
-                  - input_boolean.wed_inc_LOCKNAME_TEMPLATENUM
-                  - input_datetime.wed_start_date_LOCKNAME_TEMPLATENUM
-                  - input_datetime.wed_end_date_LOCKNAME_TEMPLATENUM
+                  - input_boolean.LOCKNAME_wed_TEMPLATENUM
+                  - input_boolean.LOCKNAME_wed_inc_TEMPLATENUM
+                  - input_datetime.LOCKNAME_wed_start_date_TEMPLATENUM
+                  - input_datetime.LOCKNAME_wed_end_date_TEMPLATENUM
                   - type: divider
-                  - input_boolean.thu_LOCKNAME_TEMPLATENUM
-                  - input_boolean.thu_inc_LOCKNAME_TEMPLATENUM
-                  - input_datetime.thu_start_date_LOCKNAME_TEMPLATENUM
-                  - input_datetime.thu_end_date_LOCKNAME_TEMPLATENUM
+                  - input_boolean.LOCKNAME_thu_TEMPLATENUM
+                  - input_boolean.LOCKNAME_thu_inc_TEMPLATENUM
+                  - input_datetime.LOCKNAME_thu_start_date_TEMPLATENUM
+                  - input_datetime.LOCKNAME_thu_end_date_TEMPLATENUM
                   - type: divider
-                  - input_boolean.fri_LOCKNAME_TEMPLATENUM
-                  - input_boolean.fri_inc_LOCKNAME_TEMPLATENUM
-                  - input_datetime.fri_start_date_LOCKNAME_TEMPLATENUM
-                  - input_datetime.fri_end_date_LOCKNAME_TEMPLATENUM
+                  - input_boolean.LOCKNAME_fri_TEMPLATENUM
+                  - input_boolean.LOCKNAME_fri_inc_TEMPLATENUM
+                  - input_datetime.LOCKNAME_fri_start_date_TEMPLATENUM
+                  - input_datetime.LOCKNAME_fri_end_date_TEMPLATENUM
                   - type: divider
-                  - input_boolean.sat_LOCKNAME_TEMPLATENUM
-                  - input_boolean.sat_inc_LOCKNAME_TEMPLATENUM
-                  - input_datetime.sat_start_date_LOCKNAME_TEMPLATENUM
-                  - input_datetime.sat_end_date_LOCKNAME_TEMPLATENUM
+                  - input_boolean.LOCKNAME_sat_TEMPLATENUM
+                  - input_boolean.LOCKNAME_sat_inc_TEMPLATENUM
+                  - input_datetime.LOCKNAME_sat_start_date_TEMPLATENUM
+                  - input_datetime.LOCKNAME_sat_end_date_TEMPLATENUM

--- a/custom_components/keymaster/lovelace.head
+++ b/custom_components/keymaster/lovelace.head
@@ -5,9 +5,6 @@
     badges:
       - input_boolean.LOCKNAME_lock_notifications
       - input_boolean.LOCKNAME_dooraccess_notifications
-      - input_boolean.LOCKNAME_garageacess_notifications
-      - entity: >-
-          LOCKENTITYNAME
-      - entity: >-
-          DOORSENSORENTITYNAME
+      - entity: LOCKENTITYNAME
+      - entity: DOORSENSORENTITYNAME
     cards:

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -208,9 +208,7 @@ def generate_package_files(
     inputlockpinheaders = ",".join(
         [f"{inputlockpinheader}_{x}" for x in range(start_from, code_slots + 1)]
     )
-    all_code_slots = ", ".join(
-        [f"{x}" for x in range(start_from, code_slots + 1)]
-    )
+    all_code_slots = ", ".join([f"{x}" for x in range(start_from, code_slots + 1)])
 
     _LOGGER.debug("Creating common YAML files...")
     replacements = {

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -208,12 +208,16 @@ def generate_package_files(
     inputlockpinheaders = ",".join(
         [f"{inputlockpinheader}_{x}" for x in range(start_from, code_slots + 1)]
     )
+    all_code_slots = ", ".join(
+        [f"{x}" for x in range(start_from, code_slots + 1)]
+    )
 
     _LOGGER.debug("Creating common YAML files...")
     replacements = {
         "LOCKNAME": lockname,
         "CASE_LOCK_NAME": lockname,
         "INPUTLOCKPINHEADER": inputlockpinheaders,
+        "ALL_CODE_SLOTS": all_code_slots,
         "ACTIVELOCKHEADER": activelockheaders,
         "LOCKENTITYNAME": lockentityname,
         "SENSORNAME": sensorname,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,4 @@
 """ Test keymaster init """
-from unittest.mock import call, patch
-
-import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.keymaster.const import DOMAIN


### PR DESCRIPTION
## Breaking change
The entity names have been updated to follow a consistent naming format - `<LOCKNAME>_<DAY OF WEEK (OPTIONAL)>_<ENTITY_NAME>_<CODE_SLOT>`. This means that states will have to be re-input into the new entities and users may have to update their lovelace code

## Proposed change
The package files generated a chain reaction of state changes to entities on any given state change for an input helper or lock state due to the way it was structured. I removed all `binary_sensors` and `sensors` that were just holding logic for another `binary_sensor` or `sensor`, removed the unused `system_ready` stuff from the additional_yaml, and simplified the logic to check whether the pin should be active based on the day, date, time, etc. This should make all of the `keymaster` logic more performant because significantly less states are changing on a given action, and there's less for HomeAssistant to store since we reduced the number of entities created.

Let me know what you think, I think it's still structured in an easily debuggable way but you may feel differently.

BUGFIX:
- `LOCKNAME_active_TEMPLATENUM` binary sensor now handles excluded time range case (it didn't previously)
- There was an automation called `<LOCK NAME> reset` that seemed intended to reset all code slots for the lock. Instead it was calling a manual or conditional notify script, which didn't seem intentional. I have fixed this functionality such that if you flip on reset the lock, it will actually reset the lock


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
