### PR TITLE
Fix references to hass.data to use the correct dictionary

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -256,9 +256,9 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         )
 
         # Unsubscribe to any listeners
-        for unsub_listener in hass.data[DOMAIN].get(UNSUB_LISTENERS, []):
+        for unsub_listener in hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []):
             unsub_listener()
-        hass.data[DOMAIN].get(UNSUB_LISTENERS, []).clear()
+        hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []).clear()
 
         hass.data[DOMAIN].pop(config_entry.entry_id)
 
@@ -331,7 +331,7 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
         config_entry.data[CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID],
         config_entry.data[CONF_SENSOR_NAME],
     )
-    hass.data[DOMAIN].update(
+    hass.data[DOMAIN][config_entry.entry_id].update(
         {
             PRIMARY_LOCK: primary_lock,
             CHILD_LOCKS: [
@@ -357,9 +357,9 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
         handle_state_change(hass, config_entry, changed_entity, old_state, new_state)
 
     # Unsubscribe to any listeners so we can create new ones
-    for unsub_listener in hass.data[DOMAIN].get(UNSUB_LISTENERS, []):
+    for unsub_listener in hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []):
         unsub_listener()
-    hass.data[DOMAIN].get(UNSUB_LISTENERS, []).clear()
+    hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []).clear()
 
     # Create new listeners
     hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(


### PR DESCRIPTION
## Proposed change
All of the data stored in `hass.data[DOMAIN]` uses the `config_entry.entry_id` as the key. I missed some places to add this so options updates to change things about the lock wouldn't have worked. This PR fixes that


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
