### PR TITLE
Use lock domain for zwave service

### DIFF
--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -171,6 +171,7 @@ def handle_state_change(
     # or lock state is coming from or going to a weird state, ignore
     if (
         changed_entity != primary_lock.lock_entity_id
+        or new_state is None
         or new_state.state not in (STATE_LOCKED, STATE_UNLOCKED)
         or old_state.state not in (STATE_LOCKED, STATE_UNLOCKED)
     ):

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -7,7 +7,6 @@ from openzwavemqtt.const import ATTR_CODE_SLOT, CommandClass
 from homeassistant.components.input_text import MODE_PASSWORD, MODE_TEXT
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.ozw import DOMAIN as OZW_DOMAIN
-from homeassistant.components.zwave.const import DOMAIN as ZWAVE_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
@@ -91,7 +90,7 @@ async def add_code(
         servicedata[ATTR_NODE_ID] = node_id
 
         try:
-            await hass.services.async_call(ZWAVE_DOMAIN, SET_USERCODE, servicedata)
+            await hass.services.async_call(LOCK_DOMAIN, SET_USERCODE, servicedata)
         except Exception as err:
             _LOGGER.error("Error calling lock.set_usercode service call: %s", str(err))
             return


### PR DESCRIPTION
## Proposed change
We were mistakenly using the `zwave` domain to try to call the `set_usercode` service instead of the `lock` domain so the service call would not be successful. This will hopefully resolve #25


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
