### PR TITLE
check for presence of a different key to determine that the user is using zwave over ozw

### DIFF
--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -13,7 +13,7 @@ from homeassistant.components.input_select import DOMAIN as IN_SELECT_DOMAIN
 from homeassistant.components.input_text import DOMAIN as IN_TXT_DOMAIN
 from homeassistant.components.ozw import DOMAIN as OZW_DOMAIN
 from homeassistant.components.timer import DOMAIN as TIMER_DOMAIN
-from homeassistant.components.zwave.const import DOMAIN as ZWAVE_DOMAIN
+from homeassistant.components.zwave.const import DATA_ZWAVE_CONFIG
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_STATE, STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.core import HomeAssistant, State
@@ -48,7 +48,7 @@ def using_ozw(hass: HomeAssistant) -> bool:
 
 def using_zwave(hass: HomeAssistant) -> bool:
     """Returns whether the zwave integration is configured."""
-    return ZWAVE_DOMAIN in hass.data
+    return DATA_ZWAVE_CONFIG in hass.data
 
 
 def get_node_id(hass: HomeAssistant, entity_id: str) -> Optional[str]:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -61,6 +61,6 @@ async def test_setup_migration_with_old_path(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 12
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -128,7 +128,7 @@ async def test_add_code(hass, lock_data, sent_messages, caplog):
         await hass.services.async_call(DOMAIN, SERVICE_ADD_CODE, servicedata)
         await hass.async_block_till_done()
         assert (
-            "Error calling lock.set_usercode service call: Unable to find service lock/set_usercode"
+            "Error calling lock.set_usercode service call: Unable to find service"
             in caplog.text
         )
 
@@ -213,7 +213,7 @@ async def test_clear_code(hass, lock_data, sent_messages, caplog):
         await hass.services.async_call(DOMAIN, SERVICE_CLEAR_CODE, servicedata)
         await hass.async_block_till_done()
         assert (
-            "Error calling lock.clear_usercode service call: Unable to find service lock/clear_usercode"
+            "Error calling lock.clear_usercode service call: Unable to find service"
             in caplog.text
         )
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -11,7 +11,6 @@ from custom_components.keymaster import (
     SERVICE_REFRESH_CODES,
 )
 from custom_components.keymaster.const import DOMAIN
-from homeassistant.components.ozw import DOMAIN as OZW_DOMAIN
 
 from .common import setup_ozw
 
@@ -129,7 +128,7 @@ async def test_add_code(hass, lock_data, sent_messages, caplog):
         await hass.services.async_call(DOMAIN, SERVICE_ADD_CODE, servicedata)
         await hass.async_block_till_done()
         assert (
-            "Error calling lock.set_usercode service call: Unable to find service lock.set_usercode"
+            "Error calling lock.set_usercode service call: Unable to find service lock/set_usercode"
             in caplog.text
         )
 
@@ -214,7 +213,7 @@ async def test_clear_code(hass, lock_data, sent_messages, caplog):
         await hass.services.async_call(DOMAIN, SERVICE_CLEAR_CODE, servicedata)
         await hass.async_block_till_done()
         assert (
-            "Error calling lock.clear_usercode service call: Unable to find service lock.clear_usercode"
+            "Error calling lock.clear_usercode service call: Unable to find service lock/clear_usercode"
             in caplog.text
         )
 


### PR DESCRIPTION
## Proposed change
More changes to address #25. In particular, I noticed that `hass.data['zwave']` never gets set so the `using_zwave` check will always return False. I've improved the check to use a key that is definitely set when `zwave` starts (https://github.com/home-assistant/core/blob/dev/homeassistant/components/zwave/__init__.py#L420). Hopefully this will resolve the linked issue.



## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
