### PR TITLE
Add fix to clear code slot for zwave

### DIFF
--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -79,7 +79,7 @@ class PinSynchedSensor(BinarySensorEntity, KeymasterTemplateEntity):
             and input_pin is not None
             and (
                 (active and input_pin == lock_pin)
-                or (not active and lock_pin in ("", "0000"))
+                or (not active and (lock_pin in ("", "0000") or lock_pin != input_pin))
             )
         )
 

--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -73,13 +73,16 @@ class PinSynchedSensor(BinarySensorEntity, KeymasterTemplateEntity):
         lock_pin = self.get_state(self._lock_pin_entity)
         active = self.get_state(self._active_entity)
 
+        if lock_pin == "0000":
+            lock_pin = ""
+
         return (
             active is not None
             and lock_pin is not None
             and input_pin is not None
             and (
                 (active and input_pin == lock_pin)
-                or (not active and (lock_pin in ("", "0000") or lock_pin != input_pin))
+                or (not active and lock_pin == "")
             )
         )
 

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -1,6 +1,7 @@
 """Services for keymaster."""
 import logging
 import os
+import random
 
 from openzwavemqtt.const import ATTR_CODE_SLOT, CommandClass
 
@@ -128,6 +129,19 @@ async def clear_code(hass: HomeAssistant, entity_id: str, code_slot: int) -> Non
             ATTR_NODE_ID: node_id,
             ATTR_CODE_SLOT: code_slot,
         }
+
+        _LOGGER.debug(
+            "Setting code slot value to random PIN as workaround in case clearing code doesn't work"
+        )
+        try:
+            await hass.services.async_call(
+                LOCK_DOMAIN,
+                SET_USERCODE,
+                {**servicedata, ATTR_USER_CODE: str(random.randint(1000, 9999))},
+            )
+        except Exception as err:
+            _LOGGER.error("Error calling lock.set_usercode service call: %s", str(err))
+            return
 
         try:
             await hass.services.async_call(LOCK_DOMAIN, CLEAR_USERCODE, servicedata)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -215,7 +215,7 @@ async def test_clear_code(hass, lock_data, sent_messages, caplog):
         await hass.services.async_call(DOMAIN, SERVICE_CLEAR_CODE, servicedata)
         await hass.async_block_till_done()
         assert (
-            "Error calling lock.clear_usercode service call: Unable to find service"
+            "Error calling lock.set_usercode service call: Unable to find service"
             in caplog.text
         )
 


### PR DESCRIPTION
## Proposed change
When we moved from the clear code automation to the keymaster service to clear codes, we lost the workaround that set a random pin on a slot in case it couldn't be cleared.


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
