### PR TITLE
Parse access count into float instead of integer

### DIFF
--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -230,7 +230,7 @@ class ActiveSensor(BinarySensorEntity, KeymasterTemplateEntity):
         access_count = self.get_state(self._access_count_entity)
 
         return not is_access_limit_enabled or (
-            access_count is not None and int(access_count) > 0
+            access_count is not None and float(access_count) > 0
         )
 
     @property


### PR DESCRIPTION
## Proposed change
Found a new bug that got exposed while I was testing other changes. Attempting to parse an `input_number` state into an int will fail because it returns a float string. I guess the jinja template handled this silently but Python does not.


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
