### PR TITLE
Block when making first workaround service call when clearing usercode

### DIFF
--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -80,10 +80,7 @@ class PinSynchedSensor(BinarySensorEntity, KeymasterTemplateEntity):
             active is not None
             and lock_pin is not None
             and input_pin is not None
-            and (
-                (active and input_pin == lock_pin)
-                or (not active and lock_pin == "")
-            )
+            and ((active and input_pin == lock_pin) or (not active and lock_pin == ""))
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -105,7 +105,9 @@ async def clear_code(hass: HomeAssistant, entity_id: str, code_slot: int) -> Non
         }
 
         try:
-            await hass.services.async_call(OZW_DOMAIN, CLEAR_USERCODE, servicedata)
+            await hass.services.async_call(
+                OZW_DOMAIN, CLEAR_USERCODE, servicedata, blocking=True
+            )
         except Exception as err:
             _LOGGER.error("Error calling ozw.clear_usercode service call: %s", str(err))
 
@@ -138,6 +140,7 @@ async def clear_code(hass: HomeAssistant, entity_id: str, code_slot: int) -> Non
                 LOCK_DOMAIN,
                 SET_USERCODE,
                 {**servicedata, ATTR_USER_CODE: str(random.randint(1000, 9999))},
+                blocking=True,
             )
         except Exception as err:
             _LOGGER.error("Error calling lock.set_usercode service call: %s", str(err))


### PR DESCRIPTION
## Proposed change
We should block when making two service calls in a row on the same code slot because we want a guaranteed order of operations


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
