### PR TITLE
Add zwave workaround to clear code and block on workaround service calls

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -214,7 +214,7 @@ async def test_clear_code(hass, lock_data, sent_messages, caplog):
         await hass.services.async_call(DOMAIN, SERVICE_CLEAR_CODE, servicedata)
         await hass.async_block_till_done()
         assert (
-            "Error calling lock.clear_usercode service call: Unable to find service lock.clear_usercode"
+            "Error calling lock.set_usercode service call: Unable to find service lock.set_usercode"
             in caplog.text
         )
 


### PR DESCRIPTION
## Proposed change
Reintroducing https://github.com/FutureTense/keymaster/pull/47 and https://github.com/FutureTense/keymaster/pull/51.

PR 47 - When we moved from the clear code automation to the keymaster service to clear codes, we lost the `zwave` workaround that set a random pin on a slot in case it couldn't be cleared. This adds it back.

PR 51 - We should block on the first service call when making two service calls in a row on the same code slot because we want a guaranteed order of operations


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
