### PR TITLE
Resubmit fix to generate packages service

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -194,7 +194,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         """Generate the package files."""
         _LOGGER.debug("DEBUG: %s", service)
         name = service.data[ATTR_NAME]
-        generate_package_files(hass, config_entry, name)
+        generate_package_files(hass, name)
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -8,7 +8,6 @@ from openzwavemqtt.const import ATTR_CODE_SLOT, CommandClass
 from homeassistant.components.input_text import MODE_PASSWORD, MODE_TEXT
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.ozw import DOMAIN as OZW_DOMAIN
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
@@ -167,10 +166,19 @@ async def clear_code(hass: HomeAssistant, entity_id: str, code_slot: int) -> Non
         raise ZWaveIntegrationNotConfiguredError
 
 
-def generate_package_files(
-    hass: HomeAssistant, config_entry: ConfigEntry, name: str
-) -> None:
+def generate_package_files(hass: HomeAssistant, name: str) -> None:
     """Generate the package files."""
+    config_entry = next(
+        (
+            hass.config_entries.async_get_entry(entry_id)
+            for entry_id in hass.data[DOMAIN]
+            if hass.data[DOMAIN][entry_id][PRIMARY_LOCK].lock_name == name
+        ),
+        None,
+    )
+    if not config_entry:
+        raise ValueError(f"Couldn't find existing lock entry for {name}")
+
     primary_lock: KeymasterLock = hass.data[DOMAIN][config_entry.entry_id][PRIMARY_LOCK]
     lockname = primary_lock.lock_name
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,7 +1,7 @@
 """ Test keymaster services """
-from unittest import mock
 from unittest.mock import patch
 
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.keymaster import (
@@ -18,7 +18,7 @@ from .common import setup_ozw
 from tests.const import CONFIG_DATA
 
 
-async def test_generate_package_files(hass, caplog):
+async def test_generate_package_files(hass):
     """Test generate_package_files"""
     entry = MockConfigEntry(
         domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=2
@@ -31,10 +31,11 @@ async def test_generate_package_files(hass, caplog):
     servicedata = {
         "lockname": "backdoor",
     }
-    await hass.services.async_call(DOMAIN, SERVICE_GENERATE_PACKAGE, servicedata)
+    with pytest.raises(ValueError):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_GENERATE_PACKAGE, servicedata, blocking=True
+        )
     await hass.async_block_till_done()
-
-    assert "DEBUG conf_lock: frontdoor name: backdoor" in caplog.text
 
     # TODO: Fix os.makedirs mock to produce exception
     # with patch("custom_components.keymaster.services.os", autospec=True) as mock_os:


### PR DESCRIPTION
## Proposed change
The service used to expect the config entry to be passed to it so it knew which lock to act on, but that wouldn't work properly for people with multiple locks. Instead, we need to find the config entry based on the provided name and only move forward if we do.

Bonus points - the service call will now fail in the frontend so the user isn't sitting around waiting for something to happen that isn't going to

Resubmission of https://github.com/FutureTense/keymaster/pull/40

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
