### PR TITLE
Resubmit fix to ZWave logic

### DIFF
--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -13,7 +13,7 @@ from homeassistant.components.input_select import DOMAIN as IN_SELECT_DOMAIN
 from homeassistant.components.input_text import DOMAIN as IN_TXT_DOMAIN
 from homeassistant.components.ozw import DOMAIN as OZW_DOMAIN
 from homeassistant.components.timer import DOMAIN as TIMER_DOMAIN
-from homeassistant.components.zwave.const import DOMAIN as ZWAVE_DOMAIN
+from homeassistant.components.zwave.const import DOMAIN as DATA_ZWAVE_CONFIG
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_STATE, STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.core import HomeAssistant, State
@@ -48,7 +48,7 @@ def using_ozw(hass: HomeAssistant) -> bool:
 
 def using_zwave(hass: HomeAssistant) -> bool:
     """Returns whether the zwave integration is configured."""
-    return ZWAVE_DOMAIN in hass.data
+    return DATA_ZWAVE_CONFIG in hass.data
 
 
 def get_node_id(hass: HomeAssistant, entity_id: str) -> Optional[str]:


### PR DESCRIPTION
## Proposed change
I noticed that hass.data['zwave'] never gets set so the using_zwave check will always return False. I've improved the check to use a key that is definitely set when zwave starts (https://github.com/home-assistant/core/blob/dev/homeassistant/components/zwave/__init__.py#L420). Hopefully this will resolve the linked issue.

Resubmission of https://github.com/FutureTense/keymaster/pull/36


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
