### PR TITLE
Allow alarm level and alarm type entities to be fake

### DIFF
--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -29,6 +29,8 @@ from .const import (
     CONF_SENSOR_NAME,
     CONF_SLOTS,
     CONF_START,
+    DEFAULT_ALARM_LEVEL_SENSOR,
+    DEFAULT_ALARM_TYPE_SENSOR,
     DEFAULT_CODE_SLOTS,
     DEFAULT_DOOR_SENSOR,
     DEFAULT_GENERATE,
@@ -190,22 +192,33 @@ def _get_schema(
                 CONF_SENSOR_NAME,
                 default=_get_default(CONF_SENSOR_NAME, DEFAULT_DOOR_SENSOR),
             ): vol.In(
-                _get_entities(
-                    hass, BINARY_DOMAIN, extra_entities=["binary_sensor.fake"]
-                )
+                _get_entities(hass, BINARY_DOMAIN, extra_entities=[DEFAULT_DOOR_SENSOR])
             ),
             vol.Optional(
                 CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
-                default=_get_default(CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID),
+                default=_get_default(
+                    CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID, DEFAULT_ALARM_LEVEL_SENSOR
+                ),
             ): vol.In(
-                _get_entities(hass, SENSORS_DOMAIN, search=["alarm_level", "user_code"])
+                _get_entities(
+                    hass,
+                    SENSORS_DOMAIN,
+                    search=["alarm_level", "user_code"],
+                    extra_entities=[DEFAULT_ALARM_LEVEL_SENSOR],
+                )
             ),
             vol.Optional(
                 CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
-                default=_get_default(CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID),
+                default=_get_default(
+                    CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
+                    DEFAULT_ALARM_TYPE_SENSOR,
+                ),
             ): vol.In(
                 _get_entities(
-                    hass, SENSORS_DOMAIN, search=["alarm_type", "access_control"]
+                    hass,
+                    SENSORS_DOMAIN,
+                    search=["alarm_type", "access_control"],
+                    extra_entities=[DEFAULT_ALARM_TYPE_SENSOR],
                 )
             ),
             vol.Required(
@@ -284,7 +297,7 @@ async def _start_config_flow(
 
         # Update options if no errors
         if not errors:
-            user_input.pop(CONF_CHILD_LOCKS_FILE)
+            user_input.pop(CONF_CHILD_LOCKS_FILE, None)
             if child_locks:
                 user_input[CONF_CHILD_LOCKS] = child_locks
             return cls.async_create_entry(title=title, data=user_input)

--- a/custom_components/keymaster/const.py
+++ b/custom_components/keymaster/const.py
@@ -55,6 +55,8 @@ DEFAULT_PACKAGES_PATH = "packages/keymaster/"
 DEFAULT_START = 1
 DEFAULT_GENERATE = True
 DEFAULT_DOOR_SENSOR = "binary_sensor.fake"
+DEFAULT_ALARM_LEVEL_SENSOR = "sensor.fake"
+DEFAULT_ALARM_TYPE_SENSOR = "sensor.fake"
 DEFAULT_HIDE_PINS = False
 
 # Action maps


### PR DESCRIPTION
## Proposed change
The alarm level/user code and alarm type/access control entities are used to detect how a door was unlocked or locked for notification purposes. This is not needed if a user simply wants to use keymaster to manage their lock PINs. This is also currently not supported for `zwave_js`, so this change would allow us to move forward with supporting `zwave_js` ahead of getting that support


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
