### PR TITLE
Some fixes

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -244,7 +244,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(
             hass.bus.async_listen(ZWAVE_JS_EVENT, zwave_js_event_listener)
         )
-    elif hass.state == CoreState.running:
+
+    if hass.state == CoreState.running:
         hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(
             async_track_state_change(
                 hass, primary_lock.lock_entity_id, entity_state_listener
@@ -378,13 +379,13 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
         handle_zwave_js_event(hass, config_entry, evt)
 
     # Create new listeners for lock state changes
-    if not using_zwave_js(hass):
-        hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(
-            async_track_state_change(
-                hass, primary_lock.lock_entity_id, entity_state_listener
-            )
+    hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(
+        async_track_state_change(
+            hass, primary_lock.lock_entity_id, entity_state_listener
         )
-    else:
+    )
+
+    if using_zwave_js(hass):
         hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(
             hass.bus.async_listen(ZWAVE_JS_EVENT, zwave_js_event_listener)
         )

--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -39,7 +39,6 @@ from .const import (
     DEFAULT_START,
     DOMAIN,
 )
-from .helpers import using_zwave_js
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -180,44 +179,6 @@ def _get_schema(
         """Gets default value for key."""
         return user_input.get(key, default_dict.get(key, fallback_default))
 
-    # Z-Wave JS uses events instead of sensors when the door is locked or unlocked
-    if using_zwave_js:
-        return vol.Schema(
-            {
-                vol.Required(
-                    CONF_LOCK_ENTITY_ID, default=_get_default(CONF_LOCK_ENTITY_ID)
-                ): vol.In(_get_entities(hass, LOCK_DOMAIN)),
-                vol.Required(
-                    CONF_SLOTS, default=_get_default(CONF_SLOTS, DEFAULT_CODE_SLOTS)
-                ): vol.All(vol.Coerce(int), vol.Range(min=1)),
-                vol.Required(
-                    CONF_START, default=_get_default(CONF_START, DEFAULT_START)
-                ): vol.All(vol.Coerce(int), vol.Range(min=1)),
-                vol.Required(CONF_LOCK_NAME, default=_get_default(CONF_LOCK_NAME)): str,
-                vol.Optional(
-                    CONF_SENSOR_NAME,
-                    default=_get_default(CONF_SENSOR_NAME, DEFAULT_DOOR_SENSOR),
-                ): vol.In(
-                    _get_entities(
-                        hass, BINARY_DOMAIN, extra_entities=[DEFAULT_DOOR_SENSOR]
-                    )
-                ),
-                vol.Required(
-                    CONF_PATH, default=_get_default(CONF_PATH, DEFAULT_PACKAGES_PATH)
-                ): str,
-                vol.Required(
-                    CONF_HIDE_PINS,
-                    default=_get_default(CONF_HIDE_PINS, DEFAULT_HIDE_PINS),
-                ): bool,
-                vol.Optional(
-                    CONF_CHILD_LOCKS_FILE,
-                    default=_get_default(CONF_CHILD_LOCKS_FILE, ""),
-                ): str,
-            },
-            extra=ALLOW_EXTRA,
-        )
-
-    # `zwave` and `ozw` use sensors when the door is locked or unlocked
     return vol.Schema(
         {
             vol.Required(
@@ -245,7 +206,7 @@ def _get_schema(
                 _get_entities(
                     hass,
                     SENSORS_DOMAIN,
-                    search=["alarm_level", "user_code"],
+                    search=["alarm_level", "user_code", "alarmlevel"],
                     extra_entities=[DEFAULT_ALARM_LEVEL_SENSOR],
                 )
             ),
@@ -259,7 +220,7 @@ def _get_schema(
                 _get_entities(
                     hass,
                     SENSORS_DOMAIN,
-                    search=["alarm_type", "access_control"],
+                    search=["alarm_type", "access_control", "alarmtype"],
                     extra_entities=[DEFAULT_ALARM_TYPE_SENSOR],
                 )
             ),

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -163,7 +163,7 @@ automation:
         entity_id: "input_boolean.allow_automation_execution"
         state: "on"
       - condition: template
-        value_template: "{{ trigger.event.data.code_slot != None and trigger.event.data.code_slot > 0 }}"
+        value_template: "{{ trigger.event.data.code_slot > 0 }}"
       - condition: template
         value_template: "{{ is_state('input_boolean.notify_LOCKNAME_' + trigger.event.data.code_slot | string, 'on') }}"
     action:
@@ -260,7 +260,7 @@ automation:
         value_template: "{{ is_state('input_boolean.accesslimit_LOCKNAME_' + trigger.event.data.code_slot | string, 'on') }}"
       - condition: template
         # Check for Keypad Unlock code
-        value_template: "{{ trigger.event.data.code_slot != None and trigger.event.data.code_slot > 0 and trigger.event.data.action_code in (6, 19)}}"
+        value_template: "{{ trigger.event.data.code_slot > 0 and trigger.event.data.action_code in (6, 19)}}"
     action:
       - service: input_number.decrement
         data_template:

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -163,7 +163,7 @@ automation:
         entity_id: "input_boolean.allow_automation_execution"
         state: "on"
       - condition: template
-        value_template: "{{ trigger.event.data.code_slot > 0 }}"
+        value_template: "{{ trigger.event.data.code_slot != None and trigger.event.data.code_slot > 0 }}"
       - condition: template
         value_template: "{{ is_state('input_boolean.notify_LOCKNAME_' + trigger.event.data.code_slot | string, 'on') }}"
     action:
@@ -260,7 +260,7 @@ automation:
         value_template: "{{ is_state('input_boolean.accesslimit_LOCKNAME_' + trigger.event.data.code_slot | string, 'on') }}"
       - condition: template
         # Check for Keypad Unlock code
-        value_template: "{{ trigger.event.data.code_slot > 0 and trigger.event.data.action_code in (6, 19)}}"
+        value_template: "{{ trigger.event.data.code_slot != None and trigger.event.data.code_slot > 0 and trigger.event.data.action_code in (6, 19)}}"
     action:
       - service: input_number.decrement
         data_template:

--- a/custom_components/keymaster/strings.json
+++ b/custom_components/keymaster/strings.json
@@ -19,7 +19,7 @@
           "child_locks_file": "Path to child locks file",
           "hide_pins": "Hide PINs in UI?"
         },
-        "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)",
+        "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)\n\nIf you are using Z-Wave JS you may or may not have alarm level and alarm type entities. If you do, select them on this form, otherwise you can use the `sensor.fake` values as placeholders.",
         "title": "KeyMaster"
       },
       "config_2": {
@@ -51,7 +51,7 @@
           "child_locks_file": "Path to child locks file",
           "hide_pins": "Hide PINs in UI?"
         },
-        "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)",
+        "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)\n\nIf you are using Z-Wave JS you may or may not have alarm level and alarm type entities. If you do, select them on this form, otherwise you can use the `sensor.fake` values as placeholders.",
         "title": "KeyMaster"
       },
       "options_2": {

--- a/custom_components/keymaster/translations/en.json
+++ b/custom_components/keymaster/translations/en.json
@@ -19,7 +19,7 @@
           "child_locks_file": "Path to child locks file",
           "hide_pins": "Hide PINs in UI?"
         },
-        "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)",
+        "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)\n\nIf you are using Z-Wave JS you may or may not have alarm level and alarm type entities. If you do, select them on this form, otherwise you can use the `sensor.fake` values as placeholders.",
         "title": "KeyMaster"
       },
       "config_2": {
@@ -51,7 +51,7 @@
           "child_locks_file": "Path to child locks file",
           "hide_pins": "Hide PINs in UI?"
         },
-        "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)",
+        "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)\n\nIf you are using Z-Wave JS you may or may not have alarm level and alarm type entities. If you do, select them on this form, otherwise you can use the `sensor.fake` values as placeholders.",
         "title": "KeyMaster"
       },
       "options_2": {


### PR DESCRIPTION
## Proposed change
Turns out that `zwave_js` still uses alarm type and alarm level sensors for certain locks. Their name is slightly different, it contains alarmlevel instead of alarm_level and alarmtype instead of alarm_type. This change allows `zwave_js` users with those sensors to still use the integration to get notifications.

I also fixed some logic that was causing notifications automations to fail.


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
