### PR TITLE
Fix state and event listeners and support child locks for lock state notifications

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -13,13 +13,7 @@ from homeassistant.components.ozw import DOMAIN as OZW_DOMAIN
 from homeassistant.components.persistent_notification import async_create, async_dismiss
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STARTED
-from homeassistant.core import (
-    Config,
-    CoreState,
-    Event,
-    HomeAssistant,
-    ServiceCall,
-)
+from homeassistant.core import Config, CoreState, Event, HomeAssistant, ServiceCall
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -385,8 +385,9 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
             )
         )
 
-    # Check if we need to check alarm type/alarm level sensors, in which case
-    # we need to listen for lock state changes
+    # Check if alarm type/alarm level sensors are specified, in which case
+    # we need to listen for lock state changes and derive the action from those
+    # sensors
     locks_to_watch = []
     for lock in [primary_lock, *child_locks]:
         if (

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -12,7 +12,12 @@ import voluptuous as vol
 from homeassistant.components.ozw import DOMAIN as OZW_DOMAIN
 from homeassistant.components.persistent_notification import async_create, async_dismiss
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_STARTED,
+    STATE_LOCKED,
+    STATE_UNLOCKED,
+)
 from homeassistant.core import Config, CoreState, Event, HomeAssistant, ServiceCall
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -99,6 +104,8 @@ async def homeassistant_started_listener(
             hass,
             [lock.lock_entity_id for lock in locks_to_watch],
             functools.partial(handle_state_change, hass, config_entry),
+            from_state=[STATE_LOCKED, STATE_UNLOCKED],
+            to_state=[STATE_LOCKED, STATE_UNLOCKED],
         )
     )
 
@@ -407,6 +414,8 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
                 hass,
                 [lock.lock_entity_id for lock in locks_to_watch],
                 functools.partial(handle_state_change, hass, config_entry),
+                from_state=[STATE_LOCKED, STATE_UNLOCKED],
+                to_state=[STATE_LOCKED, STATE_UNLOCKED],
             )
         )
 

--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -45,11 +45,11 @@ _LOGGER = logging.getLogger(__name__)
 CHILD_LOCKS_SCHEMA = cv.schema_with_slug_keys(
     {
         vol.Required(CONF_LOCK_ENTITY_ID): cv.entity_id,
-        vol.Optional(CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID, default=None): vol.Any(
-            None, cv.entity_id
-        ),
         vol.Optional(
-            CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID, default=None
+            CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID, default="sensor.fake"
+        ): vol.Any(None, cv.entity_id),
+        vol.Optional(
+            CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID, default="sensor.fake"
         ): vol.Any(None, cv.entity_id),
     }
 )

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -40,9 +40,9 @@ from .const import (
     ATTR_ACTION_TEXT,
     ATTR_CODE_SLOT_NAME,
     ATTR_NAME,
+    CHILD_LOCKS,
     CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
     CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
-    CONF_CHILD_LOCKS,
     CONF_LOCK_ENTITY_ID,
     CONF_LOCK_NAME,
     CONF_PATH,
@@ -133,7 +133,7 @@ async def generate_keymaster_locks(
             lock.get(CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID),
             lock.get(CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID),
         )
-        for lock_name, lock in config_entry.data.get(CONF_CHILD_LOCKS, {}).items()
+        for lock_name, lock in config_entry.data.get(CHILD_LOCKS, {}).items()
     ]
 
     # If we are using zwave_js, we need to grab the node and device entry for the
@@ -229,44 +229,52 @@ def delete_folder(absolute_path: str, *relative_paths: str) -> None:
         os.rmdir(path)
 
 
-def handle_zwave_js_event(hass, config_entry: ConfigEntry, evt: Event):
+def handle_zwave_js_event(hass: HomeAssistant, config_entry: ConfigEntry, evt: Event):
     """Handle Z-Wave JS event."""
     primary_lock: KeymasterLock = hass.data[DOMAIN][config_entry.entry_id][PRIMARY_LOCK]
+    child_locks: List[KeymasterLock] = hass.data[DOMAIN][config_entry.entry_id][
+        CHILD_LOCKS
+    ]
 
     # If event doesn't match the type or our device and node, we shouldn't fire an event
-    if (
-        evt.data[ATTR_TYPE] != "notification"
-        or evt.data[ATTR_NODE_ID] != primary_lock.zwave_js_lock_node.node_id
-        or evt.data[ATTR_DEVICE_ID] != primary_lock.zwave_js_lock_device.id
-    ):
+    if evt.data[ATTR_TYPE] != "notification":
         return
 
-    # Get lock state to provide as part of event data
-    lock_state = hass.states.get(primary_lock.lock_entity_id)
+    for lock in [primary_lock, *child_locks]:
+        if (
+            not lock.zwave_js_lock_node
+            or not lock.zwave_js_lock_device
+            or evt.data[ATTR_NODE_ID] != lock.zwave_js_lock_node.node_id
+            or evt.data[ATTR_DEVICE_ID] != lock.zwave_js_lock_device.id
+        ):
+            continue
 
-    params = evt.data.get(ATTR_PARAMETERS) or {}
-    code_slot = params.get("userId", 0)
+        # Get lock state to provide as part of event data
+        lock_state = hass.states.get(lock.lock_entity_id)
 
-    # Lookup name for usercode
-    code_slot_name_state = (
-        hass.states.get(f"input_text.{primary_lock.lock_name}_name_{code_slot}")
-        if code_slot and code_slot != 0
-        else None
-    )
+        params = evt.data.get(ATTR_PARAMETERS) or {}
+        code_slot = params.get("userId", 0)
 
-    hass.bus.fire(
-        EVENT_KEYMASTER_LOCK_STATE_CHANGED,
-        event_data={
-            ATTR_NAME: primary_lock.lock_name,
-            ATTR_ENTITY_ID: primary_lock.lock_entity_id,
-            ATTR_STATE: lock_state.state if lock_state else None,
-            ATTR_ACTION_TEXT: evt.data.get(ATTR_LABEL),
-            ATTR_CODE_SLOT: code_slot,
-            ATTR_CODE_SLOT_NAME: code_slot_name_state.state
-            if code_slot_name_state is not None
-            else None,
-        },
-    )
+        # Lookup name for usercode
+        code_slot_name_state = (
+            hass.states.get(f"input_text.{lock.lock_name}_name_{code_slot}")
+            if code_slot and code_slot != 0
+            else None
+        )
+
+        hass.bus.fire(
+            EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+            event_data={
+                ATTR_NAME: lock.lock_name,
+                ATTR_ENTITY_ID: lock.lock_entity_id,
+                ATTR_STATE: lock_state.state if lock_state else None,
+                ATTR_ACTION_TEXT: evt.data.get(ATTR_LABEL),
+                ATTR_CODE_SLOT: code_slot,
+                ATTR_CODE_SLOT_NAME: code_slot_name_state.state
+                if code_slot_name_state is not None
+                else None,
+            },
+        )
 
 
 def handle_state_change(
@@ -278,80 +286,87 @@ def handle_state_change(
 ) -> None:
     """Listener to track state changes to lock entities."""
     primary_lock: KeymasterLock = hass.data[DOMAIN][config_entry.entry_id][PRIMARY_LOCK]
+    child_locks: List[KeymasterLock] = hass.data[DOMAIN][config_entry.entry_id][
+        CHILD_LOCKS
+    ]
 
     # If listener was called for entity that is not for this entry,
     # or lock state is coming from or going to a weird state, ignore
     if (
-        changed_entity != primary_lock.lock_entity_id
-        or new_state is None
+        new_state is None
         or new_state.state not in (STATE_LOCKED, STATE_UNLOCKED)
         or old_state.state not in (STATE_LOCKED, STATE_UNLOCKED)
     ):
         return
 
-    # Determine action type to set appropriate action text using ACTION_MAP
-    action_type = ""
-    if (
-        ALARM_TYPE in primary_lock.alarm_type_or_access_control_entity_id
-        or ALARM_TYPE.replace("_", "")
-        in primary_lock.alarm_type_or_access_control_entity_id
-    ):
-        action_type = ALARM_TYPE
-    if ACCESS_CONTROL in primary_lock.alarm_type_or_access_control_entity_id:
-        action_type = ACCESS_CONTROL
+    for lock in [primary_lock, *child_locks]:
+        if changed_entity != lock.lock_entity_id:
+            continue
 
-    # Get alarm_level/usercode and alarm_type/access_control  states
-    alarm_level_state = hass.states.get(primary_lock.alarm_level_or_user_code_entity_id)
-    alarm_level_value = int(alarm_level_state.state) if alarm_level_state else None
+        # Determine action type to set appropriate action text using ACTION_MAP
+        action_type = ""
+        if lock.alarm_type_or_access_control_entity_id and (
+            ALARM_TYPE in lock.alarm_type_or_access_control_entity_id
+            or ALARM_TYPE.replace("_", "")
+            in lock.alarm_type_or_access_control_entity_id
+        ):
+            action_type = ALARM_TYPE
+        if (
+            lock.alarm_type_or_access_control_entity_id
+            and ACCESS_CONTROL in lock.alarm_type_or_access_control_entity_id
+        ):
+            action_type = ACCESS_CONTROL
 
-    alarm_type_state = hass.states.get(
-        primary_lock.alarm_type_or_access_control_entity_id
-    )
-    alarm_type_value = int(alarm_type_state.state) if alarm_type_state else None
+        # Get alarm_level/usercode and alarm_type/access_control  states
+        alarm_level_state = hass.states.get(lock.alarm_level_or_user_code_entity_id)
+        alarm_level_value = int(alarm_level_state.state) if alarm_level_state else None
 
-    # If lock has changed state but alarm_type/access_control state hasn't changed in a
-    # while set action_value to RF lock/unlock
-    if (
-        alarm_level_state is not None
-        and int(alarm_level_state.state) == 0
-        and dt_util.utcnow() - dt_util.as_utc(alarm_type_state.last_changed)
-        > timedelta(seconds=5)
-        and action_type in LOCK_STATE_MAP
-    ):
-        alarm_type_value = LOCK_STATE_MAP[action_type][new_state.state]
+        alarm_type_state = hass.states.get(lock.alarm_type_or_access_control_entity_id)
+        alarm_type_value = int(alarm_type_state.state) if alarm_type_state else None
 
-    # Lookup action text based on alarm type value
-    action_text = (
-        ACTION_MAP.get(action_type, {}).get(
-            alarm_type_value, "Unknown Alarm Type Value"
+        # If lock has changed state but alarm_type/access_control state hasn't changed in a
+        # while set action_value to RF lock/unlock
+        if (
+            alarm_level_state is not None
+            and int(alarm_level_state.state) == 0
+            and dt_util.utcnow() - dt_util.as_utc(alarm_type_state.last_changed)
+            > timedelta(seconds=5)
+            and action_type in LOCK_STATE_MAP
+        ):
+            alarm_type_value = LOCK_STATE_MAP[action_type][new_state.state]
+
+        # Lookup action text based on alarm type value
+        action_text = (
+            ACTION_MAP.get(action_type, {}).get(
+                alarm_type_value, "Unknown Alarm Type Value"
+            )
+            if alarm_type_value is not None
+            else None
         )
-        if alarm_type_value is not None
-        else None
-    )
 
-    # Lookup name for usercode
-    code_slot_name_state = hass.states.get(
-        f"input_text.{primary_lock.lock_name}_name_{alarm_level_value}"
-    )
+        # Lookup name for usercode
+        code_slot_name_state = hass.states.get(
+            f"input_text.{lock.lock_name}_name_{alarm_level_value}"
+        )
 
-    # Get lock state to provide as part of event data
-    lock_state = hass.states.get(primary_lock.lock_entity_id)
+        # Get lock state to provide as part of event data
+        lock_state = hass.states.get(lock.lock_entity_id)
 
-    # Fire state change event
-    hass.bus.fire(
-        EVENT_KEYMASTER_LOCK_STATE_CHANGED,
-        event_data={
-            ATTR_NAME: primary_lock.lock_name,
-            ATTR_ENTITY_ID: primary_lock.lock_entity_id,
-            ATTR_STATE: lock_state.state if lock_state else None,
-            ATTR_ACTION_CODE: alarm_type_value,
-            ATTR_ACTION_TEXT: action_text,
-            ATTR_CODE_SLOT: alarm_level_value,
-            ATTR_CODE_SLOT_NAME: code_slot_name_state.state
-            if code_slot_name_state is not None
-            else None,
-        },
-    )
+        # Fire state change event
+        hass.bus.fire(
+            EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+            event_data={
+                ATTR_NAME: lock.lock_name,
+                ATTR_ENTITY_ID: lock.lock_entity_id,
+                ATTR_STATE: lock_state.state if lock_state else None,
+                ATTR_ACTION_CODE: alarm_type_value,
+                ATTR_ACTION_TEXT: action_text,
+                ATTR_CODE_SLOT: alarm_level_value,
+                ATTR_CODE_SLOT_NAME: code_slot_name_state.state
+                if code_slot_name_state is not None
+                else None,
+            },
+        )
 
 
 def reload_package_platforms(hass: HomeAssistant) -> bool:

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -236,11 +236,13 @@ def handle_zwave_js_event(hass: HomeAssistant, config_entry: ConfigEntry, evt: E
         CHILD_LOCKS
     ]
 
-    # If event doesn't match the type or our device and node, we shouldn't fire an event
+    # If event doesn't match the right type, we shouldn't fire an event
     if evt.data[ATTR_TYPE] != "notification":
         return
 
     for lock in [primary_lock, *child_locks]:
+        # Try to find the lock that we are getting an event for, skipping
+        # ones that don't match
         if (
             not lock.zwave_js_lock_node
             or not lock.zwave_js_lock_device

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -296,6 +296,7 @@ def handle_state_change(
     # or lock state is coming from or going to a weird state, ignore
     if (
         new_state is None
+        or old_state is None
         or new_state.state not in (STATE_LOCKED, STATE_UNLOCKED)
         or old_state.state not in (STATE_LOCKED, STATE_UNLOCKED)
     ):

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -80,7 +80,7 @@ async def refresh_codes(
     node_id = get_node_id(hass, entity_id)
     if node_id is None:
         _LOGGER.error(
-            "Problem retrieving node_id from entity %s because the entity doesn't exist.",
+            "Problem retrieving node_id from entity %s",
             entity_id,
         )
         return
@@ -123,7 +123,7 @@ async def add_code(
         node_id = get_node_id(hass, entity_id)
         if node_id is None:
             _LOGGER.error(
-                "Problem retrieving node_id from entity %s because the entity doesn't exist.",
+                "Problem retrieving node_id from entity %s",
                 entity_id,
             )
             return
@@ -161,7 +161,7 @@ async def clear_code(hass: HomeAssistant, entity_id: str, code_slot: int) -> Non
         node_id = get_node_id(hass, entity_id)
         if node_id is None:
             _LOGGER.error(
-                "Problem retrieving node_id from entity %s because the entity doesn't exist.",
+                "Problem retrieving node_id from entity %s",
                 entity_id,
             )
             return
@@ -172,7 +172,8 @@ async def clear_code(hass: HomeAssistant, entity_id: str, code_slot: int) -> Non
         }
 
         _LOGGER.debug(
-            "Setting code slot value to random PIN as workaround in case clearing code doesn't work"
+            "Setting code slot value to random PIN as workaround in case clearing code "
+            "doesn't work"
         )
         await call_service(
             hass,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py37", "py38"]
+target-version = ["py38"]
 exclude = 'generated'
 
 [tool.isort]

--- a/tests/common.py
+++ b/tests/common.py
@@ -49,17 +49,21 @@ async def setup_ozw(hass, entry=None, fixture=None):
     receive_message = mock_subscribe.mock_calls[0][1][2]
 
     if fixture is not None:
-        for line in fixture.split("\n"):
-            line = line.strip()
-            if not line:
-                continue
-            topic, payload = line.split(",", 1)
-            receive_message(mock.Mock(topic=topic, payload=payload))
+        await process_fixture_data(hass, receive_message, fixture)
 
-        await hass.async_block_till_done()
+    return receive_message, entry
 
-    return receive_message
 
+async def process_fixture_data(hass, receive_message, fixture):
+    """Mock receive fixture data."""
+    for line in fixture.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        topic, payload = line.split(",", 1)
+        receive_message(mock.Mock(topic=topic, payload=payload))
+
+    await hass.async_block_till_done()
 
 class MQTTMessage:
     """Represent a mock MQTT message."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -65,6 +65,7 @@ async def process_fixture_data(hass, receive_message, fixture):
 
     await hass.async_block_till_done()
 
+
 class MQTTMessage:
     """Represent a mock MQTT message."""
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -69,7 +69,7 @@ async def test_refresh_codes(hass, lock_data, caplog):
     await hass.async_block_till_done()
 
     assert (
-        "Problem retrieving node_id from entity lock.kwikset_touchpad_electronic_deadbolt_frontdoor because the entity doesn't exist."
+        "Problem retrieving node_id from entity lock.kwikset_touchpad_electronic_deadbolt_frontdoor"
         in caplog.text
     )
 
@@ -114,7 +114,7 @@ async def test_add_code(hass, lock_data, sent_messages, caplog):
         await hass.services.async_call(DOMAIN, SERVICE_ADD_CODE, servicedata)
         await hass.async_block_till_done()
         assert (
-            "Problem retrieving node_id from entity lock.kwikset_touchpad_electronic_deadbolt_frontdoor because the entity doesn't exist."
+            "Problem retrieving node_id from entity lock.kwikset_touchpad_electronic_deadbolt_frontdoor"
             in caplog.text
         )
 
@@ -200,7 +200,7 @@ async def test_clear_code(hass, lock_data, sent_messages, caplog):
         await hass.services.async_call(DOMAIN, SERVICE_CLEAR_CODE, servicedata)
         await hass.async_block_till_done()
         assert (
-            "Problem retrieving node_id from entity lock.kwikset_touchpad_electronic_deadbolt_frontdoor because the entity doesn't exist."
+            "Problem retrieving node_id from entity lock.kwikset_touchpad_electronic_deadbolt_frontdoor"
             in caplog.text
         )
 


### PR DESCRIPTION
## Proposed change
- BUGFIX: state and event listeners may not have worked properly when users were managing multiple locks with keymaster. This should be resolved now that we are using `functools.partial`
- BUGFIX: If a user is using `zwave_js`, they may not have alarm type and alarm level sensors. Right now, if lock state changes come in via an event for `zwave_js`, we end up firing two keymaster events, one with complete information and one with partial information. This fixes that
- ENHANCEMENT: We now watch child locks for state changes and fire an event for them. There aren't notifications in place for them but this makes it possible for users to add notifications for child locks if they would like.


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
