### PR TITLE
Fix code slot count when generating code slot files, sensors, etc

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -374,12 +374,13 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
             config_entry.data[CONF_LOCK_NAME],
         )
 
-    old_slots = list(
-        range(config_entry.data[CONF_START], config_entry.data[CONF_SLOTS] + 1)
-    )
-    new_slots = list(
-        range(config_entry.options[CONF_START], config_entry.options[CONF_SLOTS] + 1)
-    )
+    start_from = config_entry.data[CONF_START]
+    code_slots = config_entry.data[CONF_SLOTS]
+    old_slots = list(range(start_from, start_from + code_slots))
+
+    start_from = config_entry.options[CONF_START]
+    code_slots = config_entry.options[CONF_SLOTS]
+    new_slots = list(range(start_from, start_from + code_slots))
 
     new_data = config_entry.options.copy()
     new_data.pop(CONF_GENERATE, None)

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -366,7 +366,7 @@ def handle_state_change(
 
 
 def reset_code_slot_if_pin_unknown(
-    hass, lock_name: str, num_code_slots: int, start_from_code_slot: int
+    hass, lock_name: str, code_slots: int, start_from: int
 ) -> None:
     """
     Reset a code slot if the PIN is unknown.
@@ -375,15 +375,13 @@ def reset_code_slot_if_pin_unknown(
     an initial state.
     """
     return asyncio.run_coroutine_threadsafe(
-        async_reset_code_slot_if_pin_unknown(
-            hass, lock_name, num_code_slots, start_from_code_slot
-        ),
+        async_reset_code_slot_if_pin_unknown(hass, lock_name, code_slots, start_from),
         hass.loop,
     ).result()
 
 
 async def async_reset_code_slot_if_pin_unknown(
-    hass, lock_name: str, num_code_slots: int, start_from_code_slot: int
+    hass, lock_name: str, code_slots: int, start_from: int
 ) -> None:
     """
     Reset a code slot if the PIN is unknown.
@@ -391,7 +389,7 @@ async def async_reset_code_slot_if_pin_unknown(
     Used when a code slot is first generated so we can give all input helpers
     an initial state.
     """
-    for x in range(start_from_code_slot, num_code_slots + 1):
+    for x in range(start_from, start_from + code_slots):
         pin_state = hass.states.get(f"input_text.{lock_name}_pin_{x}")
         if pin_state and pin_state.state == STATE_UNKNOWN:
             await hass.services.async_call(

--- a/custom_components/keymaster/sensor.py
+++ b/custom_components/keymaster/sensor.py
@@ -6,8 +6,8 @@ from typing import List
 from openzwavemqtt.const import ATTR_CODE_SLOT
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers import entity_platform
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_registry import EntityRegistry, async_get_registry
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify

--- a/custom_components/keymaster/sensor.py
+++ b/custom_components/keymaster/sensor.py
@@ -20,10 +20,12 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     """Setup config entry."""
     # Add entities for all defined slots
+    start_from = entry.data[CONF_START]
+    code_slots = entry.data[CONF_SLOTS]
     async_add_entities(
         [
             CodesSensor(hass, entry, x)
-            for x in range(entry.data[CONF_START], entry.data[CONF_SLOTS] + 1)
+            for x in range(start_from, start_from + code_slots)
         ],
         True,
     )

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -261,15 +261,18 @@ def generate_package_files(hass: HomeAssistant, name: str) -> None:
     start_from = config_entry.data[CONF_START]
 
     activelockheaders = ",".join(
-        [f"{activelockheader}_{x}" for x in range(start_from, code_slots + 1)]
+        [f"{activelockheader}_{x}" for x in range(start_from, start_from + code_slots)]
     )
     inputlockpinheaders = ",".join(
-        [f"{inputlockpinheader}_{x}" for x in range(start_from, code_slots + 1)]
+        [
+            f"{inputlockpinheader}_{x}"
+            for x in range(start_from, start_from + code_slots)
+        ]
     )
     input_reset_code_slot_headers = ",".join(
         [
             f"{input_reset_code_slot_header}_{x}"
-            for x in range(start_from, code_slots + 1)
+            for x in range(start_from, start_from + code_slots)
         ]
     )
 
@@ -298,7 +301,7 @@ def generate_package_files(hass: HomeAssistant, name: str) -> None:
 
     _LOGGER.debug("Creating per slot YAML and lovelace cards...")
     # Replace variables in code slot files
-    for x in range(start_from, code_slots + 1):
+    for x in range(start_from, start_from + code_slots):
         replacements["TEMPLATENUM"] = str(x)
 
         for in_f, out_f, write_mode in (


### PR DESCRIPTION
## Breaking change
This change will result in more code slots if starts from > 1, but the previous behavior was incorrect.

## Proposed change
Our existing slots went from the start from slot to the slot count. So, if we started from 3 and the count was 6, we would create slots 3, 4, 5, and 6. What we want is to create 3, 4, 5, 6, 7, and 8. This PR fixes that to match the desired logic

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
