### PR TITLE
Fix network ready duplicate sensor issue

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -538,7 +538,12 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
             )
         try:
             network_ready = self.hass.states.get(self.network_ready_entity)
-            if not network_ready or network_ready.state != STATE_ON:
+            if not network_ready:
+                # We may need to get a new entity ID
+                self.network_ready_entity = None
+                raise ZWaveNetworkNotReady
+
+            if network_ready.state != STATE_ON:
                 raise ZWaveNetworkNotReady
 
             return await self.hass.async_add_executor_job(self.update_usercodes)

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity_registry import (
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .binary_sensor import ENTITY_ID as generate_network_ready_unique_id
+from .binary_sensor import generate_network_ready_unique_id
 from .const import (
     ATTR_CODE_SLOT,
     ATTR_NAME,
@@ -532,7 +532,9 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
         """Async wrapper to update usercodes."""
         if not self.network_ready_entity:
             self.network_ready_entity = self.ent_reg.async_get_entity_id(
-                generate_network_ready_unique_id(self._primary_lock.lock_name)
+                "binary_sensor",
+                DOMAIN,
+                generate_network_ready_unique_id(self._primary_lock.lock_name),
             )
         try:
             network_ready = self.hass.states.get(self.network_ready_entity)

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -491,6 +491,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
             config_entry.entry_id
         ][CHILD_LOCKS]
         self.ent_reg = ent_reg
+        self.network_ready_entity = None
         super().__init__(
             hass,
             _LOGGER,
@@ -499,7 +500,6 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
             update_method=self.async_update_usercodes,
         )
         self.data = {}
-        self.network_ready_entity = None
 
     def _invalid_code(self, code_slot):
         """Return the PIN slot value as we are unable to read the slot value

--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -57,12 +57,12 @@ except (ModuleNotFoundError, ImportError):
     pass
 
 _LOGGER = logging.getLogger(__name__)
-ENTITY_NAME = "Z-Wave Network Ready"
+ENTITY_NAME = "Network"
 
 
-def generate_network_ready_unique_id(lock_name: str) -> str:
+def generate_binary_sensor_name(lock_name: str) -> str:
     """Generate unique ID for network ready sensor."""
-    return slugify(f"{lock_name}: {ENTITY_NAME}")
+    return f"{lock_name}: {ENTITY_NAME}"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -97,6 +97,8 @@ class BaseNetworkReadySensor(BinarySensorEntity):
         self.child_locks = child_locks
         self.integration_name = integration_name
         self._is_on = False
+        self._name = generate_binary_sensor_name(self.primary_lock.lock_name)
+        self._unique_id = slugify(self._name)
 
     @callback
     def async_set_is_on_property(
@@ -119,12 +121,12 @@ class BaseNetworkReadySensor(BinarySensorEntity):
     @property
     def name(self) -> str:
         """Return name of entity."""
-        return f"{self.primary_lock.lock_name}: {ENTITY_NAME}"
+        return self._name
 
     @property
     def unique_id(self) -> str:
         """Return unique ID of entity."""
-        return generate_network_ready_unique_id(self.primary_lock.lock_name)
+        return self._unique_id
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -5,7 +5,6 @@ from typing import List
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,
-    ENTITY_ID_FORMAT,
     BinarySensorEntity,
 )
 from homeassistant.components.mqtt import async_subscribe, models
@@ -58,16 +57,16 @@ except (ModuleNotFoundError, ImportError):
     pass
 
 _LOGGER = logging.getLogger(__name__)
-ENTITY_NAME = "Keymaster: ZWave Network Ready"
-ENTITY_ID = ENTITY_ID_FORMAT.format(slugify(ENTITY_NAME))
+ENTITY_NAME = "Z-Wave Network Ready"
+
+
+def generate_network_ready_unique_id(lock_name: str) -> str:
+    """Generate unique ID for network ready sensor."""
+    return slugify(f"{lock_name}: {ENTITY_NAME}")
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Setup config entry."""
-
-    if hass.states.get(ENTITY_ID):
-        return True
-
     primary_lock = hass.data[DOMAIN][config_entry.entry_id][PRIMARY_LOCK]
     child_locks = hass.data[DOMAIN][config_entry.entry_id][CHILD_LOCKS]
     if using_zwave_js(hass):
@@ -120,12 +119,12 @@ class BaseNetworkReadySensor(BinarySensorEntity):
     @property
     def name(self) -> str:
         """Return name of entity."""
-        return ENTITY_NAME
+        return f"{self.primary_lock.lock_name}: {ENTITY_NAME}"
 
     @property
     def unique_id(self) -> str:
         """Return unique ID of entity."""
-        return slugify(self.name)
+        return generate_network_ready_unique_id(self.primary_lock.lock_name)
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/keymaster/services.yaml
+++ b/custom_components/keymaster/services.yaml
@@ -15,8 +15,8 @@ add_code:
   description: Supports ozw, zwave, and zwave_js locks.
   fields:
     entity_id:
-      name: Entity ID
-      description: Lock entity to add a code to
+      name: Lock
+      description: Lock to add a code to
       required: true
       selector:
         entity:
@@ -41,8 +41,8 @@ clear_code:
   description: Supports ozw, zwave, and zwave_js locks.
   fields:
     entity_id:
-      name: Entity ID
-      description: Lock entity to clear a code from
+      name: Lock
+      description: Lock to clear a code from
       required: true
       selector:
         entity:
@@ -59,8 +59,8 @@ refresh_codes:
   description: Experimental. Only supports ozw locks for now, and may not be fully functional.
   fields:
     entity_id:
-      name: Entity ID
-      description: Lock entity to refresh codes on
+      name: Lock
+      description: Lock to refresh codes on
       required: true
       selector:
         entity:


### PR DESCRIPTION
## Breaking change
We changed the unique ID for the network ready entity which means you may end up with a dangling entity. The extra entity can be manually deleted via the Configuration > Entities list


## Proposed change
We were getting a unique ID error when a user had multiple locks. The guard that we added did not work, and I'm guessing it was a timing issue (the second lock started creating the second entity before the first was finished). Instead, we will create a network ready sensor for each lock. This will pave the way to supporting mixed lock usage (e.g. a Zigbee lock and a Z-Wave lock).

Keeping this in draft until I get confirmation that this resolves https://github.com/FutureTense/keymaster/issues/103


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/FutureTense/keymaster/issues/103
- This PR is related to issue: 
