### PR TITLE
Switch using_* logic to use entity platform

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -666,13 +666,17 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
                     code = self._invalid_code(value.index)
 
                 # Build data from entities
-                active_binary_sensor = f"binary_sensor.active_{self._primary_lock.lock_name}_{value.index}"
+                active_binary_sensor = (
+                    f"binary_sensor.active_{self._primary_lock.lock_name}_{value.index}"
+                )
                 active = self.hass.states.get(active_binary_sensor)
 
                 # Report blank slot if occupied by random code
                 if active is not None:
                     if active.state == "off":
-                        _LOGGER.debug("DEBUG: Utilizing Zwave clear_usercode work around code")
+                        _LOGGER.debug(
+                            "DEBUG: Utilizing Zwave clear_usercode work around code"
+                        )
                         code = ""
 
                 data[int(value.index)] = code

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -269,7 +269,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             DOMAIN, SERVICE_GENERATE_PACKAGE, servicedata, blocking=True
         )
 
-    if using_zwave_js(hass):
+    if using_zwave_js(lock=primary_lock):
         # Listen to Z-Wave JS events so we can fire our own events
         hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(
             hass.bus.async_listen(
@@ -443,7 +443,7 @@ async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> Non
         unsub_listener()
     hass.data[DOMAIN][config_entry.entry_id].get(UNSUB_LISTENERS, []).clear()
 
-    if using_zwave_js(hass):
+    if using_zwave_js(lock=primary_lock):
         hass.data[DOMAIN][config_entry.entry_id][UNSUB_LISTENERS].append(
             hass.bus.async_listen(
                 ZWAVE_JS_EVENT,
@@ -572,7 +572,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
         #    DOMAIN, SERVICE_REFRESH_CODES, servicedata
         # )
 
-        if using_zwave_js(self.hass):
+        if using_zwave_js(lock=self._primary_lock):
             node = self._primary_lock.zwave_js_lock_node
             if node is None:
                 raise NativeNotFoundError
@@ -596,7 +596,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
             return data
 
         # pull the codes for ozw
-        elif using_ozw(self.hass):
+        elif using_ozw(lock=self._primary_lock):
             node_id = get_node_id(self.hass, self._primary_lock.lock_entity_id)
             if node_id is None:
                 return data
@@ -633,7 +633,7 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
             return data
 
         # pull codes for zwave
-        elif using_zwave(self.hass):
+        elif using_zwave(lock=self._primary_lock):
             node_id = get_node_id(self.hass, self._primary_lock.lock_entity_id)
             if node_id is None:
                 return data
@@ -666,7 +666,9 @@ class LockUsercodeUpdateCoordinator(DataUpdateCoordinator):
                     code = self._invalid_code(value.index)
 
                 # Build data from entities
-                active_binary_sensor = f"binary_sensor.active_{self._primary_lock.lock_name}_{value.index}"
+                active_binary_sensor = (
+                    f"binary_sensor.active_{self._primary_lock.lock_name}_{value.index}"
+                )
                 active = self.hass.states.get(active_binary_sensor)
 
                 # Report blank slot if occupied by random code

--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -32,9 +32,9 @@ from .const import (
 )
 from .helpers import (
     async_update_zwave_js_nodes_and_devices,
-    using_ozw,
-    using_zwave,
-    using_zwave_js,
+    async_using_ozw,
+    async_using_zwave,
+    async_using_zwave_js,
 )
 from .lock import KeymasterLock
 
@@ -69,11 +69,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Setup config entry."""
     primary_lock = hass.data[DOMAIN][config_entry.entry_id][PRIMARY_LOCK]
     child_locks = hass.data[DOMAIN][config_entry.entry_id][CHILD_LOCKS]
-    if using_zwave_js(lock=primary_lock):
+    if async_using_zwave_js(lock=primary_lock):
         entity = ZwaveJSNetworkReadySensor(primary_lock, child_locks)
-    elif using_ozw(lock=primary_lock):
+    elif async_using_ozw(lock=primary_lock):
         entity = OZWNetworkReadySensor(primary_lock, child_locks)
-    elif using_zwave(lock=primary_lock):
+    elif async_using_zwave(lock=primary_lock):
         entity = ZwaveNetworkReadySensor(primary_lock, child_locks)
     else:
         _LOGGER.error("Z-Wave integration not found")

--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -69,11 +69,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Setup config entry."""
     primary_lock = hass.data[DOMAIN][config_entry.entry_id][PRIMARY_LOCK]
     child_locks = hass.data[DOMAIN][config_entry.entry_id][CHILD_LOCKS]
-    if using_zwave_js(hass):
+    if using_zwave_js(lock=primary_lock):
         entity = ZwaveJSNetworkReadySensor(primary_lock, child_locks)
-    elif using_ozw(hass):
+    elif using_ozw(lock=primary_lock):
         entity = OZWNetworkReadySensor(primary_lock, child_locks)
-    elif using_zwave(hass):
+    elif using_zwave(lock=primary_lock):
         entity = ZwaveNetworkReadySensor(primary_lock, child_locks)
     else:
         _LOGGER.error("Z-Wave integration not found")

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -135,7 +135,9 @@ def async_using_zwave_js(
     lock: KeymasterLock = None, entity_id: str = None, ent_reg: EntityRegistry = None
 ) -> bool:
     """Returns whether the zwave_js integration is configured."""
-    return zwave_js_supported and _async_using(ZWAVE_JS_DOMAIN, lock, entity_id, ent_reg)
+    return zwave_js_supported and _async_using(
+        ZWAVE_JS_DOMAIN, lock, entity_id, ent_reg
+    )
 
 
 def get_node_id(hass: HomeAssistant, entity_id: str) -> Optional[str]:

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -106,6 +106,9 @@ def _using(
     if not (lock or (entity_id and ent_reg)):
         raise Exception("Missing arguments")
 
+    if not is_supported:
+        return False
+
     if lock:
         entity = lock.ent_reg.async_get(lock.lock_entity_id)
     else:

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Event, HomeAssistant, State
+from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.exceptions import ServiceNotFound
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
 from homeassistant.helpers.entity_registry import (
@@ -95,7 +95,8 @@ except (ModuleNotFoundError, ImportError):
 _LOGGER = logging.getLogger(__name__)
 
 
-def _using(
+@callback
+def _async_using(
     is_supported: bool,
     domain: str,
     lock: Optional[KeymasterLock],
@@ -106,9 +107,6 @@ def _using(
     if not (lock or (entity_id and ent_reg)):
         raise Exception("Missing arguments")
 
-    if not is_supported:
-        return False
-
     if lock:
         entity = lock.ent_reg.async_get(lock.lock_entity_id)
     else:
@@ -117,25 +115,28 @@ def _using(
     return entity and entity.platform == domain
 
 
-def using_ozw(
+@callback
+def async_using_ozw(
     lock: KeymasterLock = None, entity_id: str = None, ent_reg: EntityRegistry = None
 ) -> bool:
     """Returns whether the ozw integration is configured."""
-    return _using(ozw_supported, OZW_DOMAIN, lock, entity_id, ent_reg)
+    return _async_using(ozw_supported, OZW_DOMAIN, lock, entity_id, ent_reg)
 
 
-def using_zwave(
+@callback
+def async_using_zwave(
     lock: KeymasterLock = None, entity_id: str = None, ent_reg: EntityRegistry = None
 ) -> bool:
     """Returns whether the zwave integration is configured."""
-    return _using(zwave_supported, ZWAVE_DOMAIN, lock, entity_id, ent_reg)
+    return _async_using(zwave_supported, ZWAVE_DOMAIN, lock, entity_id, ent_reg)
 
 
-def using_zwave_js(
+@callback
+def async_using_zwave_js(
     lock: KeymasterLock = None, entity_id: str = None, ent_reg: EntityRegistry = None
 ) -> bool:
     """Returns whether the zwave_js integration is configured."""
-    return _using(zwave_js_supported, ZWAVE_JS_DOMAIN, lock, entity_id, ent_reg)
+    return _async_using(zwave_js_supported, ZWAVE_JS_DOMAIN, lock, entity_id, ent_reg)
 
 
 def get_node_id(hass: HomeAssistant, entity_id: str) -> Optional[str]:

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -97,7 +97,6 @@ _LOGGER = logging.getLogger(__name__)
 
 @callback
 def _async_using(
-    is_supported: bool,
     domain: str,
     lock: Optional[KeymasterLock],
     entity_id: Optional[str],
@@ -120,7 +119,7 @@ def async_using_ozw(
     lock: KeymasterLock = None, entity_id: str = None, ent_reg: EntityRegistry = None
 ) -> bool:
     """Returns whether the ozw integration is configured."""
-    return _async_using(ozw_supported, OZW_DOMAIN, lock, entity_id, ent_reg)
+    return ozw_supported and _async_using(OZW_DOMAIN, lock, entity_id, ent_reg)
 
 
 @callback
@@ -128,7 +127,7 @@ def async_using_zwave(
     lock: KeymasterLock = None, entity_id: str = None, ent_reg: EntityRegistry = None
 ) -> bool:
     """Returns whether the zwave integration is configured."""
-    return _async_using(zwave_supported, ZWAVE_DOMAIN, lock, entity_id, ent_reg)
+    return zwave_supported and _async_using(ZWAVE_DOMAIN, lock, entity_id, ent_reg)
 
 
 @callback
@@ -136,7 +135,7 @@ def async_using_zwave_js(
     lock: KeymasterLock = None, entity_id: str = None, ent_reg: EntityRegistry = None
 ) -> bool:
     """Returns whether the zwave_js integration is configured."""
-    return _async_using(zwave_js_supported, ZWAVE_JS_DOMAIN, lock, entity_id, ent_reg)
+    return zwave_js_supported and _async_using(ZWAVE_JS_DOMAIN, lock, entity_id, ent_reg)
 
 
 def get_node_id(hass: HomeAssistant, entity_id: str) -> Optional[str]:

--- a/custom_components/keymaster/lock.py
+++ b/custom_components/keymaster/lock.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.entity_registry import EntityRegistry
 
 
 @dataclass
@@ -13,6 +14,7 @@ class KeymasterLock:
     lock_entity_id: str
     alarm_level_or_user_code_entity_id: Optional[str]
     alarm_type_or_access_control_entity_id: Optional[str]
-    door_sensor_entity_id: Optional[str]
+    ent_reg: EntityRegistry
+    door_sensor_entity_id: Optional[str] = None
     zwave_js_lock_node = None
     zwave_js_lock_device: DeviceEntry = None

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -109,17 +109,19 @@ async def add_code(
         ATTR_USER_CODE: usercode,
     }
 
-    if using_zwave_js(entity_id=entity_id, ent_reg=async_get_entity_registry(hass)):
+    ent_reg = async_get_entity_registry(hass)
+
+    if using_zwave_js(entity_id=entity_id, ent_reg=ent_reg):
         servicedata[ATTR_ENTITY_ID] = entity_id
         await call_service(
             hass, ZWAVE_JS_DOMAIN, SERVICE_SET_LOCK_USERCODE, servicedata
         )
 
-    elif using_ozw(entity_id=entity_id, ent_reg=async_get_entity_registry(hass)):
+    elif using_ozw(entity_id=entity_id, ent_reg=ent_reg):
         servicedata[ATTR_ENTITY_ID] = entity_id
         await call_service(hass, OZW_DOMAIN, SET_USERCODE, servicedata)
 
-    elif using_zwave(entity_id=entity_id, ent_reg=async_get_entity_registry(hass)):
+    elif using_zwave(entity_id=entity_id, ent_reg=ent_reg):
         node_id = get_node_id(hass, entity_id)
         if node_id is None:
             _LOGGER.error(
@@ -139,7 +141,9 @@ async def clear_code(hass: HomeAssistant, entity_id: str, code_slot: int) -> Non
     """Clear the usercode from a code slot."""
     _LOGGER.debug("Attempting to call clear_usercode...")
 
-    if using_zwave_js(hass):
+    ent_reg = async_get_entity_registry(hass)
+
+    if using_zwave_js(entity_id=entity_id, ent_reg=ent_reg):
         servicedata = {
             ATTR_ENTITY_ID: entity_id,
             ATTR_CODE_SLOT: code_slot,
@@ -148,7 +152,7 @@ async def clear_code(hass: HomeAssistant, entity_id: str, code_slot: int) -> Non
             hass, ZWAVE_JS_DOMAIN, SERVICE_CLEAR_LOCK_USERCODE, servicedata
         )
 
-    elif using_ozw(hass):
+    elif using_ozw(entity_id=entity_id, ent_reg=ent_reg):
         # Call dummy slot first as a workaround
         for curr_code_slot in (999, code_slot):
             servicedata = {
@@ -157,7 +161,7 @@ async def clear_code(hass: HomeAssistant, entity_id: str, code_slot: int) -> Non
             }
             await call_service(hass, OZW_DOMAIN, CLEAR_USERCODE, servicedata)
 
-    elif using_zwave(hass):
+    elif using_zwave(entity_id=entity_id, ent_reg=ent_reg):
         node_id = get_node_id(hass, entity_id)
         if node_id is None:
             _LOGGER.error(

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -10,6 +10,7 @@ from homeassistant.components.ozw import DOMAIN as OZW_DOMAIN
 from homeassistant.components.persistent_notification import create
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 
 from .const import (
     ATTR_CODE_SLOT,
@@ -85,7 +86,7 @@ async def refresh_codes(
         return
 
     # OZW Button press (experimental)
-    if using_ozw(hass):
+    if using_ozw(entity_id=entity_id, ent_reg=async_get_entity_registry(hass)):
         manager = hass.data[OZW_DOMAIN][MANAGER]
         lock_values = manager.get_instance(instance_id).get_node(node_id).values()
         for value in lock_values:
@@ -108,17 +109,17 @@ async def add_code(
         ATTR_USER_CODE: usercode,
     }
 
-    if using_zwave_js(hass):
+    if using_zwave_js(entity_id=entity_id, ent_reg=async_get_entity_registry(hass)):
         servicedata[ATTR_ENTITY_ID] = entity_id
         await call_service(
             hass, ZWAVE_JS_DOMAIN, SERVICE_SET_LOCK_USERCODE, servicedata
         )
 
-    elif using_ozw(hass):
+    elif using_ozw(entity_id=entity_id, ent_reg=async_get_entity_registry(hass)):
         servicedata[ATTR_ENTITY_ID] = entity_id
         await call_service(hass, OZW_DOMAIN, SET_USERCODE, servicedata)
 
-    elif using_zwave(hass):
+    elif using_zwave(entity_id=entity_id, ent_reg=async_get_entity_registry(hass)):
         node_id = get_node_id(hass, entity_id)
         if node_id is None:
             _LOGGER.error(

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,5 @@
 homeassistant
+homeassistant-pyozw==0.1.10
+pydispatcher==2.0.5
 python-openzwave-mqtt
 zwave-js-server-python

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
 homeassistant
 python-openzwave-mqtt
-zwave-js-server-python
+zwave-js-server-python==0.22.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,3 @@
 homeassistant
-homeassistant-pyozw==0.1.10
-pydispatcher==2.0.5
 python-openzwave-mqtt
 zwave-js-server-python

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,8 +253,8 @@ def mock_openzwave():
 async def mock_using_ozw():
     """Fixture to mock using_ozw in helpers"""
     with patch(
-        "custom_components.keymaster.helpers.using_zwave_js", return_value=False
+        "custom_components.keymaster.helpers.async_using_zwave_js", return_value=False
     ), patch(
-        "custom_components.keymaster.helpers.using_ozw", return_value=True
+        "custom_components.keymaster.helpers.async_using_ozw", return_value=True
     ) as mock_using_ozw_helpers:
         yield mock_using_ozw_helpers

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -116,5 +116,3 @@ async def test_zwavejs_network_ready(
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-
-    assert "Can't find your lock" in caplog.text

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -161,8 +161,8 @@ async def test_update_usercodes_using_zwave(hass, mock_openzwave, caplog):
 
     # Load the integration
     with patch(
-        "custom_components.keymaster.binary_sensor.using_zwave", return_value=True
-    ), patch("custom_components.keymaster.using_zwave", return_value=True):
+        "custom_components.keymaster.binary_sensor.async_using_zwave", return_value=True
+    ), patch("custom_components.keymaster.async_using_zwave", return_value=True):
         entry = MockConfigEntry(
             domain=DOMAIN, title="frontdoor", data=CONFIG_DATA_REAL, version=2
         )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -121,7 +121,9 @@ async def test_add_code(hass, lock_data, sent_messages, caplog):
     )
 
     # Mock using_zwave
-    with patch("custom_components.keymaster.services.using_zwave", return_value=True):
+    with patch(
+        "custom_components.keymaster.services.async_using_zwave", return_value=True
+    ):
         servicedata = {
             "entity_id": "lock.kwikset_touchpad_electronic_deadbolt_frontdoor",
             "code_slot": 1,
@@ -135,7 +137,7 @@ async def test_add_code(hass, lock_data, sent_messages, caplog):
         )
 
     with patch(
-        "custom_components.keymaster.services.using_zwave", return_value=True
+        "custom_components.keymaster.services.async_using_zwave", return_value=True
     ), patch("custom_components.keymaster.services.get_node_id", return_value="14"):
         servicedata = {
             "entity_id": "lock.kwikset_touchpad_electronic_deadbolt_frontdoor",
@@ -318,7 +320,9 @@ async def test_clear_code(hass, lock_data, sent_messages, mock_openzwave, caplog
     )
 
     # Mock using_zwave
-    with patch("custom_components.keymaster.services.using_zwave", return_value=True):
+    with patch(
+        "custom_components.keymaster.services.async_using_zwave", return_value=True
+    ):
         servicedata = {
             "entity_id": "lock.kwikset_touchpad_electronic_deadbolt_frontdoor",
             "code_slot": 1,
@@ -331,7 +335,7 @@ async def test_clear_code(hass, lock_data, sent_messages, mock_openzwave, caplog
         )
 
     with patch(
-        "custom_components.keymaster.services.using_zwave", return_value=True
+        "custom_components.keymaster.services.async_using_zwave", return_value=True
     ), patch("custom_components.keymaster.services.get_node_id", return_value="14"):
         servicedata = {
             "entity_id": "lock.kwikset_touchpad_electronic_deadbolt_frontdoor",
@@ -344,7 +348,9 @@ async def test_clear_code(hass, lock_data, sent_messages, mock_openzwave, caplog
             in caplog.text
         )
 
-    with patch("custom_components.keymaster.services.using_zwave", return_value=True):
+    with patch(
+        "custom_components.keymaster.services.async_using_zwave", return_value=True
+    ):
         # Setup zwave mock
         hass.data[DATA_NETWORK] = mock_openzwave
         node = MockNode(node_id=12)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -154,36 +154,39 @@ async def test_add_code(hass, lock_data, sent_messages, caplog):
     # Bring OZW up
     await setup_ozw(hass, fixture=lock_data)
 
-    state = hass.states.get("lock.smartcode_10_touchpad_electronic_deadbolt_locked")
-    assert state is not None
-    assert state.state == "locked"
-    assert state.attributes["node_id"] == 14
+    with patch(
+        "custom_components.keymaster.services.async_using_ozw", return_value=True
+    ):
+        state = hass.states.get("lock.smartcode_10_touchpad_electronic_deadbolt_locked")
+        assert state is not None
+        assert state.state == "locked"
+        assert state.attributes["node_id"] == 14
 
-    servicedata = {
-        "entity_id": "lock.kwikset_touchpad_electronic_deadbolt_frontdoor",
-        "code_slot": 1,
-        "usercode": "1234",
-    }
-    await hass.services.async_call(DOMAIN, SERVICE_ADD_CODE, servicedata)
-    await hass.async_block_till_done()
+        servicedata = {
+            "entity_id": "lock.kwikset_touchpad_electronic_deadbolt_frontdoor",
+            "code_slot": 1,
+            "usercode": "1234",
+        }
+        await hass.services.async_call(DOMAIN, SERVICE_ADD_CODE, servicedata)
+        await hass.async_block_till_done()
 
-    assert (
-        "Unable to find referenced entities lock.kwikset_touchpad_electronic_deadbolt_frontdoor"
-        in caplog.text
-    )
+        assert (
+            "Unable to find referenced entities lock.kwikset_touchpad_electronic_deadbolt_frontdoor"
+            in caplog.text
+        )
 
-    servicedata = {
-        "entity_id": "lock.smartcode_10_touchpad_electronic_deadbolt_locked",
-        "code_slot": 1,
-        "usercode": "123456",
-    }
-    await hass.services.async_call(DOMAIN, SERVICE_ADD_CODE, servicedata)
-    await hass.async_block_till_done()
+        servicedata = {
+            "entity_id": "lock.smartcode_10_touchpad_electronic_deadbolt_locked",
+            "code_slot": 1,
+            "usercode": "123456",
+        }
+        await hass.services.async_call(DOMAIN, SERVICE_ADD_CODE, servicedata)
+        await hass.async_block_till_done()
 
-    assert len(sent_messages) == 1
-    msg = sent_messages[0]
-    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
-    assert msg["payload"] == {"Value": "123456", "ValueIDKey": 281475217408023}
+        assert len(sent_messages) == 1
+        msg = sent_messages[0]
+        assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+        assert msg["payload"] == {"Value": "123456", "ValueIDKey": 281475217408023}
 
 
 async def test_add_code_zwave_js(hass, client, lock_kwikset_910, integration):
@@ -214,8 +217,8 @@ async def test_add_code_zwave_js(hass, client, lock_kwikset_910, integration):
     await hass.services.async_call(DOMAIN, SERVICE_ADD_CODE, servicedata)
     await hass.async_block_till_done()
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 14
     assert args["valueId"] == {
@@ -267,8 +270,8 @@ async def test_clear_code_zwave_js(hass, client, lock_kwikset_910, integration):
     await hass.services.async_call(DOMAIN, SERVICE_CLEAR_CODE, servicedata)
     await hass.async_block_till_done()
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 14
     assert args["valueId"] == {
@@ -399,39 +402,42 @@ async def test_clear_code(hass, lock_data, sent_messages, mock_openzwave, caplog
     # Bring OZW up
     await setup_ozw(hass, fixture=lock_data)
 
-    state = hass.states.get("lock.smartcode_10_touchpad_electronic_deadbolt_locked")
-    assert state is not None
-    assert state.state == "locked"
-    assert state.attributes["node_id"] == 14
+    with patch(
+        "custom_components.keymaster.services.async_using_ozw", return_value=True
+    ):
+        state = hass.states.get("lock.smartcode_10_touchpad_electronic_deadbolt_locked")
+        assert state is not None
+        assert state.state == "locked"
+        assert state.attributes["node_id"] == 14
 
-    entry = MockConfigEntry(
-        domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=2
-    )
+        entry = MockConfigEntry(
+            domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=2
+        )
 
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
-    servicedata = {
-        "entity_id": "lock.kwikset_touchpad_electronic_deadbolt_frontdoor",
-        "code_slot": 1,
-    }
-    await hass.services.async_call(DOMAIN, SERVICE_CLEAR_CODE, servicedata)
-    await hass.async_block_till_done()
+        servicedata = {
+            "entity_id": "lock.kwikset_touchpad_electronic_deadbolt_frontdoor",
+            "code_slot": 1,
+        }
+        await hass.services.async_call(DOMAIN, SERVICE_CLEAR_CODE, servicedata)
+        await hass.async_block_till_done()
 
-    assert (
-        "Unable to find referenced entities lock.kwikset_touchpad_electronic_deadbolt_frontdoor"
-        in caplog.text
-    )
+        assert (
+            "Unable to find referenced entities lock.kwikset_touchpad_electronic_deadbolt_frontdoor"
+            in caplog.text
+        )
 
-    servicedata = {
-        "entity_id": "lock.smartcode_10_touchpad_electronic_deadbolt_locked",
-        "code_slot": 1,
-    }
-    await hass.services.async_call(DOMAIN, SERVICE_CLEAR_CODE, servicedata)
-    await hass.async_block_till_done()
+        servicedata = {
+            "entity_id": "lock.smartcode_10_touchpad_electronic_deadbolt_locked",
+            "code_slot": 1,
+        }
+        await hass.services.async_call(DOMAIN, SERVICE_CLEAR_CODE, servicedata)
+        await hass.async_block_till_done()
 
-    assert len(sent_messages) == 4
-    msg = sent_messages[3]
-    assert msg["topic"] == "OpenZWave/1/command/setvalue/"
-    assert msg["payload"] == {"Value": 1, "ValueIDKey": 72057594287013910}
+        assert len(sent_messages) == 4
+        msg = sent_messages[3]
+        assert msg["topic"] == "OpenZWave/1/command/setvalue/"
+        assert msg["payload"] == {"Value": 1, "ValueIDKey": 72057594287013910}


### PR DESCRIPTION
## Proposed change
Right now we determine which integration is in use based on what we can find at `hass.data`. This isn't a great approach because it prevents people who are using multiple integrations for locks to leverage keymaster. In the future we may add support for zigbee locks as an example, so we need a better way to figure out which integration logic to use. This switch now checks the entity registry for the primary lock's platform, and uses that. This means that someone could have a `zwave_js` lock AND an `ozw` lock configured in keymaster and both will work as expected.


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
