### PR TITLE
Fix: Reset date range start/end times

### DIFF
--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -57,13 +57,13 @@ script:
       - service: input_datetime.set_datetime
         data_template:
           entity_id: "input_datetime.start_date_LOCKNAME_{{ code_slot | string }}"
-          date: >-
-            {{ now().strftime('%Y-%m-%d') }}
+          datetime: >-
+            {{ now().strftime('%Y-%m-%d 00:00') }}
       - service: input_datetime.set_datetime
         data_template:
           entity_id: "input_datetime.end_date_LOCKNAME_{{ code_slot | string }}"
-          date: >-
-            {{ now().strftime('%Y-%m-%d') }} 
+          datetime: >-
+            {{ now().strftime('%Y-%m-%d 00:00') }}
       - service: input_boolean.turn_off
         data_template:
           entity_id: "input_boolean.daterange_LOCKNAME_{{ code_slot | string }}"


### PR DESCRIPTION
## Proposed change
Commit f70d9eea54237855eb87ed966e2e3ae1e659fd64 introduced an uncaught
bug where using the `Reset Code Slot` option would not reset the time on
the start/end dates.

This fixes #165 

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #165