### PR TITLE
Initialize child locks after package generation

### DIFF
--- a/custom_components/keymaster/strings.json
+++ b/custom_components/keymaster/strings.json
@@ -17,6 +17,7 @@
           "lockname": "Lock Name (ie: frontdoor)",
           "packages_path": "Path to packages directory",
           "child_locks_file": "Path to child locks file",
+          "parent": "Select parent lock",
           "hide_pins": "Hide PINs in UI?"
         },
         "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)\n\nIf you are using Z-Wave JS you may or may not have alarm level and alarm type entities. If you do, select them on this form, otherwise you can use the `sensor.fake` values as placeholders.",
@@ -49,6 +50,7 @@
           "lockname": "Lock Name (ie: frontdoor)",
           "packages_path": "Path to packages directory",
           "child_locks_file": "Path to child locks file",
+          "parent": "Select parent lock",          
           "hide_pins": "Hide PINs in UI?"
         },
         "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)\n\nIf you are using Z-Wave JS you may or may not have alarm level and alarm type entities. If you do, select them on this form, otherwise you can use the `sensor.fake` values as placeholders.",

--- a/custom_components/keymaster/translations/en.json
+++ b/custom_components/keymaster/translations/en.json
@@ -17,6 +17,7 @@
           "lockname": "Lock Name (ie: frontdoor)",
           "packages_path": "Path to packages directory",
           "child_locks_file": "Path to child locks file",
+          "parent": "Select parent lock",          
           "hide_pins": "Hide PINs in UI?"
         },
         "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)\n\nIf you are using Z-Wave JS you may or may not have alarm level and alarm type entities. If you do, select them on this form, otherwise you can use the `sensor.fake` values as placeholders.",
@@ -49,6 +50,7 @@
           "lockname": "Lock Name (ie: frontdoor)",
           "packages_path": "Path to packages directory",
           "child_locks_file": "Path to child locks file",
+          "parent": "Select parent lock",          
           "hide_pins": "Hide PINs in UI?"
         },
         "description": "Select the lock to setup and code slots to create.\n\nPaths are relative to your Home Assistant config folder (e.g. `/config/packages/keymaster` should be entered as `packages/keymaster`)\n\nIf you are using Z-Wave JS you may or may not have alarm level and alarm type entities. If you do, select them on this form, otherwise you can use the `sensor.fake` values as placeholders.",

--- a/custom_components/keymaster/translations/nb.json
+++ b/custom_components/keymaster/translations/nb.json
@@ -17,6 +17,7 @@
           "lockname": "Låsnavn (dvs. frontdør)",
           "packages_path": "Sti til pakkekatalog",
           "child_locks_file": "Path to child locks file",
+          "parent": "Select parent lock",          
           "hide_pins": "Hide PINs in UI?"
         },
         "description": "Velg låsen du vil sette opp og kodesporene du vil opprette.",
@@ -42,6 +43,7 @@
           "lockname": "Låsnavn (dvs. frontdør)",
           "packages_path": "Sti til pakkekatalog",
           "child_locks_file": "Path to child locks file",
+          "parent": "Select parent lock",          
           "hide_pins": "Hide PINs in UI?"
         },
         "description": "Velg låsen du vil sette opp og kodesporene du vil opprette.",


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds _init_child_locks function to call the scripts "LOCKNAME_copy_from_parent_TEMPLATENUM" after the packages are generated and reloaded

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176 