### PR TITLE
fix: Add checks before calling init_child_locks

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -319,12 +319,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                 ),
             )
 
-    await init_child_locks(
-        hass,
-        config_entry.data[CONF_START],
-        config_entry.data[CONF_SLOTS],
-        config_entry.data[CONF_LOCK_NAME],
-    )
+    if primary_lock.parent is not None:
+        await init_child_locks(
+            hass,
+            config_entry.data[CONF_START],
+            config_entry.data[CONF_SLOTS],
+            config_entry.data[CONF_LOCK_NAME],
+        )
 
     return True
 

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -358,7 +358,8 @@ def generate_package_files(hass: HomeAssistant, name: str) -> None:
             "Package generation complete and all changes have been hot reloaded"
         )
         reset_code_slot_if_pin_unknown(hass, lockname, code_slots, start_from)
-        init_child_locks(hass, start_from, code_slots, lockname)
+        if primary_lock.parent is not None:
+            init_child_locks(hass, start_from, code_slots, lockname)
     else:
         create(
             hass,


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add checks before calling init_child_locks.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #187 
- This PR is related to issue: https://community.home-assistant.io/t/keymaster-z-wave-lock-manager-and-scheduler/166419/1990
