### PR TITLE
Indent parent entities correctly

### DIFF
--- a/custom_components/keymaster/keymaster_common_child.yaml
+++ b/custom_components/keymaster/keymaster_common_child.yaml
@@ -419,6 +419,6 @@ input_text:
     initial: "00:05:00"
 
 ###############  PARENT entities  #################
-LOCKNAME_PARENTLOCK_parent:
-  initial: PARENTLOCK
-  name: "Parent lock"
+  LOCKNAME_PARENTLOCK_parent:
+    initial: PARENTLOCK
+    name: "Parent lock"


### PR DESCRIPTION
## Proposed change
fix indentation of the child lock generated file so that LOCKNAME_PARENTLOCK_parent becomes an input_text


## Type of change


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
I just re-installed keymaster, and it generated the parent entity for the child lock incorrectly since it was not "under" input_text



- This PR is related to issue: #231 
