### PR TITLE
Add keymaster_ prefix to automation IDs

### DIFF
--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -147,8 +147,8 @@ input_boolean:
 
 ################  automation: #################
 automation:
-  - alias: turn_on_access_limit_LOCKNAME_TEMPLATENUM
-    id: turn_on_access_limit_LOCKNAME_TEMPLATENUM
+  - alias: keymaster_turn_on_access_limit_LOCKNAME_TEMPLATENUM
+    id: keymaster_turn_on_access_limit_LOCKNAME_TEMPLATENUM
     trigger:
       platform: state
       entity_id: input_number.accesscount_LOCKNAME_TEMPLATENUM
@@ -161,8 +161,8 @@ automation:
       target:
         entity_id: input_boolean.accesslimit_LOCKNAME_TEMPLATENUM
 
-  - alias: synchronize_codeslot_LOCKNAME_TEMPLATENUM
-    id: synchronize_codeslot_LOCKNAME_TEMPLATENUM
+  - alias: keymaster_synchronize_codeslot_LOCKNAME_TEMPLATENUM
+    id: keymaster_synchronize_codeslot_LOCKNAME_TEMPLATENUM
     initial_state: true
     mode: single
     max_exceeded: silent


### PR DESCRIPTION
## Proposed change
Adds the "keymaster" prefix to synchronize_codeslot and turn_on_access_limit automations for primary (non-child) locks.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/FutureTense/keymaster/issues/174
- This PR is related to issue: https://github.com/FutureTense/keymaster/issues/174
