### PR TITLE
slugify parent lockname in generator

### DIFF
--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -342,7 +342,7 @@ def generate_package_files(hass: HomeAssistant, name: str) -> None:
         "SENSORALARMTYPE": sensoralarmtype,
         "SENSORALARMLEVEL": sensoralarmlevel,
         "HIDE_PINS": hide_pins,
-        "PARENTLOCK": "" if primary_lock.parent is None else primary_lock.parent,
+        "PARENTLOCK": "" if primary_lock.parent is None else slugify(primary_lock.parent),
     }
 
     # Replace variables in common file


### PR DESCRIPTION
Signed-off-by: Felix Kaechele <felix@kaechele.ca>


## Proposed change
Slugify the parent lockname as well, as the package generation creates references to the parent lock which had it's name slugified when it was set up initially.


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #231 
