### PR TITLE
Fix autolock defaults

### DIFF
--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -397,24 +397,23 @@ automation:
         entity_id: script.keymaster_LOCKNAME_start_timer
 
   - alias: keymaster_LOCKNAME_initialize
+    id: keymaster_LOCKNAME_initialize
     trigger:
       platform: homeassistant
       event: start
     action:
-      - service_template: >
-          {% if states('input_text.keymaster_LOCKNAME_autolock_door_time_day')|length == 0  %}
-            input_text.set_value
-          {% endif %}
+      - service: input_text.set_value
         entity_id: input_text.keymaster_LOCKNAME_autolock_door_time_day
         data:
-          value: "02:00:00"
-      - service_template: >
-          {% if states('input_text.keymaster_LOCKNAME_autolock_door_time_night')|length == 0  %}
-            input_text.set_value
-          {% endif %}
+          value: >
+            {%- set current_value=states('input_text.keymaster_LOCKNAME_autolock_door_time_day') -%}
+            {{ iif(current_value in ['', 'unknown'], "02:00:00", current_value)}}
+      - service: input_text.set_value
         entity_id: input_text.keymaster_LOCKNAME_autolock_door_time_night
         data:
-          value: "00:05:00"
+          value: >
+            {%- set current_value=states('input_text.keymaster_LOCKNAME_autolock_door_time_night') -%}
+            {{ iif(current_value in ['', 'unknown'], "00:05:00", current_value)}}
 
 ###################  timer:  ####################
 timer:

--- a/custom_components/keymaster/keymaster_common_child.yaml
+++ b/custom_components/keymaster/keymaster_common_child.yaml
@@ -397,24 +397,23 @@ automation:
         entity_id: script.keymaster_LOCKNAME_start_timer
 
   - alias: keymaster_LOCKNAME_initialize
+    id: keymaster_LOCKNAME_initialize
     trigger:
       platform: homeassistant
       event: start
     action:
-      - service_template: >
-          {% if states('input_text.keymaster_LOCKNAME_autolock_door_time_day')|length == 0  %}
-            input_text.set_value
-          {% endif %}
+      - service: input_text.set_value
         entity_id: input_text.keymaster_LOCKNAME_autolock_door_time_day
         data:
-          value: "02:00:00"
-      - service_template: >
-          {% if states('input_text.keymaster_LOCKNAME_autolock_door_time_night')|length == 0  %}
-            input_text.set_value
-          {% endif %}
+          value: >
+            {%- set current_value=states('input_text.keymaster_LOCKNAME_autolock_door_time_day') -%}
+            {{ iif(current_value in ['', 'unknown'], "02:00:00", current_value)}}
+      - service: input_text.set_value
         entity_id: input_text.keymaster_LOCKNAME_autolock_door_time_night
         data:
-          value: "00:05:00"
+          value: >
+            {%- set current_value=states('input_text.keymaster_LOCKNAME_autolock_door_time_night') -%}
+            {{ iif(current_value in ['', 'unknown'], "00:05:00", current_value)}}
 
 ###################  timer:  ####################
 timer:


### PR DESCRIPTION
## Proposed change
The current approach yields errors on startup if autolock times have already been set, because the service_template evaluates to an empty string.

But it also simply fails to work properly. For some reason (on my system) newly defined input_text entities start with a value of 'unknown'. LLooking into it more, it looks like this is intentional, as it is explicitly tested for in the unit tests.

To fix this, I unconditionally set these input_texts on startup, but conditionally choose the value. If it is not 'unknown' or the empty string, set it to its own current value, otherwise set the default.

Lastly, I've added an id to the automation, so it can be viewed in the tracer properly.

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests