### PR TITLE
Bump minimum version of HA required

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -14,5 +14,5 @@
   "iot_class": "Local Polling",
   "zip_release": true,
   "filename": "keymaster.zip",
-  "homeassistant": "2021.9.0"
+  "homeassistant": "2022.4.0"
 }


### PR DESCRIPTION
## Proposed change
Since zwave and ozw were removed in 2022.4, this PR sets that version as the new minimum. Since this change will be read by HACS as soon as it's merged, it should only be merged when the `zwave` and `ozw` code removal gets released


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
