### PR TITLE
fix: add FE599 lock 'user access' code to `alarmType` map

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10]
+        python-version: [3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/custom_components/keymaster/const.py
+++ b/custom_components/keymaster/const.py
@@ -61,11 +61,14 @@ DEFAULT_ALARM_TYPE_SENSOR = "sensor.fake"
 DEFAULT_HIDE_PINS = False
 
 # Action maps
+# FE599 locks only send alarmType 16 for all lock/unlock commands
+# see issue #281
 ACTION_MAP = {
     ALARM_TYPE: {
         999: "Kwikset",
         0: "No Status Reported",
         9: "Lock Jammed",
+        16: "User Access", # FE599 code
         17: "Keypad Lock Jammed",
         21: "Manual Lock",
         22: "Manual Unlock",

--- a/hacs.json
+++ b/hacs.json
@@ -1,17 +1,5 @@
 {
   "name": "keymaster",
-  "domains": [
-    "automation",
-    "binary_sensor",
-    "input_boolean",
-    "input_datetime",
-    "input_number",
-    "input_text",
-    "script",
-    "sensor",
-    "template"
-  ],
-  "iot_class": "Local Polling",
   "zip_release": true,
   "filename": "keymaster.zip",
   "homeassistant": "2021.9.0"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,4 @@ pytest-homeassistant-custom-component
 black
 isort
 pydispatcher
+zeroconf

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,6 +6,7 @@ import time
 from unittest.mock import patch
 
 from homeassistant import core as ha
+from homeassistant.core import HomeAssistant
 from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.dt as date_util
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,6 +5,7 @@ import os
 import time
 from unittest.mock import patch
 
+from datetime import datetime
 from homeassistant import core as ha
 from homeassistant.core import HomeAssistant
 from homeassistant.util.async_ import run_callback_threadsafe

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,7 +6,6 @@ import time
 from unittest.mock import patch
 
 from homeassistant import core as ha
-from homeassistant.const import EVENT_TIME_CHANGED
 from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.dt as date_util
 
@@ -49,9 +48,12 @@ def threadsafe_callback_factory(func):
 
 
 @ha.callback
-def async_fire_time_changed(hass, datetime_, fire_all=False):
-    """Fire a time changes event."""
-    hass.bus.async_fire(EVENT_TIME_CHANGED, {"now": date_util.as_utc(datetime_)})
+def async_fire_time_changed(
+    hass: HomeAssistant, datetime_: datetime = None, fire_all: bool = False
+) -> None:
+    """Fire a time changed event."""
+    if datetime_ is None:
+        datetime_ = date_util.utcnow()
 
     for task in list(hass.loop._scheduled):
         if not isinstance(task, asyncio.TimerHandle):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from sqlalchemy import false
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
 from zwave_js_server.version import VersionInfo
@@ -63,6 +64,16 @@ def mock_listdir():
             "anotherfakefile.mp4",
             "lastfile.txt",
         ],
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_listdir_err():
+    """Fixture to mock listdir."""
+    with patch(
+        "os.listdir",
+        return_value=[],
     ):
         yield
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -383,15 +383,13 @@ async def test_options_flow_with_zwavejs(
         assert entry.data.copy() == data
 
 
-async def test_get_entities(hass, lock_kwikset_910, client ,integration):
+async def test_get_entities(hass, lock_kwikset_910, client, integration):
     """Test function that returns entities by domain."""
     # Load ZwaveJS
     node = lock_kwikset_910
     state = hass.states.get(KWIKSET_910_LOCK_ENTITY)
-    
+
     assert state is not None
     assert state.state == "locked"
 
-    assert KWIKSET_910_LOCK_ENTITY in _get_entities(
-        hass, LOCK_DOMAIN
-    )
+    assert KWIKSET_910_LOCK_ENTITY in _get_entities(hass, LOCK_DOMAIN)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -27,11 +27,7 @@ SCHLAGE_BE469_LOCK_ENTITY = "lock.touchscreen_deadbolt_current_lock_mode"
 KWIKSET_910_LOCK_ENTITY = "lock.smart_code_with_home_connect_technology"
 
 
-async def test_delete_lock_and_base_folder(
-    hass,
-    mock_osremove,
-    mock_osrmdir,
-):
+async def test_delete_lock_and_base_folder(hass):
     """Test delete_lock_and_base_folder"""
     entry = MockConfigEntry(
         domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=2
@@ -40,13 +36,13 @@ async def test_delete_lock_and_base_folder(
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-
-    delete_lock_and_base_folder(hass, entry)
-
-    assert mock_osrmdir.called
-    assert mock_osremove.called
-
+    
     with patch("custom_components.keymaster.helpers.os", autospec=True) as mock_os:
+        delete_lock_and_base_folder(hass, entry)
+
+        assert mock_os.rmdir.called
+        assert mock_os.remove.called
+    
         mock_os.listdir.return_value = False
         delete_lock_and_base_folder(hass, entry)
         mock_os.rmdir.assert_called_once

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -27,7 +27,7 @@ SCHLAGE_BE469_LOCK_ENTITY = "lock.touchscreen_deadbolt_current_lock_mode"
 KWIKSET_910_LOCK_ENTITY = "lock.smart_code_with_home_connect_technology"
 
 
-async def test_delete_lock_and_base_folder(hass):
+async def test_delete_lock_and_base_folder(hass, mock_osrmdir, mock_osremove):
     """Test delete_lock_and_base_folder"""
     entry = MockConfigEntry(
         domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=2
@@ -36,16 +36,28 @@ async def test_delete_lock_and_base_folder(hass):
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    
-    with patch("os", autospec=True) as mock_os:
-        delete_lock_and_base_folder(hass, entry)
 
-        assert mock_os.rmdir.called
-        assert mock_os.remove.called
-    
-        mock_os.listdir.return_value = False
-        delete_lock_and_base_folder(hass, entry)
-        mock_os.rmdir.assert_called_once
+    delete_lock_and_base_folder(hass, entry)
+
+    assert mock_osrmdir.called
+    assert mock_osremove.called
+
+
+async def test_delete_lock_and_base_folder_error(
+    hass, mock_osrmdir, mock_osremove, mock_listdir_err
+):
+    """Test delete_lock_and_base_folder"""
+    entry = MockConfigEntry(
+        domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=2
+    )
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    delete_lock_and_base_folder(hass, entry)
+
+    assert mock_osrmdir.called_once
 
 
 async def test_handle_state_change_zwave_js(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -37,7 +37,7 @@ async def test_delete_lock_and_base_folder(hass):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     
-    with patch("custom_components.keymaster.helpers.os", autospec=True) as mock_os:
+    with patch("os", autospec=True) as mock_os:
         delete_lock_and_base_folder(hass, entry)
 
         assert mock_os.rmdir.called


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds FE599 'User Access' code to `alarmType` map
Fix tests, remove python 3.8 from tests and adds python 3.10

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #281 