### PR TITLE
Correct typo in call to "keymaster_{lockname}_copy_from_parent_{x}"

### DIFF
--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -58,7 +58,7 @@ async def init_child_locks(
     # LOCKNAME_copy_from_parent_TEMPLATENUM
     _LOGGER.debug("Syncing lock: %s", lockname)
     for x in range(start, start + slots):
-        the_service = f"{lockname}_copy_from_parent_{x}"
+        the_service = f"keymaster_{lockname}_copy_from_parent_{x}"
         _LOGGER.debug("Attempting to call script: %s", the_service)
         await call_service(hass, SCRIPT_DOMAIN, the_service)
     _LOGGER.debug("Sync complete")


### PR DESCRIPTION
## Proposed change

Add missing keymaster_ prefix which was leading to an error.  Verified locally to fix the issue for me.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

- This PR fixes or closes issue: fixes #319 and #304.
