### PR TITLE
fix: add unique_id to template yaml entities

### DIFF
--- a/custom_components/keymaster/keymaster.yaml
+++ b/custom_components/keymaster/keymaster.yaml
@@ -207,6 +207,7 @@ binary_sensor:
     sensors:
       active_LOCKNAME_TEMPLATENUM:
         friendly_name: "Desired PIN State"
+        unique_id: "binary_sensor.active_LOCKNAME_TEMPLATENUM"
         value_template: >-
           {## This template checks whether the PIN should be considered active based on ##}
           {## all of the different ways the PIN can be conditionally enabled/disabled ##}
@@ -263,6 +264,7 @@ binary_sensor:
 
       pin_synched_LOCKNAME_TEMPLATENUM:
         friendly_name: "PIN synchronized with lock"
+        unique_id: "binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM"
         value_template: >
           {% set lockpin = states('sensor.LOCKNAME_code_slot_TEMPLATENUM').strip()  %}
           {% set localpin = states('input_text.LOCKNAME_pin_TEMPLATENUM').strip()  %}
@@ -282,6 +284,7 @@ sensor:
     sensors:
       connected_LOCKNAME_TEMPLATENUM:
         friendly_name: "PIN Status"
+        unique_id: "sensor.connected_LOCKNAME_TEMPLATENUM"
         value_template: >-
           {% set pin_active = is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on')  %}      
           {% set synched = is_state('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM', 'on')  %}      

--- a/custom_components/keymaster/keymaster_child.yaml
+++ b/custom_components/keymaster/keymaster_child.yaml
@@ -883,6 +883,7 @@ binary_sensor:
     sensors:
       active_LOCKNAME_TEMPLATENUM:
         friendly_name: "Desired PIN State"
+        unique_id: "binary_sensor.active_LOCKNAME_TEMPLATENUM"
         value_template: >-
           {## This template checks whether the PIN should be considered active based on ##}
           {## all of the different ways the PIN can be conditionally enabled/disabled ##}
@@ -939,6 +940,7 @@ binary_sensor:
 
       pin_synched_LOCKNAME_TEMPLATENUM:
         friendly_name: "PIN synchronized with lock"
+        unique_id: "binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM"
         value_template: >
           {% set lockpin = states('sensor.LOCKNAME_code_slot_TEMPLATENUM').strip()  %}
           {% set localpin = states('input_text.LOCKNAME_pin_TEMPLATENUM').strip()  %}
@@ -958,6 +960,7 @@ sensor:
     sensors:
       connected_LOCKNAME_TEMPLATENUM:
         friendly_name: "PIN Status"
+        unique_id: "sensor.connected_LOCKNAME_TEMPLATENUM"
         value_template: >-
           {% set pin_active = is_state('binary_sensor.active_LOCKNAME_TEMPLATENUM', 'on')  %}      
           {% set synched = is_state('binary_sensor.pin_synched_LOCKNAME_TEMPLATENUM', 'on')  %}      

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -428,6 +428,7 @@ timer:
 lock:
   - platform: template
     name: boltchecked_LOCKNAME
+    unique_id: "lock.boltchecked_LOCKNAME"
     value_template: "{{ is_state('LOCKENTITYNAME', 'locked') }}"
     lock:
       service: "{{ 'script.boltchecked_retry_LOCKNAME' if (is_state('DOORSENSORENTITYNAME', 'on')) else 'script.boltchecked_lock_LOCKNAME' }}"

--- a/custom_components/keymaster/keymaster_common_child.yaml
+++ b/custom_components/keymaster/keymaster_common_child.yaml
@@ -428,6 +428,7 @@ timer:
 lock:
   - platform: template
     name: boltchecked_LOCKNAME
+    unique_id: "lock.boltchecked_LOCKNAME"
     value_template: "{{ is_state('LOCKENTITYNAME', 'locked') }}"
     lock:
       service: "{{ 'script.boltchecked_retry_LOCKNAME' if (is_state('DOORSENSORENTITYNAME', 'on')) else 'script.boltchecked_lock_LOCKNAME' }}"


### PR DESCRIPTION
## Breaking change
If you have manually given any keymaster entities a unique_id in the keymaster yaml templates or generated yaml packages, this update will break after you regenerate the packages. If you have made any modifications to keymaster yaml, it is recommended to fully remove the keymaster integration and any manually altered entities before installing this update.


## Proposed change
Assign each entity which uses the template platform a unique_id matching it's entity_id. This will allow users to hide these entities from the Home Assistant default UI. 


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
This impacts binary_sensor, sensor, and lock domains.

Using entity_id as unique_id is designated as the id source of last resort in the HA developer documentation. However, since keymaster already assumes entity_id to be unique within the given HA instance, the impact of this is negligible. 

Generating UUIDs on demand was considered and experimentally implemented. However, the need to maintain a separate registry of UUIDs led to too many edge cases. The proposed solution was selected for its simplicity and stability. 

When combined with the additional search and filtering features of HA 2024.4, this makes it possible to hide all keymaster entities for a given lock by searching for your LOCKNAME in the entities list, selecting all, and then selecting hide. If LOCKNAME is not unique to keymaster, entities which share that string will need to be filtered out by the user. 

The need for unique LOCKNAME strings could be addressed by prefixing all keymaster entities with "keymaster_". However, that would be a breaking change for all users and is therefore omitted in this PR. 


- This PR is related to issue: #298 
