### PR TITLE
fix: add additional unique_ids to child automations

### DIFF
--- a/custom_components/keymaster/keymaster_child.yaml
+++ b/custom_components/keymaster/keymaster_child.yaml
@@ -383,6 +383,7 @@ automation:
           datetime: "{{ states.input_datetime.end_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_sun_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_sun_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.sun_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -400,6 +401,7 @@ automation:
         entity_id: input_boolean.sun_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_sun_inc_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_sun_inc_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.sun_inc_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -417,6 +419,7 @@ automation:
         entity_id: input_boolean.sun_inc_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_sun_start_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_sun_start_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.sun_start_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -432,6 +435,7 @@ automation:
           time: "{{ states.input_datetime.sun_start_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_sun_end_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_sun_end_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.sun_end_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -447,6 +451,7 @@ automation:
           time: "{{ states.input_datetime.sun_end_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_mon_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_mon_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.mon_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -464,6 +469,7 @@ automation:
         entity_id: input_boolean.mon_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_mon_inc_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_mon_inc_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.mon_inc_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -481,6 +487,7 @@ automation:
         entity_id: input_boolean.mon_inc_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_mon_start_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_mon_start_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.mon_start_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -496,6 +503,7 @@ automation:
           time: "{{ states.input_datetime.mon_start_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_mon_end_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_mon_end_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.mon_end_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -511,6 +519,7 @@ automation:
           time: "{{ states.input_datetime.mon_end_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_tue_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_tue_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.tue_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -528,6 +537,7 @@ automation:
         entity_id: input_boolean.tue_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_tue_inc_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_tue_inc_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.tue_inc_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -545,6 +555,7 @@ automation:
         entity_id: input_boolean.tue_inc_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_tue_start_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_tue_start_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.tue_start_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -560,6 +571,7 @@ automation:
           time: "{{ states.input_datetime.tue_start_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_tue_end_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_tue_end_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.tue_end_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -575,6 +587,7 @@ automation:
           time: "{{ states.input_datetime.tue_end_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_wed_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_wed_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.wed_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -592,6 +605,7 @@ automation:
         entity_id: input_boolean.wed_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_wed_inc_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_wed_inc_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.wed_inc_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -609,6 +623,7 @@ automation:
         entity_id: input_boolean.wed_inc_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_wed_start_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_wed_start_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.wed_start_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -624,6 +639,7 @@ automation:
           time: "{{ states.input_datetime.wed_start_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_wed_end_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_wed_end_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.wed_end_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -639,6 +655,7 @@ automation:
           time: "{{ states.input_datetime.wed_end_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_thu_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_thu_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.thu_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -656,6 +673,7 @@ automation:
         entity_id: input_boolean.thu_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_thu_inc_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_thu_inc_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.thu_inc_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -673,6 +691,7 @@ automation:
         entity_id: input_boolean.thu_inc_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_thu_start_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_thu_start_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.thu_start_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -688,6 +707,7 @@ automation:
           time: "{{ states.input_datetime.thu_start_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_thu_end_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_thu_end_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.thu_end_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -703,6 +723,7 @@ automation:
           time: "{{ states.input_datetime.thu_end_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_fri_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_fri_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.fri_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -720,6 +741,7 @@ automation:
         entity_id: input_boolean.fri_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_fri_inc_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_fri_inc_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.fri_inc_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -737,6 +759,7 @@ automation:
         entity_id: input_boolean.fri_inc_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_fri_start_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_fri_start_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.fri_start_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -752,6 +775,7 @@ automation:
           time: "{{ states.input_datetime.fri_start_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_fri_end_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_fri_end_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.fri_end_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -767,6 +791,7 @@ automation:
           time: "{{ states.input_datetime.fri_end_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_sat_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_sat_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.sat_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -784,6 +809,7 @@ automation:
         entity_id: input_boolean.sat_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_sat_inc_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_sat_inc_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_boolean.sat_inc_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -801,6 +827,7 @@ automation:
         entity_id: input_boolean.sat_inc_LOCKNAME_TEMPLATENUM
 
   - alias: keymaster_copy_PARENTLOCK_sat_start_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_sat_start_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.sat_start_date_PARENTLOCK_TEMPLATENUM
       platform: state
@@ -816,6 +843,7 @@ automation:
           time: "{{ states.input_datetime.sat_start_date_PARENTLOCK_TEMPLATENUM.state }}"
 
   - alias: keymaster_copy_PARENTLOCK_sat_end_date_LOCKNAME_TEMPLATENUM
+    id: keymaster_copy_PARENTLOCK_sat_end_date_LOCKNAME_TEMPLATENUM
     trigger:
       entity_id: input_datetime.sat_end_date_PARENTLOCK_TEMPLATENUM
       platform: state


### PR DESCRIPTION
## Proposed change
Added additional unique_ids to child lock "copy" automations to allow them to be managed in the UI 
Followed the same naming convention as other automations that already had unique_ids

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #360 
