### PR TITLE
Added better notification template for lock events and open close

### DIFF
--- a/custom_components/keymaster/const.py
+++ b/custom_components/keymaster/const.py
@@ -26,6 +26,7 @@ ATTR_ACTION_CODE = "action_code"
 ATTR_ACTION_TEXT = "action_text"
 ATTR_CODE_SLOT_NAME = "code_slot_name"
 ATTR_NOTIFICATION_SOURCE = "notification_source"
+ATTR_DATE_TIME_NOW = "date_time_now"
 
 # Attributes
 ATTR_CODE_SLOT = "code_slot"

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 import logging
 import os
 from typing import Dict, List, Optional, Tuple
+import time
 
 from homeassistant.components.automation import DOMAIN as AUTO_DOMAIN
 from homeassistant.components.input_boolean import DOMAIN as IN_BOOL_DOMAIN
@@ -39,6 +40,7 @@ from .const import (
     ATTR_ACTION_CODE,
     ATTR_ACTION_TEXT,
     ATTR_CODE_SLOT_NAME,
+    ATTR_DATE_TIME_NOW,
     ATTR_NAME,
     ATTR_NOTIFICATION_SOURCE,
     CHILD_LOCKS,
@@ -257,6 +259,7 @@ def handle_zwave_js_event(hass: HomeAssistant, config_entry: ConfigEntry, evt: E
                     if code_slot_name_state is not None
                     else ""
                 ),
+                ATTR_DATE_TIME_NOW: get_friendly_datetime(),
             },
         )
         return
@@ -360,6 +363,7 @@ def handle_state_change(
                     if code_slot_name_state is not None
                     else ""
                 ),
+                ATTR_DATE_TIME_NOW: get_friendly_datetime(),
             },
         )
         return
@@ -424,3 +428,12 @@ async def async_reload_package_platforms(hass: HomeAssistant) -> bool:
         except ServiceNotFound:
             return False
     return True
+
+
+def get_friendly_datetime():
+    """Get the current time with local timezone information and format to hh:mm PM/AM abr_month_name DD"""
+    local_time = time.localtime()
+
+    friendly_time = time.strftime("%I:%M %p %b %d", local_time)
+
+    return friendly_time

--- a/custom_components/keymaster/keymaster_common.yaml
+++ b/custom_components/keymaster/keymaster_common.yaml
@@ -161,8 +161,7 @@ automation:
     action:
       - service: script.keymaster_LOCKNAME_manual_notify
         data_template:
-          title: CASE_LOCK_NAME
-          message: "{{ trigger.event.data.action_text }} {% if trigger.event.data.code_slot > 0 %}({{ trigger.event.data.code_slot_name }}){% endif %}"
+          message: "LOCKNAME {{ trigger.event.data.state }}{% if trigger.event.data.code_slot > 0 %} by {{ trigger.event.data.code_slot_name }}{% endif %} {{ trigger.event.data.date_time_now }}"
 
   - alias: keymaster_CASE_LOCK_NAME User Notifications
     id: keymaster_CASE_LOCK_NAME User Notifications
@@ -182,8 +181,7 @@ automation:
     action:
       - service: script.keymaster_LOCKNAME_manual_notify
         data_template:
-          title: CASE_LOCK_NAME
-          message: "{{ trigger.event.data.action_text }} ({{ trigger.event.data.code_slot_name }})"
+          message: "LOCKNAME {{ trigger.event.data.state }}{% if trigger.event.data.code_slot > 0 %} by {{ trigger.event.data.code_slot_name }}{% endif %} {{ trigger.event.data.date_time_now }}"
 
   - alias: keymaster_CASE_LOCK_NAME Door Open and Close
     id: keymaster_CASE_LOCK_NAME Door Open and Close
@@ -199,8 +197,7 @@ automation:
     action:
       - service: script.keymaster_LOCKNAME_manual_notify
         data_template:
-          title: CASE_LOCK_NAME
-          message: "{% if trigger.to_state.state == 'on' %}Door Opened{% else %}Door Closed{% endif %}"
+          message: "LOCKNAME {% if trigger.to_state.state == 'on' %}opened{% else %}closed{% endif %} {{ trigger.event.data.date_time_now }}"
 
   - alias: keymaster_CASE_LOCK_NAME Changed Code
     id: keymaster_CASE_LOCK_NAME Changed Code

--- a/custom_components/keymaster/keymaster_common_child.yaml
+++ b/custom_components/keymaster/keymaster_common_child.yaml
@@ -161,8 +161,7 @@ automation:
     action:
       - service: script.keymaster_LOCKNAME_manual_notify
         data_template:
-          title: CASE_LOCK_NAME
-          message: "{{ trigger.event.data.action_text }} {% if trigger.event.data.code_slot > 0 %}({{ trigger.event.data.code_slot_name }}){% endif %}"
+          message: "LOCKNAME {{ trigger.event.data.state }}{% if trigger.event.data.code_slot > 0 %} by {{ trigger.event.data.code_slot_name }}{% endif %} {{ trigger.event.data.date_time_now }}"
 
   - alias: keymaster_CASE_LOCK_NAME User Notifications
     id: keymaster_CASE_LOCK_NAME User Notifications
@@ -182,8 +181,7 @@ automation:
     action:
       - service: script.keymaster_LOCKNAME_manual_notify
         data_template:
-          title: CASE_LOCK_NAME
-          message: "{{ trigger.event.data.action_text }} ({{ trigger.event.data.code_slot_name }})"
+          message: "LOCKNAME {{ trigger.event.data.state }}{% if trigger.event.data.code_slot > 0 %} by {{ trigger.event.data.code_slot_name }}{% endif %} {{ trigger.event.data.date_time_now }}"
 
   - alias: keymaster_CASE_LOCK_NAME Door Open and Close
     id: keymaster_CASE_LOCK_NAME Door Open and Close
@@ -199,8 +197,7 @@ automation:
     action:
       - service: script.keymaster_LOCKNAME_manual_notify
         data_template:
-          title: CASE_LOCK_NAME
-          message: "{% if trigger.to_state.state == 'on' %}Door Opened{% else %}Door Closed{% endif %}"
+          message: "LOCKNAME {% if trigger.to_state.state == 'on' %}opened{% else %}closed{% endif %} {{ trigger.event.data.date_time_now }}"
 
   - alias: keymaster_CASE_LOCK_NAME Changed Code
     id: keymaster_CASE_LOCK_NAME Changed Code

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,4 @@
-""" Test keymaster helpers """
+"""Test keymaster helpers"""
 
 from unittest.mock import patch
 
@@ -9,11 +9,15 @@ from custom_components.keymaster.const import (
     ATTR_ACTION_TEXT,
     ATTR_CODE_SLOT,
     ATTR_CODE_SLOT_NAME,
+    ATTR_DATE_TIME_NOW,
     ATTR_NAME,
     DOMAIN,
     EVENT_KEYMASTER_LOCK_STATE_CHANGED,
 )
-from custom_components.keymaster.helpers import delete_lock_and_base_folder
+from custom_components.keymaster.helpers import (
+    delete_lock_and_base_folder,
+    get_friendly_datetime,
+)
 from homeassistant.const import (
     ATTR_STATE,
     EVENT_HOMEASSISTANT_STARTED,
@@ -142,6 +146,7 @@ async def test_handle_state_change_zwave_js(
     assert events[0].data[ATTR_ACTION_TEXT] == "Keypad unlock operation"
     assert events[0].data[ATTR_CODE_SLOT] == 3
     assert events[0].data[ATTR_CODE_SLOT_NAME] == ""
+    assert events[0].data[ATTR_DATE_TIME_NOW] == get_friendly_datetime()
 
     assert events_js[0].data["type"] == 6
     assert events_js[0].data["event"] == 5


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The yaml template notification message can break while using the action state variable. For example, in my setup, the action state message is not very descriptive. This PR refactors the notification to a better, more versatile template.

![image](https://github.com/user-attachments/assets/39a8a3a9-804b-40b3-bc1f-fb9a97d34904)

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Code quality improvements to existing code or addition of tests

