### PR TITLE
refactor: change `STATE_LOCKED` and `STATE_UNLOCKED` to use `LockState`

### DIFF
--- a/custom_components/keymaster/const.py
+++ b/custom_components/keymaster/const.py
@@ -1,6 +1,6 @@
 """Constants for keymaster."""
 
-from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
+from homeassistant.components.lock.const import LockState
 
 DOMAIN = "keymaster"
 VERSION = "v0.0.0"  # this will be automatically updated as part of the release workflow
@@ -115,11 +115,11 @@ ACTION_MAP = {
 
 LOCK_STATE_MAP = {
     ALARM_TYPE: {
-        STATE_LOCKED: 24,
-        STATE_UNLOCKED: 25,
+        LockState.LOCKED: 24,
+        LockState.UNLOCKED: 25,
     },
     ACCESS_CONTROL: {
-        STATE_LOCKED: 3,
-        STATE_UNLOCKED: 4,
+        LockState.LOCKED: 3,
+        LockState.UNLOCKED: 4,
     },
 }


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This change is incompatible with older versions of Home Assistant before `2024.9.0`


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use `LockState` enum and remove deprecated constants `STATE_LOCKED` and `STATE_UNLOCKED`

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #386 