### PR TITLE
beta: Only slugify lock name when needed

### DIFF
--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -60,7 +60,7 @@ class KeymasterFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Check if name is unique, returning dictionary error if so"""
         # Validate that lock name is unique
         existing_entry = await self.async_set_unique_id(
-            user_input[CONF_LOCK_NAME], raise_on_progress=True
+            slugify(user_input[CONF_LOCK_NAME]).lower(), raise_on_progress=True
         )
         if existing_entry:
             return {CONF_LOCK_NAME: "same_name"}
@@ -95,9 +95,9 @@ class KeymasterOptionsFlow(config_entries.OptionsFlow):
         """Check if name is unique, returning dictionary error if so"""
         # If lock name has changed, make sure new name isn't already being used
         # otherwise show an error
-        if self.config_entry.unique_id != user_input[CONF_LOCK_NAME]:
+        if self.config_entry.unique_id != slugify(user_input[CONF_LOCK_NAME]).lower():
             for entry in self.hass.config_entries.async_entries(DOMAIN):
-                if entry.unique_id == user_input[CONF_LOCK_NAME]:
+                if entry.unique_id == slugify(user_input[CONF_LOCK_NAME]).lower():
                     return {CONF_LOCK_NAME: "same_name"}
         return {}
 
@@ -296,7 +296,6 @@ async def _start_config_flow(
     description_placeholders = {}
 
     if user_input is not None:
-        user_input[CONF_LOCK_NAME] = slugify(user_input[CONF_LOCK_NAME].lower())
         user_input[CONF_SLOTS] = int(user_input.get(CONF_SLOTS))
         user_input[CONF_START] = int(user_input.get(CONF_START))
 

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -47,7 +47,7 @@ from homeassistant.core import CoreState, Event, EventStateChangedData, HomeAssi
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_call_later, async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, slugify
 
 from .const import (
     ACCESS_CONTROL,
@@ -943,13 +943,14 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if kmlock.retry_lock and kmlock.pending_retry_lock:
             await self._lock_lock(kmlock=kmlock)
             await dismiss_persistent_notification(
-                hass=self.hass, notification_id=f"{kmlock.lock_name}_autolock_door_open"
+                hass=self.hass,
+                notification_id=f"{slugify(kmlock.lock_name).lower()}_autolock_door_open",
             )
             await send_persistent_notification(
                 hass=self.hass,
                 title=f"{kmlock.lock_name} is closed",
                 message=f"The {kmlock.lock_name} sensor indicates the door has been closed, re-attempting to lock.",
-                notification_id=f"{kmlock.lock_name}_autolock_door_closed",
+                notification_id=f"{slugify(kmlock.lock_name).lower()}_autolock_door_closed",
             )
 
         if kmlock.door_notifications:
@@ -998,7 +999,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 hass=self.hass,
                 title=f"Unable to lock {kmlock.lock_name}",
                 message=f"Unable to lock {kmlock.lock_name} as the sensor indicates the door is currently opened.  The operation will be automatically retried when the door is closed.",
-                notification_id=f"{kmlock.lock_name}_autolock_door_open",
+                notification_id=f"{slugify(kmlock.lock_name).lower()}_autolock_door_open",
             )
         else:
             await self._lock_lock(kmlock=kmlock)

--- a/custom_components/keymaster/lovelace.py
+++ b/custom_components/keymaster/lovelace.py
@@ -73,7 +73,7 @@ async def generate_lovelace(
         {
             "type": "sections",
             "max_columns": 4,
-            "title": f"{kmlock_name.replace('_',' ').title()}",
+            "title": f"{kmlock_name}",
             "path": f"keymaster_{kmlock_name}",
             "badges": mapped_badges_list,
             "sections": lovelace_list,

--- a/custom_components/keymaster/sensor.py
+++ b/custom_components/keymaster/sensor.py
@@ -113,12 +113,5 @@ class KeymasterSensor(KeymasterEntity, SensorEntity):
             return
 
         self._attr_available = True
-        if self._property.endswith(".lock_name") or self._property.endswith(
-            ".parent_name"
-        ):
-            self._attr_native_value = (
-                self._get_property_value().replace("_", " ").title()
-            )
-        else:
-            self._attr_native_value = self._get_property_value()
+        self._attr_native_value = self._get_property_value()
         self.async_write_ha_state()


### PR DESCRIPTION
## Proposed change
Only slugify lock name when needed. Lock name is no longer used to match-up entities so it can remain more user friendly (with caps and spacing). Will just slugify it when needed behind the scenes.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
