### PR TITLE
beta: Fix deprecation of async_config_entry_first_refresh

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -10,6 +10,7 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.event import async_call_later
 
@@ -104,7 +105,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if COORDINATOR not in hass.data[DOMAIN]:
         coordinator: KeymasterCoordinator = KeymasterCoordinator(hass)
         hass.data[DOMAIN][COORDINATOR] = coordinator
-        await coordinator.async_config_entry_first_refresh()
+        await coordinator.initial_setup()
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
+            raise ConfigEntryNotReady from coordinator.last_exception
     else:
         coordinator = hass.data[DOMAIN][COORDINATOR]
 

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import datetime, timedelta
 import functools
 import logging
 
@@ -222,14 +222,15 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
         await coordinator.delete_lock_by_config_entry_id(config_entry.entry_id)
 
-        if len(coordinator.data) <= 1:
+        if coordinator.count_locks_not_pending_delete == 0:
             _LOGGER.debug(
                 "[async_unload_entry] Possibly empty coordinator. "
-                "Will evaluate for removal in 30 seconds"
+                "Will evaluate for removal at %s",
+                datetime.now().astimezone() + timedelta(seconds=20),
             )
             async_call_later(
                 hass=hass,
-                delay=30,
+                delay=20,
                 action=functools.partial(delete_coordinator, hass),
             )
     return unload_ok

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -120,6 +120,9 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         self._json_filename: str = f"{DOMAIN}_kmlocks.json"
 
+    async def initial_setup(self) -> bool:
+        await self._async_setup()
+
     async def _async_setup(self) -> None:
         _LOGGER.info(
             "Keymaster %s is starting, if you have any issues please report them here: %s",

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1225,7 +1225,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         _LOGGER.debug(
             "[delete_lock_by_config_entry_id] %s: Scheduled to delete at %s",
             kmlock.lock_name,
-            datetime.now().astimezone() + timedelta(seconds=15),
+            datetime.now().astimezone() + timedelta(seconds=10),
         )
         kmlock.listeners.append(
             async_call_later(
@@ -1234,6 +1234,14 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 action=functools.partial(self._delete_lock, kmlock),
             )
         )
+
+    @property
+    def count_locks_not_pending_delete(self):
+        count = 0
+        for kmlock in self.kmlocks.values():
+            if not kmlock.pending_delete:
+                count += 1
+        return count
 
     async def get_lock_by_config_entry_id(
         self, config_entry_id: str

--- a/custom_components/keymaster/lock.py
+++ b/custom_components/keymaster/lock.py
@@ -98,6 +98,7 @@ keymasterlock_type_lookup: Mapping[str, Any] = {
     "code_slots": Mapping[int, KeymasterCodeSlot],
     "lock_notifications": bool,
     "door_notifications": bool,
+    "notify_script_name": str,
     "lock_state": str,
     "door_state": str,
     "autolock_enabled": bool,

--- a/custom_components/keymaster/migrate.py
+++ b/custom_components/keymaster/migrate.py
@@ -20,7 +20,7 @@ from homeassistant.components.timer import DOMAIN as TIMER_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceNotFound
+from homeassistant.exceptions import ConfigEntryNotReady, ServiceNotFound
 from homeassistant.helpers import entity_registry as er
 
 from .const import (
@@ -75,7 +75,10 @@ async def migrate_2to3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     if COORDINATOR not in hass.data[DOMAIN]:
         coordinator: KeymasterCoordinator = KeymasterCoordinator(hass)
         hass.data[DOMAIN][COORDINATOR] = coordinator
-        await coordinator.async_config_entry_first_refresh()
+        await coordinator.initial_setup()
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
+            raise ConfigEntryNotReady from coordinator.last_exception
     else:
         coordinator = hass.data[DOMAIN][COORDINATOR]
 

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 from homeassistant.helpers import selector
 
 from .const import (
@@ -38,7 +38,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     if COORDINATOR not in hass.data[DOMAIN]:
         coordinator: KeymasterCoordinator = KeymasterCoordinator(hass)
         hass.data[DOMAIN][COORDINATOR] = coordinator
-        await coordinator.async_config_entry_first_refresh()
+        await coordinator.initial_setup()
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
+            raise ConfigEntryNotReady from coordinator.last_exception
     else:
         coordinator = hass.data[DOMAIN][COORDINATOR]
 


### PR DESCRIPTION
## Proposed change
https://github.com/home-assistant/core/pull/128082

Using async_config_entry_first_refresh with the Coordinator not linked to a config entry is now deprecated.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
