### PR TITLE
fix: fix code slot notifications

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -831,6 +831,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
             if kmlock.code_slots[code_slot_num].notifications and not kmlock.lock_notifications:
                 if kmlock.code_slots[code_slot_num].name:
+                    message = event_label
                     message = (
                         f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
                     )


### PR DESCRIPTION
Line 834 added. The initial message string was missing, causing an exception that killed the notification. This effectively disabled all code-specific notifications and required the use of global notifications.

## Breaking change
None


## Proposed change
Line 834 added. The initial message string was missing, causing an exception that killed the notification. This effectively disabled all code-specific notifications and required the use of global notifications.


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes half of #449 
