### PR TITLE
Fix: Update reconfigure to handle None values

### DIFF
--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -89,6 +89,33 @@ class KeymasterConfigFlow(ConfigFlow, domain=DOMAIN):
         assert self._entry
         self._data = dict(self._entry.data)
 
+        _LOGGER.debug(
+            "[async_step_reconfigure] entry_id: %s, data: %s",
+            self._entry.entry_id,
+            self._data,
+        )
+
+        # Convert None to (none)
+        if self._data[CONF_DOOR_SENSOR_ENTITY_ID] is None:
+            self._data[CONF_DOOR_SENSOR_ENTITY_ID] = NONE_TEXT
+        if self._data[CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID] is None:
+            self._data[CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID] = NONE_TEXT
+        if self._data[CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID] is None:
+            self._data[CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID] = NONE_TEXT
+
+        notify_scripts = _get_entities(
+            hass=self.hass,
+            domain=SCRIPT_DOMAIN,
+            extra_entities=[NONE_TEXT],
+        )
+
+        if self._data[CONF_NOTIFY_SCRIPT_NAME] not in notify_scripts:
+            _LOGGER.debug(
+                "[async_step_reconfigure] notify script %s not found, setting to NONE_TEXT",
+                self._data[CONF_NOTIFY_SCRIPT_NAME],
+            )
+            self._data[CONF_NOTIFY_SCRIPT_NAME] = NONE_TEXT
+
         return await _start_config_flow(
             cls=self,
             step_id="reconfigure",

--- a/custom_components/keymaster/strings.json
+++ b/custom_components/keymaster/strings.json
@@ -48,7 +48,7 @@
         },
         "description": "Select the lock to setup and code slots to create. There may or may not be alarm level and alarm type entities.",
         "title": "keymaster"
-      }      
+      }
     }
   }
 }

--- a/custom_components/keymaster/translations/en.json
+++ b/custom_components/keymaster/translations/en.json
@@ -48,7 +48,7 @@
         },
         "description": "Select the lock to setup and code slots to create. There may or may not be alarm level and alarm type entities.",
         "title": "keymaster"
-      }      
+      }
     }
   }
 }

--- a/custom_components/keymaster/translations/nb.json
+++ b/custom_components/keymaster/translations/nb.json
@@ -48,7 +48,7 @@
         },
         "description": "Velg låsen du vil sette opp og kodesporene du vil opprette.",
         "title": "keymaster"
-      }      
+      }
     }
   }
 }


### PR DESCRIPTION
None values were not properly being handled during the reconfigure flow
causing users to have to reselect the None options when they shouldn't
need to.

* minor linting picked up by ruff

Issue: Fixes #471
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
