### PR TITLE
Fixes some causes of  Issue #483

### DIFF
--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -166,7 +166,8 @@ def _get_entities(
 
     if exclude_entities:
         for ent in exclude_entities:
-            data.remove(ent)
+            if ent in data:
+                data.remove(ent)
     if sort:
         data.sort()
 

--- a/custom_components/keymaster/translations/en.json
+++ b/custom_components/keymaster/translations/en.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-        "reconfigure_successful": "Reconfigure Successful"
+        "reconfigure_successful": "Reconfigure Successful",
+        "no_locks": "No lock devices found. Make sure the lock device is added to the Z-Wave network first, then try again."
     },
     "error": {
       "same_name": "keymaster Lock Name already in use"

--- a/custom_components/keymaster/translations/nb.json
+++ b/custom_components/keymaster/translations/nb.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-        "reconfigure_successful": "Reconfigure Successful"
+        "reconfigure_successful": "Reconfigure Successful",
+        "no_locks": "No lock devices found. Make sure the lock device is added to the Z-Wave network first, then try again."
     },
     "error": {
       "same_name": "Name already in use"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -37,6 +37,16 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.asyncio
 
 
+async def test_no_locks_abort(hass):
+    """Test the flow aborts when no locks are available."""
+    with patch("custom_components.keymaster.config_flow._get_entities", return_value=[]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_locks"
+
+
 @pytest.mark.parametrize(
     ("test_user_input", "title", "final_config_flow_data"),
     [


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Error checking and graceful abort (no_locks) with user-friendly message during config_flow for some edge cases that are producing 500 errors without any explanation. 
- Error checking and graceful abort if excluded device isn't in the list. 
- New error message
- New test for config_flow graceful exit on "no_locks"


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
There may be additional causes for issue #483, but this fixes the most common one (no lock device found) and an edge case (excluded lock isn't in the set, when removing)

Tested with:
Installation method Home Assistant OS
Core 2025.9.1
Supervisor 2025.09.0
Operating System 16.2
Frontend 20250903.3

- This PR fixes or closes issue: fixes #483 
