### PR TITLE
Refactor of config and coordinator to make async with Z-Wave rate limiting

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.event import async_call_later
 
@@ -161,8 +161,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     try:
         await coordinator.add_lock(kmlock=kmlock)
-    except asyncio.exceptions.CancelledError as e:
-        _LOGGER.error("Timeout on add_lock. %s: %s", e.__class__.__qualname__, e)
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.error("Error adding lock. %s: %s", e.__class__.__qualname__, e)
+        msg = f"Error adding lock: {e}"
+        raise HomeAssistantError(msg) from e
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     await generate_lovelace(

--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -166,7 +166,8 @@ def _get_entities(
 
     if exclude_entities:
         for ent in exclude_entities:
-            data.remove(ent)
+            if ent in data:
+                data.remove(ent)
     if sort:
         data.sort()
 

--- a/custom_components/keymaster/migrate.py
+++ b/custom_components/keymaster/migrate.py
@@ -20,7 +20,7 @@ from homeassistant.components.timer import DOMAIN as TIMER_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from .const import (
@@ -84,8 +84,14 @@ async def migrate_2to3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
 
     try:
         await coordinator.add_lock(kmlock=kmlock, update=True)
-    except asyncio.exceptions.CancelledError as e:
-        _LOGGER.error("Timeout on add_lock. %s: %s", e.__class__.__qualname__, e)
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.error(
+            "Error adding lock during migration. %s: %s",
+            e.__class__.__qualname__,
+            e,
+        )
+        msg = f"Error adding lock: {e}"
+        raise HomeAssistantError(msg) from e
 
     # Delete Package files
     _LOGGER.info("[migrate_2to3] Deleting Package files")

--- a/custom_components/keymaster/strings.json
+++ b/custom_components/keymaster/strings.json
@@ -4,7 +4,8 @@
         "reconfigure_successful": "Reconfigure Successful"
     },
     "error": {
-      "same_name": "keymaster Lock Name already in use"
+      "same_name": "keymaster Lock Name already in use",
+      "add_lock_failed": "Failed to add lock: {error}"
     },
     "step": {
       "user": {

--- a/custom_components/keymaster/translations/en.json
+++ b/custom_components/keymaster/translations/en.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-        "reconfigure_successful": "Reconfigure Successful"
+        "reconfigure_successful": "Reconfigure Successful",
+        "no_locks": "No lock devices found. Make sure the lock device is added to the Z-Wave network first, then try again."
     },
     "error": {
       "same_name": "keymaster Lock Name already in use"

--- a/custom_components/keymaster/translations/en.json
+++ b/custom_components/keymaster/translations/en.json
@@ -5,7 +5,8 @@
         "no_locks": "No lock devices found. Make sure the lock device is added to the Z-Wave network first, then try again."
     },
     "error": {
-      "same_name": "keymaster Lock Name already in use"
+      "same_name": "keymaster Lock Name already in use",
+      "add_lock_failed": "Failed to add lock: {error}"
     },
     "step": {
       "user": {

--- a/custom_components/keymaster/translations/nb.json
+++ b/custom_components/keymaster/translations/nb.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-        "reconfigure_successful": "Reconfigure Successful"
+        "reconfigure_successful": "Reconfigure Successful",
+        "no_locks": "No lock devices found. Make sure the lock device is added to the Z-Wave network first, then try again."
     },
     "error": {
       "same_name": "Name already in use"

--- a/custom_components/keymaster/translations/nb.json
+++ b/custom_components/keymaster/translations/nb.json
@@ -5,7 +5,8 @@
         "no_locks": "No lock devices found. Make sure the lock device is added to the Z-Wave network first, then try again."
     },
     "error": {
-      "same_name": "Name already in use"
+      "same_name": "Name already in use",
+      "add_lock_failed": "Failed to add lock: {error}"
     },
     "step": {
       "user": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,14 +9,13 @@ from unittest.mock import DEFAULT, AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from zwave_js_server.model.driver import Driver
-from zwave_js_server.model.node import Node
-from zwave_js_server.version import VersionInfo
 
-from custom_components.keymaster.const import NONE_TEXT
-from homeassistant.components.zwave_js import PLATFORMS
+# Provide placeholder constants to avoid importing the integration at import time
+NONE_TEXT = "(none)"
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+
+PLATFORMS: list[Platform] = []
 
 from .common import load_fixture
 
@@ -235,7 +234,7 @@ async def integration_fixture(
         unique_id=str(client.driver.controller.home_id),
     )
     entry.add_to_hass(hass)
-    with patch("homeassistant.components.zwave_js.PLATFORMS", platforms):
+    with patch("homeassistant.components.zwave_js.PLATFORMS", platforms, create=True):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -37,6 +37,16 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.asyncio
 
 
+async def test_no_locks_abort(hass):
+    """Test the flow aborts when no locks are available."""
+    with patch("custom_components.keymaster.config_flow._get_entities", return_value=[]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_locks"
+
+
 @pytest.mark.parametrize(
     ("test_user_input", "title", "final_config_flow_data"),
     [


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

### Scenario

If we have many locks, many slots per lock, a congested Z-Wave network or S0_Legacy locks, keymaster's initialization will block HA startup main loop, timeout, and even flood the Z-Wave network with too much traffic. In the test instance, we initialized two locks as parent/child, with 99 slots each, both on S0_Legacy security which creates 3x the traffic. This implementation was able to complete initialization with 8000+ entities without interfering with HA's startup or flooding the Z-Wave. 

### Changes

We have refactored the config_flow and coordinator to use async operations and parallelization, everywhere. This frees up the main event loop and allows HA to startup normally. Z-Wave messages and initialization are now parallelized, not in a lock*slot nested loop.

Async operation however means we have to throttle the Z-Wave messages to prevent keymaster from flooding the network. We have added a generic _throttle function that wraps Z-Wave calls and keeps them to 10% of the max capacity of Z-Wave (configurable with constants in the code, conservative for now). 

With these changes, the timeout needed to be changed, so that keymaster startup wouldn't timeout part way through. We implemented a dynamic timeout that scales up based on the number of locks, number of slots and whether the locks are S2_Authenticated (efficient) or S0_Legacy (3x more traffic). With a dynamic timeout, the startup completes successfully. 

We added more robust exception handling, and error reporting so as to fail gracefully and inform the user.

Finally, the async operations, Z-Wave rate limiting, dynamic timeout, and exception handling have been covered with tests to avoid regression. 

This is a pretty hefty PR, but it has been tested and makes the initialization and updates of locks much more robust. 

### Test Instance Version

Installation method Home Assistant OS
Core 2025.9.1
Supervisor 2025.09.0
Operating System 16.2
Frontend 20250903.3

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

