### PR TITLE
fix: preserve plaintext PINs in UI by ignoring masked usercodes from lock

### DIFF
--- a/custom_components/keymaster/text.py
+++ b/custom_components/keymaster/text.py
@@ -135,11 +135,13 @@ class KeymasterText(KeymasterEntity, TextEntity):
                     config_entry_id=self._config_entry.entry_id,
                     code_slot_num=self._code_slot,
                     pin=value,
+                    set_in_kmlock=True,
                 )
             elif not value and self._code_slot:
                 await self.coordinator.clear_pin_from_lock(
                     config_entry_id=self._config_entry.entry_id,
                     code_slot_num=self._code_slot,
+                    clear_from_kmlock=True,
                 )
             else:
                 return


### PR DESCRIPTION
- Summary
  - After adding a PIN and syncing, the UI later showed “\*\*\*\*\*”. Root cause: we overwrote the locally stored clear PIN with the lock-reported usercode from Z‑Wave JS, which many locks redact (e.g., “\*\*\*\*\*\*”). The UI simply displays whatever is in `kmlock.code_slots[n].pin`.

- What changed
  - coordinator.py
    - `_sync_pin(...)`: Only adopt the lock’s usercode if it’s all digits (i.e., looks like a real code). If the lock reports a redacted or non-digit value, keep the locally stored PIN and still mark the slot `Synced`. If the lock reports empty but the slot is enabled/active and we have a local PIN, push our local PIN back to the lock. Clear the lock when the slot is disabled/inactive.
  - text.py
    - `async_set_value(...)`: When setting a PIN from the UI, pass `set_in_kmlock=True` so the clear PIN is persisted in memory immediately. When clearing, pass `clear_from_kmlock=True` to clear in-memory state as well.

- Why
  - Locks (and Z‑Wave JS) often redact usercodes on read. If we adopt that value, we replace our clear PIN with “******” in memory/JSON, and the UI then shows asterisks. By preferring the local value unless we get a concrete numeric usercode from the lock, plaintext remains visible in the UI (when the “hide pins” option is off), and behavior remains correct.

- Behavior before vs after
  - Before: After sync, lock’s redacted value overwrote local PIN → UI flipped to “******”.
  - After: Adding a PIN keeps UI plaintext. If the lock reports a real numeric code, we adopt it; if it reports masked/empty for an enabled+active slot, we keep/enforce the local clear PIN. Disabled/inactive slots still clear the lock as before.

- Persistence
  - Keymaster already persists PINs (salted/base64) to JSON and decodes them at startup. This continues unchanged; we simply avoid overwriting the saved clear PIN with redacted values.

- Security considerations
  - This affects display logic only when “hide pins” is false. Storage remains encoded (salted base64) as before.

- Testing
  - Add new PIN in UI → verify UI stays plaintext after “Synced”.
  - Restart Home Assistant → UI still shows plaintext (from decoded JSON).
  - Change code on the lock:
    - If the lock reports digits → local PIN adopts the lock value.
    - If the lock reports masked/empty → local PIN remains and is re-enforced when applicable (slot enabled/active).
  - Toggle slot enabled/active and confirm set/clear flows still function.

- Follow-ups (optional)
  - If desired, bound “real code” adoption by length (e.g., 4–8 digits).
  - Consider improving sync-status transitions when updating an already-synced code.

Commit message suggestion
- Subject: Preserve plaintext PINs in UI by ignoring redacted lock usercodes; persist local PIN on set
- Body: Prefer local clear PIN unless the lock reports an all-digit usercode. Update in-memory state immediately on UI set/clear. Prevents UI flipping to “******” after sync while maintaining correct syncing behavior.

- This PR fixes or closes issue: fixes #476 
- This PR is related to issue: 
