### PR TITLE
Drop python 3.11 and 3.12 support

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -20,9 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - name: 🛠️ Set up Python
-        uses: actions/setup-python@v5
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: 🛠️ Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,14 @@ venv
 coverage.xml
 .tox
 ha-core/
+
+# Node.js / TypeScript build
+node_modules/
+yarn.lock
+package-lock.json
+
+# AI assistant files
+.claude/
+.cursor/
+.aider*
+.continue/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -627,15 +627,14 @@ property-decorators = ["propcache.cached_property"]
 
 [tool.tox.gh-actions]
 python = """
-    3.11: py311
-    3.12: py312
     3.13: py313, lint, mypy
+    3.14: py314
 """
 
 [tool.tox]
 skipsdist = true
 requires = ["tox>=4.19"]
-env_list = ["py311", "py312", "py313", "lint", "mypy"]
+env_list = ["py313", "py314", "lint", "mypy"]
 skip_missing_interpreters = true
 
 [tool.tox.env_run_base]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -362,20 +362,8 @@ def mock_async_call_later():
 
 
 @pytest.fixture(name="keymaster_integration")
-async def mock_keymaster_integration(hass, client):
-    """Fixture to bypass zwavejs checks."""
-    entry = MockConfigEntry(
-        domain="zwave_js",
-        data={"url": "ws://test.org"},
-        unique_id=str(client.driver.controller.home_id),
-    )
-    entry.add_to_hass(hass)
-    with patch("homeassistant.components.zwave_js.PLATFORMS", platforms):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    client.async_send_command.reset_mock()
-
+async def mock_keymaster_integration(hass, integration):
+    """Fixture to bypass zwavejs checks. Depends on integration fixture for zwave_js."""
     with (
         patch(
             "custom_components.keymaster.KeymasterCoordinator._connect_and_update_lock",
@@ -394,4 +382,4 @@ async def mock_keymaster_integration(hass, client):
             return_value=True,
         ),
     ):
-        yield
+        yield integration


### PR DESCRIPTION
## Breaking change
Installations that rely on python3.11 or python3.12 are no longer supported. Home Assistant has required python3.13 since the 2024.12 release.


## Proposed change
- updated test targets: remove python 3.11/3.12 and added 3.14
- added gitignore from my other PR
- remove duplicate setup-python step in pytest CI workflow


## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
