### PR TITLE
perf: remove redundant default properties from lovelace output

### DIFF
--- a/custom_components/keymaster/lovelace.py
+++ b/custom_components/keymaster/lovelace.py
@@ -324,7 +324,6 @@ def _generate_code_slot_dict(
                 "type": "heading",
                 "heading": f"Code Slot {code_slot_num}",
                 "heading_style": "title",
-                "badges": [],
             },
             {
                 "type": "conditional",
@@ -337,43 +336,23 @@ def _generate_code_slot_dict(
                         {
                             "entity": f"text.code_slots:{code_slot_num}.name",
                             "name": "Name",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"text.code_slots:{code_slot_num}.pin",
                             "name": "PIN",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {"type": "divider"},
                         {
                             "entity": f"switch.code_slots:{code_slot_num}.enabled",
                             "name": "Enabled",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"binary_sensor.code_slots:{code_slot_num}.active",
                             "name": "Active",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"sensor.code_slots:{code_slot_num}.synced",
                             "name": "Sync Status",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                     ],
                 },
@@ -385,10 +364,6 @@ def _generate_code_slot_dict(
             {
                 "entity": f"switch.code_slots:{code_slot_num}.override_parent",
                 "name": "Override Parent",
-                "secondary_info": "none",
-                "tap_action": {"action": "none"},
-                "hold_action": {"action": "none"},
-                "double_tap_action": {"action": "none"},
             }
         )
     code_slot_dict["cards"][1]["card"]["entities"].extend(
@@ -396,19 +371,11 @@ def _generate_code_slot_dict(
             {
                 "entity": f"switch.code_slots:{code_slot_num}.notifications",
                 "name": "Notifications",
-                "secondary_info": "none",
-                "tap_action": {"action": "none"},
-                "hold_action": {"action": "none"},
-                "double_tap_action": {"action": "none"},
             },
             {"type": "divider"},
             {
                 "entity": f"switch.code_slots:{code_slot_num}.accesslimit_count_enabled",
                 "name": "Limit by Number of Uses",
-                "secondary_info": "none",
-                "tap_action": {"action": "none"},
-                "hold_action": {"action": "none"},
-                "double_tap_action": {"action": "none"},
             },
             {
                 "type": "conditional",
@@ -421,10 +388,6 @@ def _generate_code_slot_dict(
                 "row": {
                     "entity": f"number.code_slots:{code_slot_num}.accesslimit_count",
                     "name": "Uses Remaining",
-                    "secondary_info": "none",
-                    "tap_action": {"action": "none"},
-                    "hold_action": {"action": "none"},
-                    "double_tap_action": {"action": "none"},
                 },
             },
         ]
@@ -436,10 +399,6 @@ def _generate_code_slot_dict(
                 {
                     "entity": f"switch.code_slots:{code_slot_num}.accesslimit_date_range_enabled",
                     "name": "Limit by Date Range",
-                    "secondary_info": "none",
-                    "tap_action": {"action": "none"},
-                    "hold_action": {"action": "none"},
-                    "double_tap_action": {"action": "none"},
                 },
                 {
                     "type": "conditional",
@@ -452,10 +411,6 @@ def _generate_code_slot_dict(
                     "row": {
                         "entity": f"datetime.code_slots:{code_slot_num}.accesslimit_date_range_start",
                         "name": "Date Range Start",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -469,10 +424,6 @@ def _generate_code_slot_dict(
                     "row": {
                         "entity": f"datetime.code_slots:{code_slot_num}.accesslimit_date_range_end",
                         "name": "Date Range End",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
             ]
@@ -484,10 +435,6 @@ def _generate_code_slot_dict(
                 {
                     "entity": f"switch.code_slots:{code_slot_num}.accesslimit_day_of_week_enabled",
                     "name": "Limit by Day of Week",
-                    "secondary_info": "none",
-                    "tap_action": {"action": "none"},
-                    "hold_action": {"action": "none"},
-                    "double_tap_action": {"action": "none"},
                 },
             ]
         )
@@ -509,11 +456,8 @@ def _generate_lock_badges(
         {
             "type": "entity",
             "show_name": False,
-            "show_state": True,
-            "show_icon": True,
             "entity": "sensor.lock_name",
             "color": "",
-            "tap_action": {"action": "none"},
         }
     ]
     if child:
@@ -521,30 +465,22 @@ def _generate_lock_badges(
             {
                 "type": "entity",
                 "show_name": True,
-                "show_state": True,
-                "show_icon": True,
                 "entity": "sensor.parent_name",
                 "name": "Parent Lock",
                 "color": "",
-                "tap_action": {"action": "none"},
-            }
+                }
         )
     badges.extend(
         [
             {
                 "type": "entity",
                 "show_name": False,
-                "show_state": True,
-                "show_icon": True,
                 "entity": "binary_sensor.connected",
                 "color": "",
-                "tap_action": {"action": "none"},
-            },
+                },
             {
                 "type": "entity",
                 "show_name": True,
-                "show_state": True,
-                "show_icon": True,
                 "entity": "switch.lock_notifications",
                 "color": "",
                 "name": "Lock Notifications",
@@ -557,8 +493,6 @@ def _generate_lock_badges(
             {
                 "type": "entity",
                 "show_name": True,
-                "show_state": True,
-                "show_icon": True,
                 "entity": "switch.door_notifications",
                 "color": "",
                 "tap_action": {"action": "toggle"},
@@ -569,8 +503,6 @@ def _generate_lock_badges(
         {
             "type": "entity",
             "show_name": True,
-            "show_state": True,
-            "show_icon": True,
             "entity": lock_entity,
             "name": "Lock",
             "color": "",
@@ -582,20 +514,15 @@ def _generate_lock_badges(
             {
                 "type": "entity",
                 "show_name": True,
-                "show_state": True,
-                "show_icon": True,
                 "entity": door_sensor,
                 "name": "Door",
                 "color": "",
-                "tap_action": {"action": "none"},
-            }
+                }
         )
     badges.append(
         {
             "type": "entity",
             "show_name": True,
-            "show_state": True,
-            "show_icon": True,
             "entity": "switch.autolock_enabled",
             "color": "",
             "tap_action": {"action": "toggle"},
@@ -607,8 +534,6 @@ def _generate_lock_badges(
             {
                 "type": "entity",
                 "show_name": True,
-                "show_state": True,
-                "show_icon": True,
                 "entity": "switch.retry_lock",
                 "color": "",
                 "tap_action": {"action": "toggle"},
@@ -627,8 +552,6 @@ def _generate_lock_badges(
             {
                 "type": "entity",
                 "show_name": True,
-                "show_state": True,
-                "show_icon": True,
                 "entity": "number.autolock_min_day",
                 "color": "",
                 "name": "Day Auto Lock",
@@ -643,8 +566,6 @@ def _generate_lock_badges(
             {
                 "type": "entity",
                 "show_name": True,
-                "show_state": True,
-                "show_icon": True,
                 "entity": "number.autolock_min_night",
                 "color": "",
                 "name": "Night Auto Lock",
@@ -678,10 +599,6 @@ def _generate_dow_entities(code_slot_num: int) -> list[MutableMapping[str, Any]]
                     "row": {
                         "entity": f"switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.dow_enabled",
                         "name": f"{dow}",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -699,10 +616,6 @@ def _generate_dow_entities(code_slot_num: int) -> list[MutableMapping[str, Any]]
                     "row": {
                         "entity": f"switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.limit_by_time",
                         "name": "Limit by Time of Day",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -724,10 +637,6 @@ def _generate_dow_entities(code_slot_num: int) -> list[MutableMapping[str, Any]]
                     "row": {
                         "entity": f"switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.include_exclude",
                         "name": "Include (On)/Exclude (Off) Time",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -749,10 +658,6 @@ def _generate_dow_entities(code_slot_num: int) -> list[MutableMapping[str, Any]]
                     "row": {
                         "entity": f"time.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.time_start",
                         "name": "Start Time",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -774,10 +679,6 @@ def _generate_dow_entities(code_slot_num: int) -> list[MutableMapping[str, Any]]
                     "row": {
                         "entity": f"time.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.time_end",
                         "name": "End Time",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
             ]
@@ -805,7 +706,6 @@ def _generate_child_code_slot_dict(
                 "type": "heading",
                 "heading": f"Code Slot {code_slot_num}",
                 "heading_style": "title",
-                "badges": [],
             },
             {
                 "type": "conditional",
@@ -825,69 +725,37 @@ def _generate_child_code_slot_dict(
                             "type": "simple-entity",
                             "name": "Name",
                             "entity": f"parent.text.code_slots:{code_slot_num}.name",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "type": "simple-entity",
                             "name": "PIN",
                             "entity": f"parent.text.code_slots:{code_slot_num}.pin",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "type": "simple-entity",
                             "name": "Enabled",
                             "entity": f"parent.switch.code_slots:{code_slot_num}.enabled",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"binary_sensor.code_slots:{code_slot_num}.active",
                             "name": "Active",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"sensor.code_slots:{code_slot_num}.synced",
                             "name": "Sync Status",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"switch.code_slots:{code_slot_num}.override_parent",
                             "name": "Override Parent",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"switch.code_slots:{code_slot_num}.notifications",
                             "name": "Notifications",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "type": "simple-entity",
                             "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_count_enabled",
                             "name": "Limit by Number of Uses",
-                            "secondary_info": "none",
-                            "tap_action": {"action": "none"},
-                            "hold_action": {"action": "none"},
-                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "type": "conditional",
@@ -901,10 +769,6 @@ def _generate_child_code_slot_dict(
                                 "type": "simple-entity",
                                 "entity": f"parent.number.code_slots:{code_slot_num}.accesslimit_count",
                                 "name": "Uses Remaining",
-                                "secondary_info": "none",
-                                "tap_action": {"action": "none"},
-                                "hold_action": {"action": "none"},
-                                "double_tap_action": {"action": "none"},
                             },
                         },
                     ],
@@ -931,10 +795,6 @@ def _generate_child_code_slot_dict(
                     "type": "simple-entity",
                     "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_date_range_enabled",
                     "name": "Limit by Date Range",
-                    "secondary_info": "none",
-                    "tap_action": {"action": "none"},
-                    "hold_action": {"action": "none"},
-                    "double_tap_action": {"action": "none"},
                 },
                 {
                     "type": "conditional",
@@ -948,10 +808,6 @@ def _generate_child_code_slot_dict(
                         "type": "simple-entity",
                         "entity": f"parent.datetime.code_slots:{code_slot_num}.accesslimit_date_range_start",
                         "name": "Date Range Start",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -966,10 +822,6 @@ def _generate_child_code_slot_dict(
                         "type": "simple-entity",
                         "entity": f"parent.datetime.code_slots:{code_slot_num}.accesslimit_date_range_end",
                         "name": "Date Range End",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
             ]
@@ -982,10 +834,6 @@ def _generate_child_code_slot_dict(
                     "type": "simple-entity",
                     "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_day_of_week_enabled",
                     "name": "Limit by Day of Week",
-                    "secondary_info": "none",
-                    "tap_action": {"action": "none"},
-                    "hold_action": {"action": "none"},
-                    "double_tap_action": {"action": "none"},
                 },
             ]
         )
@@ -1016,10 +864,6 @@ def _generate_child_dow_entities(
                         "type": "simple-entity",
                         "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.dow_enabled",
                         "name": f"{dow}",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -1038,10 +882,6 @@ def _generate_child_dow_entities(
                         "type": "simple-entity",
                         "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.limit_by_time",
                         "name": "Limit by Time",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -1064,10 +904,6 @@ def _generate_child_dow_entities(
                         "type": "simple-entity",
                         "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.include_exclude",
                         "name": "Include (On)/Exclude (Off) Time",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -1090,10 +926,6 @@ def _generate_child_dow_entities(
                         "type": "simple-entity",
                         "entity": f"parent.time.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.time_start",
                         "name": "Start Time",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -1116,10 +948,6 @@ def _generate_child_dow_entities(
                         "type": "simple-entity",
                         "entity": f"parent.time.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.time_end",
                         "name": "End Time",
-                        "secondary_info": "none",
-                        "tap_action": {"action": "none"},
-                        "hold_action": {"action": "none"},
-                        "double_tap_action": {"action": "none"},
                     },
                 },
             ]

--- a/custom_components/keymaster/lovelace.py
+++ b/custom_components/keymaster/lovelace.py
@@ -336,23 +336,38 @@ def _generate_code_slot_dict(
                         {
                             "entity": f"text.code_slots:{code_slot_num}.name",
                             "name": "Name",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"text.code_slots:{code_slot_num}.pin",
                             "name": "PIN",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {"type": "divider"},
                         {
                             "entity": f"switch.code_slots:{code_slot_num}.enabled",
                             "name": "Enabled",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"binary_sensor.code_slots:{code_slot_num}.active",
                             "name": "Active",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"sensor.code_slots:{code_slot_num}.synced",
                             "name": "Sync Status",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                     ],
                 },
@@ -364,6 +379,9 @@ def _generate_code_slot_dict(
             {
                 "entity": f"switch.code_slots:{code_slot_num}.override_parent",
                 "name": "Override Parent",
+                "tap_action": {"action": "none"},
+                "hold_action": {"action": "none"},
+                "double_tap_action": {"action": "none"},
             }
         )
     code_slot_dict["cards"][1]["card"]["entities"].extend(
@@ -371,11 +389,17 @@ def _generate_code_slot_dict(
             {
                 "entity": f"switch.code_slots:{code_slot_num}.notifications",
                 "name": "Notifications",
+                "tap_action": {"action": "none"},
+                "hold_action": {"action": "none"},
+                "double_tap_action": {"action": "none"},
             },
             {"type": "divider"},
             {
                 "entity": f"switch.code_slots:{code_slot_num}.accesslimit_count_enabled",
                 "name": "Limit by Number of Uses",
+                "tap_action": {"action": "none"},
+                "hold_action": {"action": "none"},
+                "double_tap_action": {"action": "none"},
             },
             {
                 "type": "conditional",
@@ -388,6 +412,9 @@ def _generate_code_slot_dict(
                 "row": {
                     "entity": f"number.code_slots:{code_slot_num}.accesslimit_count",
                     "name": "Uses Remaining",
+                    "tap_action": {"action": "none"},
+                    "hold_action": {"action": "none"},
+                    "double_tap_action": {"action": "none"},
                 },
             },
         ]
@@ -399,6 +426,9 @@ def _generate_code_slot_dict(
                 {
                     "entity": f"switch.code_slots:{code_slot_num}.accesslimit_date_range_enabled",
                     "name": "Limit by Date Range",
+                    "tap_action": {"action": "none"},
+                    "hold_action": {"action": "none"},
+                    "double_tap_action": {"action": "none"},
                 },
                 {
                     "type": "conditional",
@@ -411,6 +441,9 @@ def _generate_code_slot_dict(
                     "row": {
                         "entity": f"datetime.code_slots:{code_slot_num}.accesslimit_date_range_start",
                         "name": "Date Range Start",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -424,6 +457,9 @@ def _generate_code_slot_dict(
                     "row": {
                         "entity": f"datetime.code_slots:{code_slot_num}.accesslimit_date_range_end",
                         "name": "Date Range End",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
             ]
@@ -435,6 +471,9 @@ def _generate_code_slot_dict(
                 {
                     "entity": f"switch.code_slots:{code_slot_num}.accesslimit_day_of_week_enabled",
                     "name": "Limit by Day of Week",
+                    "tap_action": {"action": "none"},
+                    "hold_action": {"action": "none"},
+                    "double_tap_action": {"action": "none"},
                 },
             ]
         )
@@ -458,6 +497,7 @@ def _generate_lock_badges(
             "show_name": False,
             "entity": "sensor.lock_name",
             "color": "",
+            "tap_action": {"action": "none"},
         }
     ]
     if child:
@@ -468,7 +508,8 @@ def _generate_lock_badges(
                 "entity": "sensor.parent_name",
                 "name": "Parent Lock",
                 "color": "",
-                }
+                "tap_action": {"action": "none"},
+            }
         )
     badges.extend(
         [
@@ -477,7 +518,8 @@ def _generate_lock_badges(
                 "show_name": False,
                 "entity": "binary_sensor.connected",
                 "color": "",
-                },
+                "tap_action": {"action": "none"},
+            },
             {
                 "type": "entity",
                 "show_name": True,
@@ -517,7 +559,8 @@ def _generate_lock_badges(
                 "entity": door_sensor,
                 "name": "Door",
                 "color": "",
-                }
+                "tap_action": {"action": "none"},
+            }
         )
     badges.append(
         {
@@ -599,6 +642,9 @@ def _generate_dow_entities(code_slot_num: int) -> list[MutableMapping[str, Any]]
                     "row": {
                         "entity": f"switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.dow_enabled",
                         "name": f"{dow}",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -616,6 +662,9 @@ def _generate_dow_entities(code_slot_num: int) -> list[MutableMapping[str, Any]]
                     "row": {
                         "entity": f"switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.limit_by_time",
                         "name": "Limit by Time of Day",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -637,6 +686,9 @@ def _generate_dow_entities(code_slot_num: int) -> list[MutableMapping[str, Any]]
                     "row": {
                         "entity": f"switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.include_exclude",
                         "name": "Include (On)/Exclude (Off) Time",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -658,6 +710,9 @@ def _generate_dow_entities(code_slot_num: int) -> list[MutableMapping[str, Any]]
                     "row": {
                         "entity": f"time.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.time_start",
                         "name": "Start Time",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -679,6 +734,9 @@ def _generate_dow_entities(code_slot_num: int) -> list[MutableMapping[str, Any]]
                     "row": {
                         "entity": f"time.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.time_end",
                         "name": "End Time",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
             ]
@@ -725,37 +783,61 @@ def _generate_child_code_slot_dict(
                             "type": "simple-entity",
                             "name": "Name",
                             "entity": f"parent.text.code_slots:{code_slot_num}.name",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "type": "simple-entity",
                             "name": "PIN",
                             "entity": f"parent.text.code_slots:{code_slot_num}.pin",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "type": "simple-entity",
                             "name": "Enabled",
                             "entity": f"parent.switch.code_slots:{code_slot_num}.enabled",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"binary_sensor.code_slots:{code_slot_num}.active",
                             "name": "Active",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"sensor.code_slots:{code_slot_num}.synced",
                             "name": "Sync Status",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"switch.code_slots:{code_slot_num}.override_parent",
                             "name": "Override Parent",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "entity": f"switch.code_slots:{code_slot_num}.notifications",
                             "name": "Notifications",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "type": "simple-entity",
                             "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_count_enabled",
                             "name": "Limit by Number of Uses",
+                            "tap_action": {"action": "none"},
+                            "hold_action": {"action": "none"},
+                            "double_tap_action": {"action": "none"},
                         },
                         {
                             "type": "conditional",
@@ -769,6 +851,9 @@ def _generate_child_code_slot_dict(
                                 "type": "simple-entity",
                                 "entity": f"parent.number.code_slots:{code_slot_num}.accesslimit_count",
                                 "name": "Uses Remaining",
+                                "tap_action": {"action": "none"},
+                                "hold_action": {"action": "none"},
+                                "double_tap_action": {"action": "none"},
                             },
                         },
                     ],
@@ -795,6 +880,9 @@ def _generate_child_code_slot_dict(
                     "type": "simple-entity",
                     "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_date_range_enabled",
                     "name": "Limit by Date Range",
+                    "tap_action": {"action": "none"},
+                    "hold_action": {"action": "none"},
+                    "double_tap_action": {"action": "none"},
                 },
                 {
                     "type": "conditional",
@@ -808,6 +896,9 @@ def _generate_child_code_slot_dict(
                         "type": "simple-entity",
                         "entity": f"parent.datetime.code_slots:{code_slot_num}.accesslimit_date_range_start",
                         "name": "Date Range Start",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -822,6 +913,9 @@ def _generate_child_code_slot_dict(
                         "type": "simple-entity",
                         "entity": f"parent.datetime.code_slots:{code_slot_num}.accesslimit_date_range_end",
                         "name": "Date Range End",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
             ]
@@ -834,6 +928,9 @@ def _generate_child_code_slot_dict(
                     "type": "simple-entity",
                     "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_day_of_week_enabled",
                     "name": "Limit by Day of Week",
+                    "tap_action": {"action": "none"},
+                    "hold_action": {"action": "none"},
+                    "double_tap_action": {"action": "none"},
                 },
             ]
         )
@@ -864,6 +961,9 @@ def _generate_child_dow_entities(
                         "type": "simple-entity",
                         "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.dow_enabled",
                         "name": f"{dow}",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -882,6 +982,9 @@ def _generate_child_dow_entities(
                         "type": "simple-entity",
                         "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.limit_by_time",
                         "name": "Limit by Time",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -904,6 +1007,9 @@ def _generate_child_dow_entities(
                         "type": "simple-entity",
                         "entity": f"parent.switch.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.include_exclude",
                         "name": "Include (On)/Exclude (Off) Time",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -926,6 +1032,9 @@ def _generate_child_dow_entities(
                         "type": "simple-entity",
                         "entity": f"parent.time.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.time_start",
                         "name": "Start Time",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
                 {
@@ -948,6 +1057,9 @@ def _generate_child_dow_entities(
                         "type": "simple-entity",
                         "entity": f"parent.time.code_slots:{code_slot_num}.accesslimit_day_of_week:{dow_num}.time_end",
                         "name": "End Time",
+                        "tap_action": {"action": "none"},
+                        "hold_action": {"action": "none"},
+                        "double_tap_action": {"action": "none"},
                     },
                 },
             ]

--- a/scripts/compare_lovelace_output.py
+++ b/scripts/compare_lovelace_output.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Compare Lovelace view config output between two git branches.
+
+Usage:
+    python scripts/compare_lovelace_output.py <branch1> <branch2>
+
+Example:
+    python scripts/compare_lovelace_output.py beta feature/lovelace-output-optimization
+
+This script will:
+1. Generate view configs from both branches using the test cases below
+2. Save the outputs to /tmp/<branch>_view_config.json
+3. Report the size difference and whether outputs are functionally equivalent
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# =============================================================================
+# TEST CASES - Add more test cases here as needed
+# =============================================================================
+TEST_CASES = [
+    (
+        "basic",
+        {
+            "kmlock_name": "Front Door",
+            "keymaster_config_entry_id": "entry123",
+            "code_slot_start": 1,
+            "code_slots": 2,
+            "lock_entity": "lock.front_door",
+            "advanced_date_range": False,
+            "advanced_day_of_week": False,
+            "door_sensor": None,
+            "parent_config_entry_id": None,
+        },
+    ),
+    (
+        "with_day_of_week",
+        {
+            "kmlock_name": "Front Door",
+            "keymaster_config_entry_id": "entry123",
+            "code_slot_start": 1,
+            "code_slots": 2,
+            "lock_entity": "lock.front_door",
+            "advanced_date_range": False,
+            "advanced_day_of_week": True,
+            "door_sensor": None,
+            "parent_config_entry_id": None,
+        },
+    ),
+    (
+        "child_lock",
+        {
+            "kmlock_name": "Back Door",
+            "keymaster_config_entry_id": "child123",
+            "code_slot_start": 1,
+            "code_slots": 2,
+            "lock_entity": "lock.back_door",
+            "advanced_date_range": False,
+            "advanced_day_of_week": False,
+            "door_sensor": None,
+            "parent_config_entry_id": "parent123",
+        },
+    ),
+]
+
+
+def generate_config_script() -> str:
+    """Return the Python code to generate view configs."""
+    return '''
+import json
+import sys
+sys.path.insert(0, ".")
+
+from unittest.mock import MagicMock, patch
+
+with patch("custom_components.keymaster.lovelace.er"):
+    import custom_components.keymaster.lovelace as lovelace_module
+
+    def passthrough_map(hass, lovelace_entities, keymaster_config_entry_id, parent_config_entry_id=None):
+        return lovelace_entities
+
+    lovelace_module._map_property_to_entity_id = passthrough_map
+
+    from custom_components.keymaster.lovelace import generate_view_config
+
+    mock_hass = MagicMock()
+    test_cases = TEST_CASES_PLACEHOLDER
+
+    results = {}
+    for name, params in test_cases:
+        result = generate_view_config(hass=mock_hass, **params)
+        results[name] = result
+
+    print(json.dumps(results, indent=2, sort_keys=True))
+'''
+
+
+def deep_equal(obj1: Any, obj2: Any, path: str = "") -> list[str]:
+    """Recursively compare two objects for semantic equality (ignoring key order)."""
+    diffs = []
+
+    if type(obj1) != type(obj2):
+        diffs.append(f"{path}: type mismatch {type(obj1).__name__} vs {type(obj2).__name__}")
+        return diffs
+
+    if isinstance(obj1, dict):
+        keys1 = set(obj1.keys())
+        keys2 = set(obj2.keys())
+
+        for key in sorted(keys1 - keys2):
+            diffs.append(f"{path}.{key}: only in first branch")
+
+        for key in sorted(keys2 - keys1):
+            diffs.append(f"{path}.{key}: only in second branch")
+
+        for key in sorted(keys1 & keys2):
+            diffs.extend(deep_equal(obj1[key], obj2[key], f"{path}.{key}"))
+
+    elif isinstance(obj1, list):
+        if len(obj1) != len(obj2):
+            diffs.append(f"{path}: list length {len(obj1)} vs {len(obj2)}")
+        for i, (item1, item2) in enumerate(zip(obj1, obj2)):
+            diffs.extend(deep_equal(item1, item2, f"{path}[{i}]"))
+
+    elif obj1 != obj2:
+        diffs.append(f"{path}: {obj1!r} vs {obj2!r}")
+
+    return diffs
+
+
+def generate_for_branch(branch: str, repo_root: Path) -> tuple[dict, int]:
+    """Generate view config for a branch and return (config, size_bytes)."""
+    current_branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    ).stdout.strip()
+
+    try:
+        # Checkout target branch
+        subprocess.run(
+            ["git", "checkout", branch],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            check=True,
+        )
+
+        # Generate the config
+        script = generate_config_script().replace(
+            "TEST_CASES_PLACEHOLDER", repr(TEST_CASES)
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+
+        if result.returncode != 0:
+            print(f"Error generating config for {branch}:", file=sys.stderr)
+            print(result.stderr, file=sys.stderr)
+            sys.exit(1)
+
+        config = json.loads(result.stdout)
+        size_bytes = len(result.stdout.encode())
+
+        return config, size_bytes
+
+    finally:
+        # Restore original branch
+        subprocess.run(
+            ["git", "checkout", current_branch],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare Lovelace view config output between two git branches."
+    )
+    parser.add_argument("branch1", help="First branch to compare")
+    parser.add_argument("branch2", help="Second branch to compare")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("/tmp"),
+        help="Directory to save output JSON files (default: /tmp)",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).parent.parent
+
+    print(f"Generating config from {args.branch1}...")
+    config1, size1 = generate_for_branch(args.branch1, repo_root)
+
+    print(f"Generating config from {args.branch2}...")
+    config2, size2 = generate_for_branch(args.branch2, repo_root)
+
+    # Save outputs
+    output1 = args.output_dir / f"{args.branch1.replace('/', '_')}_view_config.json"
+    output2 = args.output_dir / f"{args.branch2.replace('/', '_')}_view_config.json"
+
+    output1.write_text(json.dumps(config1, indent=2, sort_keys=True))
+    output2.write_text(json.dumps(config2, indent=2, sort_keys=True))
+
+    print(f"\nOutputs saved to:")
+    print(f"  {output1}")
+    print(f"  {output2}")
+
+    # Compare
+    print(f"\n{'=' * 60}")
+    print("SIZE COMPARISON")
+    print(f"{'=' * 60}")
+    print(f"  {args.branch1}: {size1:,} bytes")
+    print(f"  {args.branch2}: {size2:,} bytes")
+
+    diff = size1 - size2
+    if diff > 0:
+        pct = (diff / size1) * 100
+        print(f"  Reduction: {diff:,} bytes ({pct:.1f}%)")
+    elif diff < 0:
+        pct = (abs(diff) / size2) * 100
+        print(f"  Increase: {abs(diff):,} bytes ({pct:.1f}%)")
+    else:
+        print("  No size difference")
+
+    print(f"\n{'=' * 60}")
+    print("FUNCTIONAL COMPARISON")
+    print(f"{'=' * 60}")
+
+    diffs = deep_equal(config1, config2)
+    if diffs:
+        print(f"  Found {len(diffs)} differences:")
+        for d in diffs[:20]:
+            print(f"    {d}")
+        if len(diffs) > 20:
+            print(f"    ... and {len(diffs) - 20} more")
+    else:
+        print("  ✓ Outputs are functionally identical")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Summary

Removes redundant default property values from the generated Lovelace view configuration, reducing payload size by ~6% with no functional change.

## Proposed change

This PR removes properties from the Lovelace config output that are set to their default values. Home Assistant's Lovelace frontend automatically applies these defaults, so explicitly including them is unnecessary and bloats the configuration.

### Properties removed

| Property | Default Value | Why safe to remove |
|----------|---------------|-------------------|
| `show_icon` | `true` | [Default for entity badges](https://www.home-assistant.io/dashboards/badges/) |
| `show_state` | `true` | [Default for entity badges](https://www.home-assistant.io/dashboards/badges/) |
| `secondary_info` | `"none"` | When omitted, no secondary info is shown (same behavior) |
| `badges` | `[]` | Empty arrays have no effect on heading cards |

### Properties intentionally kept

| Property | Value | Why kept |
|----------|-------|----------|
| `tap_action` | `{"action": "none"}` | **Not a default** - explicitly disables row tap to prevent accidental toggles (default would be `toggle` or `more-info`) |
| `hold_action` | `{"action": "none"}` | **Not a default** - explicitly disables hold action (default is `more-info`) |
| `double_tap_action` | `{"action": "none"}` | **Not a default** - explicitly disables double-tap (default is `more-info`) |

### Size reduction

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Config size | 124,616 bytes | 116,898 bytes | **-7,718 bytes (-6.2%)** |

This was measured using a test configuration with 3 test cases (basic lock, lock with day-of-week, and child lock).

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- A verification script is included at `scripts/compare_lovelace_output.py` to compare output between branches
- A follow-up PR will refactor the code into helper functions (reducing code lines significantly) while maintaining identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)