### PR TITLE
refactor: split requirements into test, lint, and dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -652,13 +652,13 @@ commands = [
     ["ruff", "check", "custom_components{/}"],
     ["ruff", "check", "tests{/}"],
 ]
-deps = ["-rrequirements_test.txt"]
+deps = ["-rrequirements_lint.txt"]
 
 [tool.tox.env.mypy]
 description = "Run mypy for type-checking under {base_python}"
 ignore_errors = true
 commands = [["mypy", "custom_components{/}keymaster"]]
-deps = ["-rrequirements_test.txt"]
+deps = ["-rrequirements_lint.txt"]
 
 [tool.codespell]
 ignore-words-list = "hass"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,6 @@
-homeassistant
-pyserial
-pyudev
-zwave-js-server-python
+# Development dependencies - includes test and lint
+-r requirements_test.txt
+-r requirements_lint.txt
+
+# Test orchestration for local development
+tox

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,0 +1,6 @@
+# Lint dependencies for ruff, mypy, and pylint
+mypy
+pylint
+pylint-per-file-ignores
+ruff
+types-PyYAML

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,13 +1,14 @@
--r requirements_dev.txt
+# Test dependencies for pytest
+pytest
+pytest-homeassistant-custom-component
+
+# Additional HA ecosystem packages required by tests
 aiohttp_cors
 aiousbwatcher
 asyncio_mqtt
-mypy
+homeassistant
 pydispatcher
-pylint
-pytest
-pytest-homeassistant-custom-component
-ruff
-tox
-types-PyYAML
+pyserial
+pyudev
 zeroconf
+zwave-js-server-python


### PR DESCRIPTION
# Summary

Split requirements files to enable more targeted dependency installation in CI workflows.

## Proposed change

- **requirements_test.txt**: pytest and HA ecosystem packages needed for running tests
- **requirements_lint.txt**: ruff, mypy, pylint for linting and type-checking
- **requirements_dev.txt**: includes both test and lint requirements, plus tox

Update tox configuration in pyproject.toml:
- `py313`/`py314` envs use `requirements_test.txt`
- `lint` env uses `requirements_lint.txt`
- `mypy` env uses `requirements_lint.txt`

This allows CI workflow jobs to install only the dependencies they need.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: N/A (maintenance improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)