### PR TITLE
refactor: parallelize CI jobs and apply ruff formatting

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,4 +1,4 @@
-name: Pytest
+name: Python CI
 
 on:
   push:
@@ -25,7 +25,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    name: Run tests
+    name: Pytest
     strategy:
       matrix:
         python-version:
@@ -41,15 +41,46 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: 📦 Install requirements
-        run: |
-          pip install tox tox-gh-actions
-      - name: 🏃 Test with tox
-        run: tox
-      - name: 📤 Upload coverage to Codecov
-        uses: "actions/upload-artifact@v4"
+        run: pip install -r requirements_test.txt
+      - name: 🏃 Run pytest
+        run: pytest tests --cov=custom_components/keymaster --cov-report=xml
+      - name: 📤 Upload coverage artifact
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-data
-          path: "coverage.xml"
+          path: coverage.xml
+
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint (ruff)
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@v4
+      - name: 🛠️ Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: 📦 Install requirements
+        run: pip install -r requirements_lint.txt
+      - name: 🧹 Run ruff format check
+        run: ruff format --check custom_components/ tests/
+      - name: 🔍 Run ruff check
+        run: ruff check custom_components/ tests/
+
+  mypy:
+    runs-on: ubuntu-latest
+    name: Type check (mypy)
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@v4
+      - name: 🛠️ Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: 📦 Install requirements
+        run: pip install -r requirements_lint.txt
+      - name: 🔎 Run mypy
+        run: mypy custom_components/keymaster
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -40,8 +40,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: 🚀 Install uv
+        uses: astral-sh/setup-uv@v5
       - name: 📦 Install requirements
-        run: pip install -r requirements_test.txt
+        run: uv pip install --system -r requirements_test.txt
       - name: 🏃 Run pytest
         run: pytest tests --cov=custom_components/keymaster --cov-report=xml
       - name: 📤 Upload coverage artifact
@@ -60,8 +62,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - name: 🚀 Install uv
+        uses: astral-sh/setup-uv@v5
       - name: 📦 Install requirements
-        run: pip install -r requirements_lint.txt
+        run: uv pip install --system -r requirements_lint.txt
       - name: 🧹 Run ruff format check
         run: ruff format --check custom_components/ tests/
       - name: 🔍 Run ruff check
@@ -77,8 +81,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - name: 🚀 Install uv
+        uses: astral-sh/setup-uv@v5
       - name: 📦 Install requirements
-        run: pip install -r requirements_lint.txt
+        run: uv pip install --system -r requirements_lint.txt
       - name: 🔎 Run mypy
         run: mypy custom_components/keymaster
 

--- a/custom_components/keymaster/button.py
+++ b/custom_components/keymaster/button.py
@@ -60,9 +60,7 @@ async def async_setup_entry(
 
 
 @dataclass(frozen=True, kw_only=True)
-class KeymasterButtonEntityDescription(
-    KeymasterEntityDescription, ButtonEntityDescription
-):
+class KeymasterButtonEntityDescription(KeymasterEntityDescription, ButtonEntityDescription):
     """Entity Description for Keymaster Buttons."""
 
 

--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -215,15 +215,11 @@ def _get_schema(
         script_default = NONE_TEXT
     elif script_default != NONE_TEXT and not script_default.startswith("script."):
         script_default = f"script.{script_default}"
-    _LOGGER.debug(
-        "[get_schema] script_default: %s (%s)", script_default, type(script_default)
-    )
+    _LOGGER.debug("[get_schema] script_default: %s (%s)", script_default, type(script_default))
     lock_entities = _get_entities(
         hass=hass,
         domain=LOCK_DOMAIN,
-        exclude_entities=_get_locks_in_use(
-            hass=hass, exclude=_get_default(CONF_LOCK_ENTITY_ID)
-        ),
+        exclude_entities=_get_locks_in_use(hass=hass, exclude=_get_default(CONF_LOCK_ENTITY_ID)),
     )
     if not lock_entities:
         if flow is not None:
@@ -232,18 +228,18 @@ def _get_schema(
     return vol.Schema(
         {
             vol.Required(CONF_LOCK_NAME, default=_get_default(CONF_LOCK_NAME)): str,
-            vol.Required(
-                CONF_LOCK_ENTITY_ID, default=_get_default(CONF_LOCK_ENTITY_ID)
-            ): vol.In(lock_entities),
-            vol.Optional(
-                CONF_PARENT, default=_get_default(CONF_PARENT, NONE_TEXT)
-            ): vol.In(_available_parent_locks(hass, entry_id)),
-            vol.Required(
-                CONF_SLOTS, default=_get_default(CONF_SLOTS, DEFAULT_CODE_SLOTS)
-            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
-            vol.Required(
-                CONF_START, default=_get_default(CONF_START, DEFAULT_START)
-            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Required(CONF_LOCK_ENTITY_ID, default=_get_default(CONF_LOCK_ENTITY_ID)): vol.In(
+                lock_entities
+            ),
+            vol.Optional(CONF_PARENT, default=_get_default(CONF_PARENT, NONE_TEXT)): vol.In(
+                _available_parent_locks(hass, entry_id)
+            ),
+            vol.Required(CONF_SLOTS, default=_get_default(CONF_SLOTS, DEFAULT_CODE_SLOTS)): vol.All(
+                vol.Coerce(int), vol.Range(min=1)
+            ),
+            vol.Required(CONF_START, default=_get_default(CONF_START, DEFAULT_START)): vol.All(
+                vol.Coerce(int), vol.Range(min=1)
+            ),
             vol.Optional(
                 CONF_DOOR_SENSOR_ENTITY_ID,
                 default=_get_default(CONF_DOOR_SENSOR_ENTITY_ID, NONE_TEXT),
@@ -256,9 +252,7 @@ def _get_schema(
             ),
             vol.Optional(
                 CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
-                default=_get_default(
-                    CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID, NONE_TEXT
-                ),
+                default=_get_default(CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID, NONE_TEXT),
             ): vol.In(
                 _get_entities(
                     hass=hass,
@@ -293,15 +287,11 @@ def _get_schema(
             ),
             vol.Required(
                 CONF_ADVANCED_DATE_RANGE,
-                default=_get_default(
-                    CONF_ADVANCED_DATE_RANGE, DEFAULT_ADVANCED_DATE_RANGE
-                ),
+                default=_get_default(CONF_ADVANCED_DATE_RANGE, DEFAULT_ADVANCED_DATE_RANGE),
             ): bool,
             vol.Required(
                 CONF_ADVANCED_DAY_OF_WEEK,
-                default=_get_default(
-                    CONF_ADVANCED_DAY_OF_WEEK, DEFAULT_ADVANCED_DAY_OF_WEEK
-                ),
+                default=_get_default(CONF_ADVANCED_DAY_OF_WEEK, DEFAULT_ADVANCED_DAY_OF_WEEK),
             ): bool,
             vol.Required(
                 CONF_HIDE_PINS, default=_get_default(CONF_HIDE_PINS, DEFAULT_HIDE_PINS)

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -125,9 +125,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=60),
             config_entry=None,
         )
-        self._json_folder: str = self.hass.config.path(
-            "custom_components", DOMAIN, "json_kmlocks"
-        )
+        self._json_folder: str = self.hass.config.path("custom_components", DOMAIN, "json_kmlocks")
         self._json_filename: str = f"{DOMAIN}_kmlocks.json"
 
     async def initial_setup(self) -> None:
@@ -142,9 +140,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         await self.hass.async_add_executor_job(self._create_json_folder)
 
-        imported_config = await self.hass.async_add_executor_job(
-            self._get_dict_from_json_file
-        )
+        imported_config = await self.hass.async_add_executor_job(self._get_dict_from_json_file)
 
         _LOGGER.debug("[async_setup] Imported %s keymaster locks", len(imported_config))
         self.kmlocks = imported_config
@@ -157,9 +153,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         await self._verify_lock_configuration()
 
     def _create_json_folder(self) -> None:
-        _LOGGER.debug(
-            "[create_json_folder] json_kmlocks Location: %s", self._json_folder
-        )
+        _LOGGER.debug("[create_json_folder] json_kmlocks Location: %s", self._json_folder)
 
         try:
             Path(self._json_folder).mkdir(parents=True, exist_ok=True)
@@ -199,8 +193,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         # _LOGGER.debug(f"[get_dict_from_json_file] Imported JSON: {config}")
         kmlocks: MutableMapping = {
-            key: self._dict_to_kmlocks(value, KeymasterLock)
-            for key, value in config.items()
+            key: self._dict_to_kmlocks(value, KeymasterLock) for key, value in config.items()
         }
 
         _LOGGER.debug("[get_dict_from_json_file] Imported kmlocks: %s", kmlocks)
@@ -216,9 +209,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 config_entry_id
             )
             if config_entry is None:
-                _LOGGER.debug(
-                    "[verify_lock_configuration] %s: No config entry found", lock
-                )
+                _LOGGER.debug("[verify_lock_configuration] %s: No config entry found", lock)
                 _LOGGER.debug("deleting %s from kmlocks", lock)
                 await self.delete_lock_by_config_entry_id(config_entry_id)
             _LOGGER.debug("================================")
@@ -302,16 +293,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         # )
                         if isinstance(field_value, dict):
                             # If the value_type is a dataclass, recursively process it
-                            if is_dataclass(value_type) and isinstance(
-                                value_type, type
-                            ):
+                            if is_dataclass(value_type) and isinstance(value_type, type):
                                 # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting dict items for {field_name}")
                                 field_value = {
                                     (
                                         int(k)
-                                        if key_type is int
-                                        and isinstance(k, str)
-                                        and k.isdigit()
+                                        if key_type is int and isinstance(k, str) and k.isdigit()
                                         else k
                                     ): self._dict_to_kmlocks(v, value_type)
                                     for k, v in field_value.items()
@@ -321,9 +308,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                                 field_value = {
                                     (
                                         int(k)
-                                        if key_type is int
-                                        and isinstance(k, str)
-                                        and k.isdigit()
+                                        if key_type is int and isinstance(k, str) and k.isdigit()
                                         else k
                                     ): v
                                     for k, v in field_value.items()
@@ -386,11 +371,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     ]
                 elif isinstance(field_value, dict):
                     result[field_name] = {
-                        k: (
-                            self._kmlocks_to_dict(v)
-                            if hasattr(v, "__dataclass_fields__")
-                            else v
-                        )
+                        k: (self._kmlocks_to_dict(v) if hasattr(v, "__dataclass_fields__") else v)
                         for k, v in field_value.items()
                     }
                 else:
@@ -431,9 +412,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         # _LOGGER.debug(f"[write_config_to_json] Dict to Save: {config}")
         if config == self._prev_kmlocks_dict:
-            _LOGGER.debug(
-                "[write_config_to_json] No changes to kmlocks. Not updating JSON file"
-            )
+            _LOGGER.debug("[write_config_to_json] No changes to kmlocks. Not updating JSON file")
             return True
         self._prev_kmlocks_dict = config
         try:
@@ -458,13 +437,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     if kmlock.parent_name == parent_lock.lock_name:
                         if kmlock.parent_config_entry_id is None:
                             kmlock.parent_config_entry_id = parent_config_entry_id
-                        if (
-                            keymaster_config_entry_id
-                            not in parent_lock.child_config_entry_ids
-                        ):
-                            parent_lock.child_config_entry_ids.append(
-                                keymaster_config_entry_id
-                            )
+                        if keymaster_config_entry_id not in parent_lock.child_config_entry_ids:
+                            parent_lock.child_config_entry_ids.append(keymaster_config_entry_id)
                         break
             for child_config_entry_id in list(kmlock.child_config_entry_ids):
                 if (
@@ -473,13 +447,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     != keymaster_config_entry_id
                 ):
                     with contextlib.suppress(ValueError):
-                        self.kmlocks[
-                            keymaster_config_entry_id
-                        ].child_config_entry_ids.remove(child_config_entry_id)
+                        self.kmlocks[keymaster_config_entry_id].child_config_entry_ids.remove(
+                            child_config_entry_id
+                        )
 
-    async def _handle_zwave_js_lock_event(
-        self, kmlock: KeymasterLock, event: Event
-    ) -> None:
+    async def _handle_zwave_js_lock_event(self, kmlock: KeymasterLock, event: Event) -> None:
         """Handle Z-Wave JS event."""
 
         if (
@@ -553,9 +525,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         event: Event[EventStateChangedData],
     ) -> None:
         """Track state changes to lock entities."""
-        _LOGGER.debug(
-            "[handle_lock_state_change] %s: event: %s", kmlock.lock_name, event
-        )
+        _LOGGER.debug("[handle_lock_state_change] %s: event: %s", kmlock.lock_name, event)
         if not event:
             return
 
@@ -576,23 +546,19 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         action_type: str = ""
         if kmlock.alarm_type_or_access_control_entity_id and (
             ALARM_TYPE in kmlock.alarm_type_or_access_control_entity_id
-            or ALARM_TYPE.replace("_", "")
-            in kmlock.alarm_type_or_access_control_entity_id
+            or ALARM_TYPE.replace("_", "") in kmlock.alarm_type_or_access_control_entity_id
         ):
             action_type = ALARM_TYPE
         elif kmlock.alarm_type_or_access_control_entity_id and (
             ACCESS_CONTROL in kmlock.alarm_type_or_access_control_entity_id
-            or ACCESS_CONTROL.replace("_", "")
-            in kmlock.alarm_type_or_access_control_entity_id
+            or ACCESS_CONTROL.replace("_", "") in kmlock.alarm_type_or_access_control_entity_id
         ):
             action_type = ACCESS_CONTROL
 
         # Get alarm_level/usercode and alarm_type/access_control states
         alarm_level_state = None
         if kmlock.alarm_level_or_user_code_entity_id:
-            alarm_level_state = self.hass.states.get(
-                kmlock.alarm_level_or_user_code_entity_id
-            )
+            alarm_level_state = self.hass.states.get(kmlock.alarm_level_or_user_code_entity_id)
         alarm_level_value: int | None = (
             int(alarm_level_state.state)
             if alarm_level_state
@@ -601,13 +567,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         alarm_type_state = None
         if kmlock.alarm_type_or_access_control_entity_id:
-            alarm_type_state = self.hass.states.get(
-                kmlock.alarm_type_or_access_control_entity_id
-            )
+            alarm_type_state = self.hass.states.get(kmlock.alarm_type_or_access_control_entity_id)
         alarm_type_value: int | None = (
             int(alarm_type_state.state)
-            if alarm_type_state
-            and alarm_type_state.state not in {STATE_UNKNOWN, STATE_UNAVAILABLE}
+            if alarm_type_state and alarm_type_state.state not in {STATE_UNKNOWN, STATE_UNAVAILABLE}
             else None
         )
 
@@ -655,9 +618,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             new_state,
         )
         if old_state not in {LockState.LOCKED, LockState.UNLOCKED}:
-            _LOGGER.debug(
-                "[handle_lock_state_change] %s: Ignoring state change", kmlock.lock_name
-            )
+            _LOGGER.debug("[handle_lock_state_change] %s: Ignoring state change", kmlock.lock_name)
         elif new_state == LockState.UNLOCKED:
             await self._lock_unlocked(
                 kmlock=kmlock,
@@ -686,9 +647,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         event: Event[EventStateChangedData],
     ) -> None:
         """Track state changes to door entities."""
-        _LOGGER.debug(
-            "[handle_door_state_change] %s: event: %s", kmlock.lock_name, event
-        )
+        _LOGGER.debug("[handle_door_state_change] %s: event: %s", kmlock.lock_name, event)
         if not event:
             return
 
@@ -711,9 +670,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             new_state,
         )
         if old_state not in {STATE_ON, STATE_OFF}:
-            _LOGGER.debug(
-                "[handle_door_state_change] %s: Ignoring state change", kmlock.lock_name
-            )
+            _LOGGER.debug("[handle_door_state_change] %s: Ignoring state change", kmlock.lock_name)
         elif new_state == STATE_ON:
             await self._door_opened(kmlock)
         elif new_state == STATE_OFF:
@@ -780,9 +737,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     @staticmethod
     async def _unsubscribe_listeners(kmlock: KeymasterLock) -> None:
         # Unsubscribe to any listeners
-        _LOGGER.debug(
-            "[unsubscribe_listeners] %s: Removing all listeners", kmlock.lock_name
-        )
+        _LOGGER.debug("[unsubscribe_listeners] %s: Removing all listeners", kmlock.lock_name)
         if not hasattr(kmlock, "listeners") or kmlock.listeners is None:
             kmlock.listeners = []
             return
@@ -819,9 +774,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if not self._throttle.is_allowed(
             "lock_unlocked", kmlock.keymaster_config_entry_id, THROTTLE_SECONDS
         ):
-            _LOGGER.debug(
-                "[lock_unlocked] %s: Throttled. source: %s", kmlock.lock_name, source
-            )
+            _LOGGER.debug("[lock_unlocked] %s: Throttled. source: %s", kmlock.lock_name, source)
             return
 
         if kmlock.lock_state == LockState.UNLOCKED:
@@ -851,7 +804,9 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     and kmlock.code_slots.get(code_slot_num)
                     and kmlock.code_slots[code_slot_num].name
                 ):
-                    message = f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
+                    message = (
+                        f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
+                    )
                 else:
                     message = f"{message} by Code Slot {code_slot_num}"
             await send_manual_notification(
@@ -861,29 +816,21 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 message=message,
             )
 
-        if (
-            code_slot_num > 0
-            and kmlock.code_slots
-            and code_slot_num in kmlock.code_slots
-        ):
+        if code_slot_num > 0 and kmlock.code_slots and code_slot_num in kmlock.code_slots:
             if (
                 kmlock.parent_name
                 and kmlock.parent_config_entry_id
                 and not kmlock.code_slots[code_slot_num].override_parent
             ):
-                parent_kmlock: KeymasterLock | None = (
-                    await self.get_lock_by_config_entry_id(
-                        kmlock.parent_config_entry_id
-                    )
+                parent_kmlock: KeymasterLock | None = await self.get_lock_by_config_entry_id(
+                    kmlock.parent_config_entry_id
                 )
                 if (
                     isinstance(parent_kmlock, KeymasterLock)
                     and parent_kmlock.code_slots
                     and code_slot_num
                     and code_slot_num in parent_kmlock.code_slots
-                    and parent_kmlock.code_slots[
-                        code_slot_num
-                    ].accesslimit_count_enabled
+                    and parent_kmlock.code_slots[code_slot_num].accesslimit_count_enabled
                 ):
                     accesslimit_count: int | None = parent_kmlock.code_slots[
                         code_slot_num
@@ -895,17 +842,14 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             elif kmlock.code_slots[code_slot_num].accesslimit_count_enabled:
                 accesslimit_count = kmlock.code_slots[code_slot_num].accesslimit_count
                 if isinstance(accesslimit_count, int) and accesslimit_count > 0:
-                    kmlock.code_slots[code_slot_num].accesslimit_count = (
-                        accesslimit_count - 1
-                    )
+                    kmlock.code_slots[code_slot_num].accesslimit_count = accesslimit_count - 1
 
-            if (
-                kmlock.code_slots[code_slot_num].notifications
-                and not kmlock.lock_notifications
-            ):
+            if kmlock.code_slots[code_slot_num].notifications and not kmlock.lock_notifications:
                 if kmlock.code_slots[code_slot_num].name:
                     message = event_label
-                    message = f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
+                    message = (
+                        f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
+                    )
                 else:
                     message = f"{message} by Code Slot {code_slot_num}"
                 await send_manual_notification(
@@ -944,9 +888,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if not self._throttle.is_allowed(
             "lock_locked", kmlock.keymaster_config_entry_id, THROTTLE_SECONDS
         ):
-            _LOGGER.debug(
-                "[lock_locked] %s: Throttled. source: %s", kmlock.lock_name, source
-            )
+            _LOGGER.debug("[lock_locked] %s: Throttled. source: %s", kmlock.lock_name, source)
             return
 
         if kmlock.lock_state == LockState.LOCKED:
@@ -1082,9 +1024,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         else:
             await self._lock_lock(kmlock=kmlock)
 
-    async def _update_door_and_lock_state(
-        self, trigger_actions_if_changed: bool = False
-    ) -> None:
+    async def _update_door_and_lock_state(self, trigger_actions_if_changed: bool = False) -> None:
         # _LOGGER.debug("[update_door_and_lock_state] Running")
         for kmlock in self.kmlocks.values():
             if isinstance(kmlock.lock_entity_id, str) and kmlock.lock_entity_id:
@@ -1126,9 +1066,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         kmlock.lock_state = lock_state
 
             if kmlock.door_sensor_entity_id:
-                if temp_door_state := self.hass.states.get(
-                    kmlock.door_sensor_entity_id
-                ):
+                if temp_door_state := self.hass.states.get(kmlock.door_sensor_entity_id):
                     door_state: str = temp_door_state.state
                     if door_state in {STATE_OPEN, STATE_CLOSED}:
                         if (
@@ -1175,9 +1113,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 self.kmlocks[kmlock.keymaster_config_entry_id].pending_delete = False
                 await self._update_lock(kmlock)
                 return
-            _LOGGER.debug(
-                "[add_lock] %s: Lock already exists, not adding", kmlock.lock_name
-            )
+            _LOGGER.debug("[add_lock] %s: Lock already exists, not adding", kmlock.lock_name)
             return
         _LOGGER.debug("[add_lock] %s", kmlock.lock_name)
         self.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
@@ -1192,9 +1128,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         await self._initial_setup_done_event.wait()
         _LOGGER.debug("[update_lock] %s", new.lock_name)
         if new.keymaster_config_entry_id not in self.kmlocks:
-            _LOGGER.debug(
-                "[update_lock] %s: Can't update, lock doesn't exist", new.lock_name
-            )
+            _LOGGER.debug("[update_lock] %s: Can't update, lock doesn't exist", new.lock_name)
             return False
         old: KeymasterLock = self.kmlocks[new.keymaster_config_entry_id]
         if (
@@ -1235,26 +1169,16 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             new_kmslot.notifications = old_kmslot.notifications
             new_kmslot.accesslimit_count_enabled = old_kmslot.accesslimit_count_enabled
             new_kmslot.accesslimit_count = old_kmslot.accesslimit_count
-            new_kmslot.accesslimit_date_range_enabled = (
-                old_kmslot.accesslimit_date_range_enabled
-            )
-            new_kmslot.accesslimit_date_range_start = (
-                old_kmslot.accesslimit_date_range_start
-            )
-            new_kmslot.accesslimit_date_range_end = (
-                old_kmslot.accesslimit_date_range_end
-            )
-            new_kmslot.accesslimit_day_of_week_enabled = (
-                old_kmslot.accesslimit_day_of_week_enabled
-            )
+            new_kmslot.accesslimit_date_range_enabled = old_kmslot.accesslimit_date_range_enabled
+            new_kmslot.accesslimit_date_range_start = old_kmslot.accesslimit_date_range_start
+            new_kmslot.accesslimit_date_range_end = old_kmslot.accesslimit_date_range_end
+            new_kmslot.accesslimit_day_of_week_enabled = old_kmslot.accesslimit_day_of_week_enabled
             if not new_kmslot.accesslimit_day_of_week:
                 continue
             for dow_num, new_dow in new_kmslot.accesslimit_day_of_week.items():
                 if not old_kmslot.accesslimit_day_of_week:
                     continue
-                old_dow: KeymasterCodeSlotDayOfWeek = (
-                    old_kmslot.accesslimit_day_of_week[dow_num]
-                )
+                old_dow: KeymasterCodeSlotDayOfWeek = old_kmslot.accesslimit_day_of_week[dow_num]
                 new_dow.dow_enabled = old_dow.dow_enabled
                 new_dow.limit_by_time = old_dow.limit_by_time
                 new_dow.include_exclude = old_dow.include_exclude
@@ -1288,9 +1212,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
             return
         _LOGGER.debug("[delete_lock] %s: Deleting", kmlock.lock_name)
-        await self.hass.async_add_executor_job(
-            delete_lovelace, self.hass, kmlock.lock_name
-        )
+        await self.hass.async_add_executor_job(delete_lovelace, self.hass, kmlock.lock_name)
         if kmlock.autolock_timer:
             await kmlock.autolock_timer.cancel()
         await KeymasterCoordinator._unsubscribe_listeners(
@@ -1333,17 +1255,13 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 count += 1
         return count
 
-    async def get_lock_by_config_entry_id(
-        self, config_entry_id: str
-    ) -> KeymasterLock | None:
+    async def get_lock_by_config_entry_id(self, config_entry_id: str) -> KeymasterLock | None:
         """Get a keymaster lock by entry_id."""
         await self._initial_setup_done_event.wait()
         # _LOGGER.debug(f"[get_lock_by_config_entry_id] config_entry_id: {config_entry_id}")
         return self.kmlocks.get(config_entry_id, None)
 
-    def sync_get_lock_by_config_entry_id(
-        self, config_entry_id: str
-    ) -> KeymasterLock | None:
+    def sync_get_lock_by_config_entry_id(self, config_entry_id: str) -> KeymasterLock | None:
         """Get a keymaster lock by entry_id."""
         # _LOGGER.debug(f"[sync_get_lock_by_config_entry_id] config_entry_id: {config_entry_id}")
         return self.kmlocks.get(config_entry_id, None)
@@ -1360,9 +1278,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         await self._initial_setup_done_event.wait()
         # _LOGGER.debug(f"[set_pin_on_lock] config_entry_id: {config_entry_id}, code_slot_num: {code_slot_num}, pin: {pin}, update_after: {update_after}")
 
-        kmlock: KeymasterLock | None = await self.get_lock_by_config_entry_id(
-            config_entry_id
-        )
+        kmlock: KeymasterLock | None = await self.get_lock_by_config_entry_id(config_entry_id)
         if not isinstance(kmlock, KeymasterLock):
             _LOGGER.error(
                 "[Coordinator] Can't find lock with config_entry_id: %s",
@@ -1454,9 +1370,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     ) -> bool:
         """Clear the usercode from a code slot."""
         await self._initial_setup_done_event.wait()
-        kmlock: KeymasterLock | None = await self.get_lock_by_config_entry_id(
-            config_entry_id
-        )
+        kmlock: KeymasterLock | None = await self.get_lock_by_config_entry_id(config_entry_id)
         if not isinstance(kmlock, KeymasterLock):
             _LOGGER.error(
                 "[Coordinator] Can't find lock with config_entry_id: %s",
@@ -1518,9 +1432,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     code_slot_num,
                 )
             try:
-                usercode: ZwaveJSCodeSlot = get_usercode(
-                    kmlock.zwave_js_lock_node, code_slot_num
-                )
+                usercode: ZwaveJSCodeSlot = get_usercode(kmlock.zwave_js_lock_node, code_slot_num)
             except BaseZwaveJSServerError as e:
                 _LOGGER.error(
                     "[Coordinator] %s: Code Slot %s: Unable to confirm PIN is cleared. %s: %s",
@@ -1600,9 +1512,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         dow_slots: MutableMapping[int, KeymasterCodeSlotDayOfWeek] = {}
         for i, dow in enumerate(DAY_NAMES):
-            dow_slots[i] = KeymasterCodeSlotDayOfWeek(
-                day_of_week_num=i, day_of_week_name=dow
-            )
+            dow_slots[i] = KeymasterCodeSlotDayOfWeek(day_of_week_num=i, day_of_week_name=dow)
         new_kmslot = KeymasterCodeSlot(
             number=code_slot_num, enabled=False, accesslimit_day_of_week=dow_slots
         )
@@ -1619,8 +1529,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             return False
 
         if kmslot.accesslimit_count_enabled and (
-            not isinstance(kmslot.accesslimit_count, float)
-            or kmslot.accesslimit_count <= 0
+            not isinstance(kmslot.accesslimit_count, float) or kmslot.accesslimit_count <= 0
         ):
             return False
 
@@ -1634,12 +1543,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         if kmslot.accesslimit_day_of_week_enabled and kmslot.accesslimit_day_of_week:
             today_index: int = dt.now().astimezone().weekday()
-            today: KeymasterCodeSlotDayOfWeek = kmslot.accesslimit_day_of_week[
-                today_index
-            ]
-            _LOGGER.debug(
-                "[is_slot_active] today_index: %s, today: %s", today_index, today
-            )
+            today: KeymasterCodeSlotDayOfWeek = kmslot.accesslimit_day_of_week[today_index]
+            _LOGGER.debug("[is_slot_active] today_index: %s, today: %s", today_index, today)
             if not today.dow_enabled:
                 return False
 
@@ -1661,10 +1566,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 and (
                     not isinstance(today.time_start, dt_time)
                     or not isinstance(today.time_end, dt_time)
-                    or (
-                        dt.now().time() >= today.time_start
-                        and dt.now().time() <= today.time_end
-                    )
+                    or (dt.now().time() >= today.time_start and dt.now().time() <= today.time_end)
                 )
             ):
                 return False
@@ -1674,14 +1576,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     async def _trigger_quick_refresh(self, _: dt) -> None:
         await self.async_request_refresh()
 
-    async def update_slot_active_state(
-        self, config_entry_id: str, code_slot_num: int
-    ) -> bool:
+    async def update_slot_active_state(self, config_entry_id: str, code_slot_num: int) -> bool:
         """Update the active state for a code slot."""
         await self._initial_setup_done_event.wait()
-        kmlock: KeymasterLock | None = await self.get_lock_by_config_entry_id(
-            config_entry_id
-        )
+        kmlock: KeymasterLock | None = await self.get_lock_by_config_entry_id(config_entry_id)
         if not isinstance(kmlock, KeymasterLock):
             _LOGGER.error(
                 "[Coordinator] Can't find lock with config_entry_id: %s",
@@ -1697,8 +1595,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
             return False
 
-        kmlock.code_slots[code_slot_num].active = (
-            await KeymasterCoordinator._is_slot_active(kmlock.code_slots[code_slot_num])
+        kmlock.code_slots[code_slot_num].active = await KeymasterCoordinator._is_slot_active(
+            kmlock.code_slots[code_slot_num]
         )
         return True
 
@@ -1762,9 +1660,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             and kmlock.connected
             and prev_lock_connected
         ):
-            kmlock_node_state: MutableMapping = dump_node_state(
-                kmlock.zwave_js_lock_node
-            )
+            kmlock_node_state: MutableMapping = dump_node_state(kmlock.zwave_js_lock_node)
             _LOGGER.debug(
                 "[connect_and_update_lock] %s: node_status: %s",
                 kmlock.lock_name,
@@ -1789,9 +1685,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         lock_dev_reg_entry = None
         if lock_ent_reg_entry and lock_ent_reg_entry.device_id:
-            lock_dev_reg_entry = self._device_registry.async_get(
-                lock_ent_reg_entry.device_id
-            )
+            lock_dev_reg_entry = self._device_registry.async_get(lock_ent_reg_entry.device_id)
         if not lock_dev_reg_entry:
             _LOGGER.error(
                 "[Coordinator] %s: Can't find the lock in the Device Registry",
@@ -1841,15 +1735,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         # Update all keymaster locks
         for keymaster_config_entry_id in self.kmlocks:
-            await self._update_lock_data(
-                keymaster_config_entry_id=keymaster_config_entry_id
-            )
+            await self._update_lock_data(keymaster_config_entry_id=keymaster_config_entry_id)
 
         # Propagate parent kmlock settings to child kmlocks
         for keymaster_config_entry_id in self.kmlocks:
-            await self._sync_child_locks(
-                keymaster_config_entry_id=keymaster_config_entry_id
-            )
+            await self._sync_child_locks(keymaster_config_entry_id=keymaster_config_entry_id)
 
         # Handle sync status update if necessary
         if self._sync_status_counter > SYNC_STATUS_THRESHOLD:
@@ -1891,15 +1781,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         node: ZwaveJSNode | None = kmlock.zwave_js_lock_node
         if node is None:
-            _LOGGER.error(
-                "[Coordinator] %s: Z-Wave JS Node not defined", kmlock.lock_name
-            )
+            _LOGGER.error("[Coordinator] %s: Z-Wave JS Node not defined", kmlock.lock_name)
             return
 
-        usercodes: list[ZwaveJSCodeSlot] = (
-            await KeymasterCoordinator._get_usercodes_from_node(
-                node=node, kmlock=kmlock
-            )
+        usercodes: list[ZwaveJSCodeSlot] = await KeymasterCoordinator._get_usercodes_from_node(
+            node=node, kmlock=kmlock
         )
         _LOGGER.debug(
             "[update_lock_data] %s: usercodes: %s",
@@ -1936,9 +1822,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         # Check active status of code slots and set/clear PINs on Z-Wave JS Lock
         if kmlock.code_slots:
             for code_slot_num, kmslot in kmlock.code_slots.items():
-                await self._update_slot(
-                    kmlock=kmlock, kmslot=kmslot, code_slot_num=code_slot_num
-                )
+                await self._update_slot(kmlock=kmlock, kmslot=kmslot, code_slot_num=code_slot_num)
 
         # Get usercodes from Z-Wave JS Lock and update kmlock PINs
         for usercode_slot in usercodes:
@@ -1967,9 +1851,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 override=True,
             )
 
-    async def _sync_usercode(
-        self, kmlock: KeymasterLock, usercode_slot: ZwaveJSCodeSlot
-    ) -> None:
+    async def _sync_usercode(self, kmlock: KeymasterLock, usercode_slot: ZwaveJSCodeSlot) -> None:
         """Sync a usercode from Z-Wave JS."""
         code_slot_num: int = int(usercode_slot[ZWAVEJS_ATTR_CODE_SLOT])
         usercode: str = usercode_slot[ZWAVEJS_ATTR_USERCODE]
@@ -1982,12 +1864,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             usercode_resp: ZwaveJSCodeSlot = await get_usercode_from_node(
                 kmlock.zwave_js_lock_node, code_slot_num
             )
-            usercode = usercode_slot[ZWAVEJS_ATTR_USERCODE] = usercode_resp[
-                ZWAVEJS_ATTR_USERCODE
-            ]
-            in_use = usercode_slot[ZWAVEJS_ATTR_IN_USE] = usercode_resp[
-                ZWAVEJS_ATTR_IN_USE
-            ]
+            usercode = usercode_slot[ZWAVEJS_ATTR_USERCODE] = usercode_resp[ZWAVEJS_ATTR_USERCODE]
+            in_use = usercode_slot[ZWAVEJS_ATTR_IN_USE] = usercode_resp[ZWAVEJS_ATTR_IN_USE]
 
         # Fix for Schlage masked responses: if slot is not in use (status=0) but
         # usercode is masked (e.g., "**********"), treat it as empty
@@ -1996,9 +1874,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         await self._sync_pin(kmlock, code_slot_num, usercode)
 
-    async def _sync_pin(
-        self, kmlock: KeymasterLock, code_slot_num: int, usercode: str
-    ) -> None:
+    async def _sync_pin(self, kmlock: KeymasterLock, code_slot_num: int, usercode: str) -> None:
         """Sync the pin with the lock based on conditions."""
         if not kmlock.code_slots:
             return
@@ -2071,9 +1947,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         for child_entry_id in kmlock.child_config_entry_ids:
             await self._sync_child_lock(kmlock, child_entry_id)
 
-    async def _sync_child_lock(
-        self, kmlock: KeymasterLock, child_entry_id: str
-    ) -> None:
+    async def _sync_child_lock(self, kmlock: KeymasterLock, child_entry_id: str) -> None:
         """Sync the settings for a child lock."""
         child_kmlock = await self.get_lock_by_config_entry_id(child_entry_id)
         if not isinstance(child_kmlock, KeymasterLock):
@@ -2084,9 +1958,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             return
 
         if not async_using_zwave_js(hass=self.hass, kmlock=child_kmlock):
-            _LOGGER.error(
-                "[Coordinator] %s: Not using Z-Wave JS", child_kmlock.lock_name
-            )
+            _LOGGER.error("[Coordinator] %s: Not using Z-Wave JS", child_kmlock.lock_name)
             return
 
         if kmlock.code_slots == child_kmlock.code_slots:
@@ -2106,10 +1978,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if not kmlock.code_slots:
             return
         for code_slot_num, kmslot in kmlock.code_slots.items():
-            if (
-                not child_kmlock.code_slots
-                or code_slot_num not in child_kmlock.code_slots
-            ):
+            if not child_kmlock.code_slots or code_slot_num not in child_kmlock.code_slots:
                 continue
             if (
                 not child_kmlock.code_slots
@@ -2144,9 +2013,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
             # If parent slot is disabled or inactive, treat parent PIN as None for comparison
             # to prevent endless clear loops when parent still has PIN in memory
-            parent_pin_for_comparison = (
-                kmslot.pin if (kmslot.enabled and kmslot.active) else None
-            )
+            parent_pin_for_comparison = kmslot.pin if (kmslot.enabled and kmslot.active) else None
 
             pin_mismatch = parent_pin_for_comparison != child_pin and not (
                 child_pin and "*" in child_pin

--- a/custom_components/keymaster/datetime.py
+++ b/custom_components/keymaster/datetime.py
@@ -66,9 +66,7 @@ async def async_setup_entry(
 
 
 @dataclass(frozen=True, kw_only=True)
-class KeymasterDateTimeEntityDescription(
-    KeymasterEntityDescription, DateTimeEntityDescription
-):
+class KeymasterDateTimeEntityDescription(KeymasterEntityDescription, DateTimeEntityDescription):
     """Entity Description for keymaster DateTime."""
 
 
@@ -109,8 +107,7 @@ class KeymasterDateTime(KeymasterEntity, DateTimeEntity):
             return
 
         if ".code_slots" in self._property and (
-            not self._kmlock.code_slots
-            or self._code_slot not in self._kmlock.code_slots
+            not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
             self.async_write_ha_state()

--- a/custom_components/keymaster/entity.py
+++ b/custom_components/keymaster/entity.py
@@ -36,26 +36,18 @@ class KeymasterEntity(CoordinatorEntity[KeymasterCoordinator]):
         self._config_entry: ConfigEntry = entity_description.config_entry
         self.entity_description: KeymasterEntityDescription = entity_description
         self._attr_available = False
-        self._property: str = (
-            entity_description.key
-        )  # <Platform>.<Property>.<SubProperty>:<Slot Number*>.<SubProperty>:<Slot Number*>  *Only if needed
-        self._kmlock: KeymasterLock | None = (
-            self.coordinator.sync_get_lock_by_config_entry_id(
-                self._config_entry.entry_id
-            )
+        self._property: str = entity_description.key  # <Platform>.<Property>.<SubProperty>:<Slot Number*>.<SubProperty>:<Slot Number*>  *Only if needed
+        self._kmlock: KeymasterLock | None = self.coordinator.sync_get_lock_by_config_entry_id(
+            self._config_entry.entry_id
         )
         if self._kmlock:
-            self._attr_name: str | None = (
-                f"{self._kmlock.lock_name} {self.entity_description.name}"
-            )
+            self._attr_name: str | None = f"{self._kmlock.lock_name} {self.entity_description.name}"
         # _LOGGER.debug(
         #     "[Entity init] entity_description.name: %s, name: %s",
         #     self.entity_description.name,
         #     self.name,
         # )
-        self._attr_unique_id: str = (
-            f"{self._config_entry.entry_id}_{slugify(self._property)}"
-        )
+        self._attr_unique_id: str = f"{self._config_entry.entry_id}_{slugify(self._property)}"
         # _LOGGER.debug(
         #     "[Entity init] %s: property: %s, unique_id: %s",
         #     self.name,

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -31,9 +31,7 @@ class Throttle:
 
     def __init__(self) -> None:
         """Initialize Throttle class."""
-        self._cooldowns: MutableMapping = (
-            {}
-        )  # Nested dictionary: {function_name: {key: last_called_time}}
+        self._cooldowns: MutableMapping = {}  # Nested dictionary: {function_name: {key: last_called_time}}
 
     def is_allowed(self, func_name: str, key: str, cooldown_seconds: int) -> bool:
         """Check if function is allowed to run or not."""
@@ -80,9 +78,7 @@ class KeymasterTimer:
             self._unsub_events = []
 
         if sun.is_up(self.hass):
-            delay: int = (
-                self._kmlock.autolock_min_day or DEFAULT_AUTOLOCK_MIN_DAY
-            ) * 60
+            delay: int = (self._kmlock.autolock_min_day or DEFAULT_AUTOLOCK_MIN_DAY) * 60
         else:
             delay = (self._kmlock.autolock_min_night or DEFAULT_AUTOLOCK_MIN_NIGHT) * 60
         self._end_time = dt.now().astimezone() + timedelta(seconds=delay)
@@ -94,9 +90,7 @@ class KeymasterTimer:
         self._unsub_events.append(
             async_call_later(hass=self.hass, delay=delay, action=self._call_action)
         )
-        self._unsub_events.append(
-            async_call_later(hass=self.hass, delay=delay, action=self.cancel)
-        )
+        self._unsub_events.append(async_call_later(hass=self.hass, delay=delay, action=self.cancel))
         return True
 
     async def cancel(self, timer_elapsed: dt | None = None) -> None:
@@ -239,9 +233,7 @@ async def delete_code_slot_entities(
         if entity_id:
             try:
                 entity_registry.async_remove(entity_id)
-                _LOGGER.debug(
-                    "[delete_code_slot_entities] Removed entity: %s", entity_id
-                )
+                _LOGGER.debug("[delete_code_slot_entities] Removed entity: %s", entity_id)
             except (KeyError, ValueError) as e:
                 _LOGGER.warning(
                     "Error removing entity: %s. %s: %s",
@@ -269,9 +261,7 @@ async def delete_code_slot_entities(
             if entity_id:
                 try:
                     entity_registry.async_remove(entity_id)
-                    _LOGGER.debug(
-                        "[delete_code_slot_entities] Removed entity: %s", entity_id
-                    )
+                    _LOGGER.debug("[delete_code_slot_entities] Removed entity: %s", entity_id)
                 except (KeyError, ValueError) as e:
                     _LOGGER.warning(
                         "Error removing entity: %s. %s: %s",
@@ -280,9 +270,7 @@ async def delete_code_slot_entities(
                         e,
                     )
             else:
-                _LOGGER.debug(
-                    "[delete_code_slot_entities] No entity_id found for %s", prop
-                )
+                _LOGGER.debug("[delete_code_slot_entities] No entity_id found for %s", prop)
 
 
 async def call_hass_service(
@@ -302,9 +290,7 @@ async def call_hass_service(
     )
 
     try:
-        await hass.services.async_call(
-            domain, service, service_data=service_data, target=target
-        )
+        await hass.services.async_call(domain, service, service_data=service_data, target=target)
     except ServiceNotFound:
         _LOGGER.warning("Action Not Found: %s.%s", domain, service)
 
@@ -351,11 +337,7 @@ async def send_persistent_notification(
     )
 
 
-async def dismiss_persistent_notification(
-    hass: HomeAssistant, notification_id: str
-) -> None:
+async def dismiss_persistent_notification(hass: HomeAssistant, notification_id: str) -> None:
     """Clear or dismisss a persistent notification."""
-    _LOGGER.debug(
-        "[dismiss_persistent_notification] notification_id: %s", notification_id
-    )
+    _LOGGER.debug("[dismiss_persistent_notification] notification_id: %s", notification_id)
     persistent_notification.async_dismiss(hass=hass, notification_id=notification_id)

--- a/custom_components/keymaster/lock.py
+++ b/custom_components/keymaster/lock.py
@@ -45,9 +45,7 @@ class KeymasterCodeSlot:
     accesslimit_date_range_start: dt | None = None
     accesslimit_date_range_end: dt | None = None
     accesslimit_day_of_week_enabled: bool = False
-    accesslimit_day_of_week: MutableMapping[int, KeymasterCodeSlotDayOfWeek] | None = (
-        None
-    )
+    accesslimit_day_of_week: MutableMapping[int, KeymasterCodeSlotDayOfWeek] | None = None
 
 
 @dataclass

--- a/custom_components/keymaster/migrate.py
+++ b/custom_components/keymaster/migrate.py
@@ -69,9 +69,7 @@ async def migrate_2to3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
         ent = hass.states.get(ent_id)
         if not ent:
             continue
-        await _migrate_2to3_set_property_value(
-            kmlock=kmlock, prop=prop, value=ent.state
-        )
+        await _migrate_2to3_set_property_value(kmlock=kmlock, prop=prop, value=ent.state)
     _LOGGER.debug("[migrate_2to3] kmlock: %s", kmlock)
     hass.data.setdefault(DOMAIN, {})
     if COORDINATOR not in hass.data[DOMAIN]:
@@ -91,9 +89,7 @@ async def migrate_2to3(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
 
     # Delete Package files
     _LOGGER.info("[migrate_2to3] Deleting Package files")
-    await hass.async_add_executor_job(
-        _migrate_2to3_delete_lock_and_base_folder, hass, config_entry
-    )
+    await hass.async_add_executor_job(_migrate_2to3_delete_lock_and_base_folder, hass, config_entry)
 
     # FIX: Check the return value. If reload fails, abort migration.
     if not await _migrate_2to3_reload_package_platforms(hass=hass):
@@ -149,9 +145,7 @@ async def _migrate_2to3_create_kmlock(config_entry: ConfigEntry) -> KeymasterLoc
     ):
         dow_slots: MutableMapping[int, KeymasterCodeSlotDayOfWeek] = {}
         for i, dow in enumerate(DAY_NAMES):
-            dow_slots[i] = KeymasterCodeSlotDayOfWeek(
-                day_of_week_num=i, day_of_week_name=dow
-            )
+            dow_slots[i] = KeymasterCodeSlotDayOfWeek(day_of_week_num=i, day_of_week_name=dow)
         code_slots[x] = KeymasterCodeSlot(number=x, accesslimit_day_of_week=dow_slots)
 
     return KeymasterLock(
@@ -173,9 +167,7 @@ async def _migrate_2to3_create_kmlock(config_entry: ConfigEntry) -> KeymasterLoc
     )
 
 
-async def _migrate_2to3_set_property_value(
-    kmlock: KeymasterLock, prop: str, value: Any
-) -> bool:
+async def _migrate_2to3_set_property_value(kmlock: KeymasterLock, prop: str, value: Any) -> bool:
     if "." not in prop:
         return False
 
@@ -193,10 +185,8 @@ async def _migrate_2to3_set_property_value(
     final_prop: str = prop_list[-1]
     if ":" in final_prop:
         attr, num = final_prop.split(":")
-        getattr(obj, attr)[int(num)] = (
-            await _migrate_2to3_validate_and_convert_property(
-                prop=prop, attr=attr, value=value
-            )
+        getattr(obj, attr)[int(num)] = await _migrate_2to3_validate_and_convert_property(
+            prop=prop, attr=attr, value=value
         )
     else:
         setattr(
@@ -210,9 +200,7 @@ async def _migrate_2to3_set_property_value(
     return True
 
 
-async def _migrate_2to3_validate_and_convert_property(
-    prop: str, attr: str, value: Any
-) -> Any:
+async def _migrate_2to3_validate_and_convert_property(prop: str, attr: str, value: Any) -> Any:
     if keymasterlock_type_lookup.get(attr) is not None and isinstance(
         value, keymasterlock_type_lookup.get(attr, object)
     ):
@@ -226,9 +214,7 @@ async def _migrate_2to3_validate_and_convert_property(
         except ValueError:
             try:
                 time_obj: dt = dt.strptime(value, "%H:%M:%S")
-                value = round(
-                    time_obj.hour * 60 + time_obj.minute + round(time_obj.second)
-                )
+                value = round(time_obj.hour * 60 + time_obj.minute + round(time_obj.second))
             except ValueError:
                 _LOGGER.debug(
                     "[migrate_2to3_set_property_value] Value Type Mismatch, cannot convert str to int. Property: %s, final_prop: %s, value: %s. Type: %s, Expected Type: %s",
@@ -325,9 +311,7 @@ async def _migrate_2to3_reload_package_platforms(hass: HomeAssistant) -> bool:
         TIMER_DOMAIN,
     ]:
         if hass.services.has_service(domain=domain, service=SERVICE_RELOAD):
-            await hass.services.async_call(
-                domain=domain, service=SERVICE_RELOAD, blocking=True
-            )
+            await hass.services.async_call(domain=domain, service=SERVICE_RELOAD, blocking=True)
         else:
             _LOGGER.warning("Reload service not found for domain: %s", domain)
             return False

--- a/custom_components/keymaster/number.py
+++ b/custom_components/keymaster/number.py
@@ -95,9 +95,7 @@ async def async_setup_entry(
 
 
 @dataclass(frozen=True, kw_only=True)
-class KeymasterNumberEntityDescription(
-    KeymasterEntityDescription, NumberEntityDescription
-):
+class KeymasterNumberEntityDescription(KeymasterEntityDescription, NumberEntityDescription):
     """Entity Description for keymaster Number entities."""
 
 
@@ -139,8 +137,7 @@ class KeymasterNumber(KeymasterEntity, NumberEntity):
             return
 
         if ".code_slots" in self._property and (
-            not self._kmlock.code_slots
-            or self._code_slot not in self._kmlock.code_slots
+            not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
             self.async_write_ha_state()

--- a/custom_components/keymaster/sensor.py
+++ b/custom_components/keymaster/sensor.py
@@ -80,9 +80,7 @@ async def async_setup_entry(
 
 
 @dataclass(frozen=True, kw_only=True)
-class KeymasterSensorEntityDescription(
-    KeymasterEntityDescription, SensorEntityDescription
-):
+class KeymasterSensorEntityDescription(KeymasterEntityDescription, SensorEntityDescription):
     """Entity Description for keymaster Sensors."""
 
 
@@ -110,8 +108,7 @@ class KeymasterSensor(KeymasterEntity, SensorEntity):
             return
 
         if ".code_slots" in self._property and (
-            not self._kmlock.code_slots
-            or self._code_slot not in self._kmlock.code_slots
+            not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
             self.async_write_ha_state()

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -73,17 +73,17 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         entries: list[ConfigEntry] = hass.config_entries.async_entries(domain=DOMAIN)
         for config_entry in entries:
             await async_generate_lovelace(
-                    hass=hass,
-                    kmlock_name=config_entry.data[CONF_LOCK_NAME],
-                    keymaster_config_entry_id=config_entry.entry_id,
-                    parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
-                    code_slot_start=config_entry.data[CONF_START],
-                    code_slots=config_entry.data[CONF_SLOTS],
-                    lock_entity=config_entry.data[CONF_LOCK_ENTITY_ID],
-                    advanced_date_range=config_entry.data[CONF_ADVANCED_DATE_RANGE],
-                    advanced_day_of_week=config_entry.data[CONF_ADVANCED_DAY_OF_WEEK],
-                    door_sensor=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
-                )
+                hass=hass,
+                kmlock_name=config_entry.data[CONF_LOCK_NAME],
+                keymaster_config_entry_id=config_entry.entry_id,
+                parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
+                code_slot_start=config_entry.data[CONF_START],
+                code_slots=config_entry.data[CONF_SLOTS],
+                lock_entity=config_entry.data[CONF_LOCK_ENTITY_ID],
+                advanced_date_range=config_entry.data[CONF_ADVANCED_DATE_RANGE],
+                advanced_day_of_week=config_entry.data[CONF_ADVANCED_DAY_OF_WEEK],
+                door_sensor=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
+            )
 
     # hass.services.async_register(
     #     DOMAIN,

--- a/custom_components/keymaster/switch.py
+++ b/custom_components/keymaster/switch.py
@@ -162,9 +162,7 @@ async def async_setup_entry(
 
 
 @dataclass(frozen=True, kw_only=True)
-class KeymasterSwitchEntityDescription(
-    KeymasterEntityDescription, SwitchEntityDescription
-):
+class KeymasterSwitchEntityDescription(KeymasterEntityDescription, SwitchEntityDescription):
     """Entity Description for keymaster Switches."""
 
 
@@ -211,10 +209,7 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
         if (
             not self._property.endswith(".enabled")
             and ".code_slots" in self._property
-            and (
-                not self._kmlock.code_slots
-                or self._code_slot not in self._kmlock.code_slots
-            )
+            and (not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots)
         ):
             self._attr_available = False
             self.async_write_ha_state()
@@ -226,18 +221,14 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
             and (
                 not self._kmlock.code_slots
                 or not self._code_slot
-                or not self._kmlock.code_slots[
-                    self._code_slot
-                ].accesslimit_day_of_week_enabled
+                or not self._kmlock.code_slots[self._code_slot].accesslimit_day_of_week_enabled
             )
         ):
             self._attr_available = False
             self.async_write_ha_state()
             return
 
-        code_slots: MutableMapping[int, KeymasterCodeSlot] | None = (
-            self._kmlock.code_slots
-        )
+        code_slots: MutableMapping[int, KeymasterCodeSlot] | None = self._kmlock.code_slots
         accesslimit_dow: MutableMapping[int, KeymasterCodeSlotDayOfWeek] | None = None
         if self._code_slot is not None and code_slots and self._code_slot in code_slots:
             accesslimit_dow = code_slots[self._code_slot].accesslimit_day_of_week

--- a/custom_components/keymaster/text.py
+++ b/custom_components/keymaster/text.py
@@ -106,8 +106,7 @@ class KeymasterText(KeymasterEntity, TextEntity):
             return
 
         if ".code_slots" in self._property and (
-            not self._kmlock.code_slots
-            or self._code_slot not in self._kmlock.code_slots
+            not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
             self.async_write_ha_state()

--- a/custom_components/keymaster/time.py
+++ b/custom_components/keymaster/time.py
@@ -119,8 +119,7 @@ class KeymasterTime(KeymasterEntity, TimeEntity):
             return
 
         if ".code_slots" in self._property and (
-            not self._kmlock.code_slots
-            or self._code_slot not in self._kmlock.code_slots
+            not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
             self.async_write_ha_state()
@@ -129,24 +128,20 @@ class KeymasterTime(KeymasterEntity, TimeEntity):
         if ".accesslimit_day_of_week" in self._property and (
             not self._kmlock.code_slots
             or not self._code_slot
-            or not self._kmlock.code_slots[
-                self._code_slot
-            ].accesslimit_day_of_week_enabled
+            or not self._kmlock.code_slots[self._code_slot].accesslimit_day_of_week_enabled
         ):
             self._attr_available = False
             self.async_write_ha_state()
             return
 
-        if self._property.endswith(".time_start") or self._property.endswith(
-            ".time_end"
-        ):
+        if self._property.endswith(".time_start") or self._property.endswith(".time_end"):
             # code_slots and _code_slot validation already handled by lines 117-121 above
             # Safe to assert these are not None here
             assert self._kmlock.code_slots is not None
             assert self._code_slot is not None
-            accesslimit_day_of_week: (
-                MutableMapping[int, KeymasterCodeSlotDayOfWeek] | None
-            ) = self._kmlock.code_slots[self._code_slot].accesslimit_day_of_week
+            accesslimit_day_of_week: MutableMapping[int, KeymasterCodeSlotDayOfWeek] | None = (
+                self._kmlock.code_slots[self._code_slot].accesslimit_day_of_week
+            )
             if (
                 self._day_of_week_num is None
                 or accesslimit_day_of_week is None
@@ -159,11 +154,7 @@ class KeymasterTime(KeymasterEntity, TimeEntity):
             day_of_week: KeymasterCodeSlotDayOfWeek | None = accesslimit_day_of_week[
                 self._day_of_week_num
             ]
-            if (
-                day_of_week is None
-                or not day_of_week.dow_enabled
-                or not day_of_week.limit_by_time
-            ):
+            if day_of_week is None or not day_of_week.dow_enabled or not day_of_week.limit_by_time:
                 self._attr_available = False
                 self.async_write_ha_state()
                 return
@@ -195,10 +186,7 @@ class KeymasterTime(KeymasterEntity, TimeEntity):
             value,
         )
         if (
-            (
-                self._property.endswith(".time_start")
-                or self._property.endswith(".time_end")
-            )
+            (self._property.endswith(".time_start") or self._property.endswith(".time_end"))
             and self._kmlock
             and self._kmlock.parent_name
             and (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -524,8 +524,6 @@ ignore = [
 
   "TRY003", # Avoid specifying long messages outside the exception class
   "TRY400", # Use `logging.exception` instead of `logging.error`
-  # Ignored due to performance: https://github.com/charliermarsh/ruff/issues/2923
-  "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
   "UP046", # Non PEP 695 generic class
   "UP047", # Non PEP 696 generic function
   "UP049", # Avoid private type parameter names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -625,40 +625,5 @@ max-complexity = 25
 [tool.ruff.lint.pydocstyle]
 property-decorators = ["propcache.cached_property"]
 
-[tool.tox.gh-actions]
-python = """
-    3.13: py313, lint, mypy
-    3.14: py314
-"""
-
-[tool.tox]
-skipsdist = true
-requires = ["tox>=4.19"]
-env_list = ["py313", "py314", "lint", "mypy"]
-skip_missing_interpreters = true
-
-[tool.tox.env_run_base]
-description = "Run pytest under {base_python}"
-commands = [[ "pytest", "tests", { replace = "posargs", extend = true} ]]
-deps = ["-rrequirements_test.txt"]
-ignore_errors = true
-
-[tool.tox.env.lint]
-description = "Lint code using ruff under {base_python}"
-ignore_errors = true
-commands = [
-    ["ruff", "format", "custom_components{/}"],
-    ["ruff", "format", "tests{/}"],
-    ["ruff", "check", "custom_components{/}"],
-    ["ruff", "check", "tests{/}"],
-]
-deps = ["-rrequirements_lint.txt"]
-
-[tool.tox.env.mypy]
-description = "Run mypy for type-checking under {base_python}"
-ignore_errors = true
-commands = [["mypy", "custom_components{/}keymaster"]]
-deps = ["-rrequirements_lint.txt"]
-
 [tool.codespell]
 ignore-words-list = "hass"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,3 @@
 # Development dependencies - includes test and lint
 -r requirements_test.txt
 -r requirements_lint.txt
-
-# Test orchestration for local development
-tox

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,6 @@
 # Test dependencies for pytest
 pytest
+pytest-cov
 pytest-homeassistant-custom-component
 
 # Additional HA ecosystem packages required by tests

--- a/tests/common.py
+++ b/tests/common.py
@@ -44,9 +44,7 @@ def threadsafe_callback_factory(func):
     def threadsafe(*args, **kwargs):
         """Call func threadsafe."""
         hass = args[0]
-        return run_callback_threadsafe(
-            hass.loop, ft.partial(func, *args, **kwargs)
-        ).result()
+        return run_callback_threadsafe(hass.loop, ft.partial(func, *args, **kwargs)).result()
 
     return threadsafe
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,9 +182,7 @@ def mock_client_fixture(
     listen_block: asyncio.Event,
 ):
     """Mock a client."""
-    with patch(
-        "homeassistant.components.zwave_js.ZwaveClient", autospec=True
-    ) as client_class:
+    with patch("homeassistant.components.zwave_js.ZwaveClient", autospec=True) as client_class:
         client = client_class.return_value
 
         async def connect():
@@ -219,9 +217,7 @@ def mock_client_fixture(
                 return {"changed": False}
             return DEFAULT
 
-        client.async_send_command.return_value = {
-            "result": {"success": True, "status": 255}
-        }
+        client.async_send_command.return_value = {"result": {"success": True, "status": 255}}
         client.async_send_command.side_effect = async_send_command_side_effect
 
         yield client
@@ -276,9 +272,7 @@ def controller_state_fixture():
 @pytest.fixture(name="controller_node_state", scope="package")
 def controller_node_state_fixture() -> dict[str, Any]:
     """Load the controller node state fixture data."""
-    return copy.deepcopy(
-        json.loads(load_fixture("zwave_js/controller_node_state.json"))
-    )
+    return copy.deepcopy(json.loads(load_fixture("zwave_js/controller_node_state.json")))
 
 
 @pytest.fixture(name="version_state", scope="package")
@@ -314,27 +308,21 @@ async def mock_zwavejs_get_usercodes():
         {"code_slot": 13, "usercode": "", "in_use": False},
         {"code_slot": 14, "usercode": "", "in_use": False},
     ]
-    with patch(
-        "zwave_js_server.util.lock.get_usercodes", return_value=slot_data
-    ) as mock_usercodes:
+    with patch("zwave_js_server.util.lock.get_usercodes", return_value=slot_data) as mock_usercodes:
         yield mock_usercodes
 
 
 @pytest.fixture
 async def mock_zwavejs_clear_usercode():
     """Fixture to mock clear_usercode."""
-    with patch(
-        "zwave_js_server.util.lock.clear_usercode", return_value=None
-    ) as mock_usercodes:
+    with patch("zwave_js_server.util.lock.clear_usercode", return_value=None) as mock_usercodes:
         yield mock_usercodes
 
 
 @pytest.fixture
 async def mock_zwavejs_set_usercode():
     """Fixture to mock set_usercode."""
-    with patch(
-        "zwave_js_server.util.lock.set_usercode", return_value=None
-    ) as mock_usercodes:
+    with patch("zwave_js_server.util.lock.set_usercode", return_value=None) as mock_usercodes:
         yield mock_usercodes
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -14,9 +14,7 @@ NETWORK_READY_ENTITY = "binary_sensor.frontdoor_network"
 KWIKSET_910_LOCK_ENTITY = "lock.garage_door"
 
 
-async def test_zwavejs_network_ready(
-    hass, client, lock_kwikset_910, integration, caplog
-):
+async def test_zwavejs_network_ready(hass, client, lock_kwikset_910, integration, caplog):
     """Test zwavejs network ready sensor."""
 
     # Skip test if Z-Wave integration didn't load properly (USB module missing)

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -83,9 +83,7 @@ async def test_button_entities_created(hass: HomeAssistant, button_config_entry)
     assert "Code Slot 2: Reset" in entity_names
 
 
-async def test_button_entity_initialization(
-    hass: HomeAssistant, button_config_entry, coordinator
-):
+async def test_button_entity_initialization(hass: HomeAssistant, button_config_entry, coordinator):
     """Test button entity initialization."""
     entity_description = KeymasterButtonEntityDescription(
         key="button.code_slots:1.reset",
@@ -202,9 +200,7 @@ async def test_button_entity_available_when_connected_and_slot_exists(
     assert entity._attr_available
 
 
-async def test_button_press_reset_lock(
-    hass: HomeAssistant, button_config_entry, coordinator
-):
+async def test_button_press_reset_lock(hass: HomeAssistant, button_config_entry, coordinator):
     """Test pressing reset lock button calls coordinator reset_lock."""
     # Create a connected lock
     kmlock = KeymasterLock(
@@ -237,9 +233,7 @@ async def test_button_press_reset_lock(
         )
 
 
-async def test_button_press_reset_code_slot(
-    hass: HomeAssistant, button_config_entry, coordinator
-):
+async def test_button_press_reset_code_slot(hass: HomeAssistant, button_config_entry, coordinator):
     """Test pressing reset code slot button calls coordinator reset_code_slot."""
     # Create a connected lock with code slot
     kmlock = KeymasterLock(
@@ -264,9 +258,7 @@ async def test_button_press_reset_code_slot(
     entity = KeymasterButton(entity_description=entity_description)
 
     # Mock coordinator.reset_code_slot
-    with patch.object(
-        coordinator, "reset_code_slot", new=AsyncMock()
-    ) as mock_reset_slot:
+    with patch.object(coordinator, "reset_code_slot", new=AsyncMock()) as mock_reset_slot:
         await entity.async_press()
 
         # Should call reset_code_slot with config entry ID and slot number

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -38,9 +38,7 @@ pytestmark = pytest.mark.asyncio
 
 async def test_no_locks_abort(hass):
     """Test the flow aborts when no locks are available."""
-    with patch(
-        "custom_components.keymaster.config_flow._get_entities", return_value=[]
-    ):
+    with patch("custom_components.keymaster.config_flow._get_entities", return_value=[]):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -98,9 +96,7 @@ async def test_form(test_user_input, title, final_config_flow_data, hass):
         "custom_components.keymaster.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         _LOGGER.warning("[test_form] result2 Starting")
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], test_user_input
-        )
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], test_user_input)
         _LOGGER.warning("[test_form] result2: %s", result2)
         assert result2["type"] is FlowResultType.CREATE_ENTRY
         assert result2["title"] == title
@@ -160,9 +156,7 @@ async def test_form_no_script(test_user_input, title, final_config_flow_data, ha
         "custom_components.keymaster.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         _LOGGER.warning("[test_form] result2 Starting")
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], test_user_input
-        )
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], test_user_input)
         _LOGGER.warning("[test_form] result2: %s", result2)
         assert result2["type"] is FlowResultType.CREATE_ENTRY
         assert result2["title"] == title
@@ -208,9 +202,7 @@ async def test_form_no_script(test_user_input, title, final_config_flow_data, ha
     ],
 )
 @pytest.mark.usefixtures("mock_get_entities")
-async def test_reconfiguration_form(
-    test_user_input, title, final_config_flow_data, hass
-):
+async def test_reconfiguration_form(test_user_input, title, final_config_flow_data, hass):
     """Test we get the form."""
     del title  # Used in parametrize but not in test body
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -53,10 +53,7 @@ def validate_lock_relationship_invariants(
 
     # Invariant 4: If child points to parent, parent must list child
     for lock_id, lock in coordinator.kmlocks.items():
-        if (
-            lock.parent_config_entry_id
-            and lock.parent_config_entry_id in coordinator.kmlocks
-        ):
+        if lock.parent_config_entry_id and lock.parent_config_entry_id in coordinator.kmlocks:
             parent = coordinator.kmlocks[lock.parent_config_entry_id]
             if lock_id not in parent.child_config_entry_ids:
                 violations.append(
@@ -128,9 +125,7 @@ class TestVerifyLockConfiguration:
         """Test that valid config entries are not deleted."""
         # Arrange
         mock_coordinator.kmlocks = {"test_entry_id": mock_keymaster_lock}
-        mock_coordinator.hass.config_entries.async_get_entry.return_value = (
-            mock_config_entry
-        )
+        mock_coordinator.hass.config_entries.async_get_entry.return_value = mock_config_entry
 
         # Act
         await mock_coordinator._verify_lock_configuration()
@@ -156,9 +151,7 @@ class TestVerifyLockConfiguration:
         mock_coordinator.hass.config_entries.async_get_entry.assert_called_once_with(
             "test_entry_id"
         )
-        mock_coordinator.delete_lock_by_config_entry_id.assert_called_once_with(
-            "test_entry_id"
-        )
+        mock_coordinator.delete_lock_by_config_entry_id.assert_called_once_with("test_entry_id")
 
     async def test_verify_lock_configuration_with_multiple_locks_mixed_validity(
         self, mock_coordinator, mock_config_entry
@@ -184,18 +177,14 @@ class TestVerifyLockConfiguration:
                 return mock_config_entry
             return None
 
-        mock_coordinator.hass.config_entries.async_get_entry.side_effect = (
-            mock_get_entry
-        )
+        mock_coordinator.hass.config_entries.async_get_entry.side_effect = mock_get_entry
 
         # Act
         await mock_coordinator._verify_lock_configuration()
 
         # Assert
         assert mock_coordinator.hass.config_entries.async_get_entry.call_count == 2
-        mock_coordinator.delete_lock_by_config_entry_id.assert_called_once_with(
-            "invalid_entry_id"
-        )
+        mock_coordinator.delete_lock_by_config_entry_id.assert_called_once_with("invalid_entry_id")
 
     async def test_verify_lock_configuration_with_empty_kmlocks(self, mock_coordinator):
         """Test that verification works correctly when there are no locks."""
@@ -223,9 +212,7 @@ class TestVerifyLockConfiguration:
         lock2.lock_name = "Lock 2"
 
         mock_coordinator.kmlocks = {"entry_id_1": lock1, "entry_id_2": lock2}
-        mock_coordinator.hass.config_entries.async_get_entry.return_value = (
-            mock_config_entry
-        )
+        mock_coordinator.hass.config_entries.async_get_entry.return_value = mock_config_entry
 
         # Act
         await mock_coordinator._verify_lock_configuration()
@@ -234,9 +221,7 @@ class TestVerifyLockConfiguration:
         assert mock_coordinator.hass.config_entries.async_get_entry.call_count == 2
         mock_coordinator.delete_lock_by_config_entry_id.assert_not_called()
 
-    async def test_verify_lock_configuration_with_all_invalid_locks(
-        self, mock_coordinator
-    ):
+    async def test_verify_lock_configuration_with_all_invalid_locks(self, mock_coordinator):
         """Test verification when all locks have invalid config entries."""
         # Arrange
         lock1 = Mock(spec=KeymasterLock)
@@ -259,12 +244,8 @@ class TestVerifyLockConfiguration:
         # Assert
         assert mock_coordinator.hass.config_entries.async_get_entry.call_count == 2
         assert mock_coordinator.delete_lock_by_config_entry_id.call_count == 2
-        mock_coordinator.delete_lock_by_config_entry_id.assert_any_call(
-            "invalid_entry_id_1"
-        )
-        mock_coordinator.delete_lock_by_config_entry_id.assert_any_call(
-            "invalid_entry_id_2"
-        )
+        mock_coordinator.delete_lock_by_config_entry_id.assert_any_call("invalid_entry_id_1")
+        mock_coordinator.delete_lock_by_config_entry_id.assert_any_call("invalid_entry_id_2")
 
 
 class TestUpdateChildCodeSlots:
@@ -299,9 +280,7 @@ class TestUpdateChildCodeSlots:
 
         # Test the logic: parent_pin_for_comparison should be None when disabled
         parent_pin_for_comparison = (
-            mock_code_slot.pin
-            if (mock_code_slot.enabled and mock_code_slot.active)
-            else None
+            mock_code_slot.pin if (mock_code_slot.enabled and mock_code_slot.active) else None
         )
         child_pin = child_slot.pin
 
@@ -334,9 +313,7 @@ class TestUpdateChildCodeSlots:
 
         # Test the logic: parent_pin_for_comparison should be None when inactive
         parent_pin_for_comparison = (
-            mock_code_slot.pin
-            if (mock_code_slot.enabled and mock_code_slot.active)
-            else None
+            mock_code_slot.pin if (mock_code_slot.enabled and mock_code_slot.active) else None
         )
         child_pin = child_slot.pin
 
@@ -368,9 +345,7 @@ class TestUpdateChildCodeSlots:
 
         # Test the logic: parent_pin_for_comparison should be actual PIN when enabled+active
         parent_pin_for_comparison = (
-            mock_code_slot.pin
-            if (mock_code_slot.enabled and mock_code_slot.active)
-            else None
+            mock_code_slot.pin if (mock_code_slot.enabled and mock_code_slot.active) else None
         )
         child_pin = child_slot.pin
 
@@ -402,9 +377,7 @@ class TestUpdateChildCodeSlots:
 
         # Test the logic
         parent_pin_for_comparison = (
-            mock_code_slot.pin
-            if (mock_code_slot.enabled and mock_code_slot.active)
-            else None
+            mock_code_slot.pin if (mock_code_slot.enabled and mock_code_slot.active) else None
         )
         child_pin = child_slot.pin
 
@@ -437,9 +410,7 @@ class TestUpdateChildCodeSlots:
 
         # Test the logic
         parent_pin_for_comparison = (
-            mock_code_slot.pin
-            if (mock_code_slot.enabled and mock_code_slot.active)
-            else None
+            mock_code_slot.pin if (mock_code_slot.enabled and mock_code_slot.active) else None
         )
         child_pin = child_slot.pin
 
@@ -517,9 +488,7 @@ class TestRebuildLockRelationships:
         child_lock.keymaster_config_entry_id = "child_id"
         child_lock.lock_name = "Child Lock"
         child_lock.child_config_entry_ids = []
-        child_lock.parent_config_entry_id = (
-            "new_parent_id"  # Points to different parent!
-        )
+        child_lock.parent_config_entry_id = "new_parent_id"  # Points to different parent!
 
         mock_coordinator.kmlocks = {
             "old_parent_id": old_parent_lock,
@@ -554,9 +523,7 @@ class TestRebuildLockRelationships:
         # Assert: All orphans removed
         assert len(parent_lock.child_config_entry_ids) == 0
 
-    async def test_rebuild_with_mixed_valid_and_orphaned_children(
-        self, mock_coordinator
-    ):
+    async def test_rebuild_with_mixed_valid_and_orphaned_children(self, mock_coordinator):
         """Test cleanup when parent has both valid and orphaned children."""
         # Arrange
         parent_lock = Mock(spec=KeymasterLock)
@@ -845,9 +812,9 @@ class TestLockRelationshipInvariants:
         # Verify no parent lists non-existent children (would cause KeyError with bug)
         for lock in mock_coordinator.kmlocks.values():
             for child_id in lock.child_config_entry_ids:
-                assert (
-                    child_id in mock_coordinator.kmlocks
-                ), f"Parent {lock.keymaster_config_entry_id} lists non-existent child {child_id}"
+                assert child_id in mock_coordinator.kmlocks, (
+                    f"Parent {lock.keymaster_config_entry_id} lists non-existent child {child_id}"
+                )
 
         # Phase 3: Randomly remove half the locks
         all_lock_ids = list(mock_coordinator.kmlocks.keys())
@@ -861,9 +828,9 @@ class TestLockRelationshipInvariants:
         # Verify no parent lists non-existent children after cleanup
         for lock in mock_coordinator.kmlocks.values():
             for child_id in lock.child_config_entry_ids:
-                assert (
-                    child_id in mock_coordinator.kmlocks
-                ), f"After removals: Parent {lock.keymaster_config_entry_id} lists non-existent child {child_id}"
+                assert child_id in mock_coordinator.kmlocks, (
+                    f"After removals: Parent {lock.keymaster_config_entry_id} lists non-existent child {child_id}"
+                )
 
     async def test_exact_production_bug_scenario(self, mock_coordinator):
         """Reproduce the EXACT scenario that caused the production KeyError bug.
@@ -898,9 +865,7 @@ class TestLockRelationshipInvariants:
         violations = validate_lock_relationship_invariants(mock_coordinator)
         assert len(violations) == 0, f"Violations: {violations}"
 
-    async def test_bidirectional_consistency_after_parent_change(
-        self, mock_coordinator
-    ):
+    async def test_bidirectional_consistency_after_parent_change(self, mock_coordinator):
         """Test that bidirectional consistency maintained when child changes parent.
 
         Note: _rebuild_lock_relationships only removes mismatched children from parents.
@@ -983,9 +948,7 @@ class TestLockStateEventHandlers:
 
         assert mock_kmlock.lock_state == LockState.LOCKED
 
-    async def test_lock_locked_already_locked_no_change(
-        self, mock_coordinator, mock_kmlock
-    ):
+    async def test_lock_locked_already_locked_no_change(self, mock_coordinator, mock_kmlock):
         """Test _lock_locked does nothing if already locked."""
 
         mock_kmlock.lock_state = LockState.LOCKED
@@ -1007,9 +970,7 @@ class TestLockStateEventHandlers:
 
         assert mock_kmlock.lock_state == initial_state
 
-    async def test_lock_locked_cancels_autolock_timer(
-        self, mock_coordinator, mock_kmlock
-    ):
+    async def test_lock_locked_cancels_autolock_timer(self, mock_coordinator, mock_kmlock):
         """Test _lock_locked cancels autolock timer if running."""
         mock_kmlock.autolock_timer = AsyncMock()
         mock_kmlock.autolock_timer.cancel = AsyncMock()
@@ -1051,9 +1012,7 @@ class TestLockStateEventHandlers:
 
         assert mock_kmlock.door_state == STATE_OPEN
 
-    async def test_door_opened_already_open_no_change(
-        self, mock_coordinator, mock_kmlock
-    ):
+    async def test_door_opened_already_open_no_change(self, mock_coordinator, mock_kmlock):
         """Test _door_opened does nothing if already open."""
 
         mock_kmlock.door_state = STATE_OPEN
@@ -1152,9 +1111,7 @@ class TestStateSynchronization:
         mock_lock_state.state = LockState.LOCKED
         mock_coordinator.hass.states.get = Mock(return_value=mock_lock_state)
 
-        await mock_coordinator._update_door_and_lock_state(
-            trigger_actions_if_changed=False
-        )
+        await mock_coordinator._update_door_and_lock_state(trigger_actions_if_changed=False)
 
         assert mock_kmlock_with_entities.lock_state == LockState.LOCKED
 
@@ -1180,9 +1137,7 @@ class TestStateSynchronization:
 
         mock_coordinator.hass.states.get = Mock(side_effect=mock_states_get)
 
-        await mock_coordinator._update_door_and_lock_state(
-            trigger_actions_if_changed=False
-        )
+        await mock_coordinator._update_door_and_lock_state(trigger_actions_if_changed=False)
 
         assert mock_kmlock_with_entities.door_state == STATE_OPEN
 
@@ -1200,9 +1155,7 @@ class TestStateSynchronization:
         mock_lock_state.state = LockState.LOCKED
         mock_coordinator.hass.states.get = Mock(return_value=mock_lock_state)
 
-        await mock_coordinator._update_door_and_lock_state(
-            trigger_actions_if_changed=True
-        )
+        await mock_coordinator._update_door_and_lock_state(trigger_actions_if_changed=True)
 
         # Verify _lock_locked was called
         mock_coordinator._lock_locked.assert_called_once()
@@ -1224,9 +1177,7 @@ class TestStateSynchronization:
         mock_lock_state.state = LockState.UNLOCKED
         mock_coordinator.hass.states.get = Mock(return_value=mock_lock_state)
 
-        await mock_coordinator._update_door_and_lock_state(
-            trigger_actions_if_changed=True
-        )
+        await mock_coordinator._update_door_and_lock_state(trigger_actions_if_changed=True)
 
         # Verify _lock_unlocked was called
         mock_coordinator._lock_unlocked.assert_called_once()
@@ -1257,9 +1208,7 @@ class TestStateSynchronization:
 
         mock_coordinator.hass.states.get = Mock(side_effect=mock_states_get)
 
-        await mock_coordinator._update_door_and_lock_state(
-            trigger_actions_if_changed=True
-        )
+        await mock_coordinator._update_door_and_lock_state(trigger_actions_if_changed=True)
 
         # Verify _door_opened was called
         mock_coordinator._door_opened.assert_called_once()
@@ -1287,9 +1236,7 @@ class TestStateSynchronization:
 
         mock_coordinator.hass.states.get = Mock(side_effect=mock_states_get)
 
-        await mock_coordinator._update_door_and_lock_state(
-            trigger_actions_if_changed=True
-        )
+        await mock_coordinator._update_door_and_lock_state(trigger_actions_if_changed=True)
 
         # Verify _door_closed was called
         mock_coordinator._door_closed.assert_called_once()
@@ -1306,9 +1253,7 @@ class TestStateSynchronization:
         mock_coordinator.hass.states.get = Mock(return_value=None)
 
         # Should not raise exception
-        await mock_coordinator._update_door_and_lock_state(
-            trigger_actions_if_changed=False
-        )
+        await mock_coordinator._update_door_and_lock_state(trigger_actions_if_changed=False)
 
         # State should remain unchanged
         assert mock_kmlock_with_entities.lock_state == LockState.UNLOCKED
@@ -1321,9 +1266,7 @@ class TestStateSynchronization:
         mock_coordinator.kmlocks = {"test_lock_id": mock_kmlock_with_entities}
 
         # Should not raise exception
-        await mock_coordinator._update_door_and_lock_state(
-            trigger_actions_if_changed=False
-        )
+        await mock_coordinator._update_door_and_lock_state(trigger_actions_if_changed=False)
 
     async def test_update_door_and_lock_state_handles_no_door_sensor(
         self, mock_coordinator, mock_kmlock_with_entities
@@ -1338,9 +1281,7 @@ class TestStateSynchronization:
         mock_coordinator.hass.states.get = Mock(return_value=mock_lock_state)
 
         # Should not raise exception
-        await mock_coordinator._update_door_and_lock_state(
-            trigger_actions_if_changed=False
-        )
+        await mock_coordinator._update_door_and_lock_state(trigger_actions_if_changed=False)
 
         # Lock state should be updated, door state unchanged
         assert mock_kmlock_with_entities.lock_state == LockState.LOCKED
@@ -1349,9 +1290,7 @@ class TestStateSynchronization:
 class TestCoordinatorUtilities:
     """Test coordinator utility and getter functions."""
 
-    async def test_count_locks_not_pending_delete_with_multiple_locks(
-        self, mock_coordinator
-    ):
+    async def test_count_locks_not_pending_delete_with_multiple_locks(self, mock_coordinator):
         """Test counting locks excluding pending delete."""
 
         # Create multiple locks with different states
@@ -1399,9 +1338,7 @@ class TestCoordinatorUtilities:
 
         assert mock_coordinator.count_locks_not_pending_delete == 0
 
-    async def test_get_lock_by_config_entry_id_found(
-        self, mock_coordinator, mock_keymaster_lock
-    ):
+    async def test_get_lock_by_config_entry_id_found(self, mock_coordinator, mock_keymaster_lock):
         """Test getting lock by config entry ID when it exists."""
         mock_keymaster_lock.keymaster_config_entry_id = "test_entry_id"
         mock_coordinator.kmlocks = {"test_entry_id": mock_keymaster_lock}

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -83,10 +83,10 @@ async def test_delete_lock(hass, mock_coordinator, mock_lock):
     mock_lock.pending_delete = True
 
     # Mock file operations
-    with patch("custom_components.keymaster.coordinator.delete_lovelace"), patch.object(
-        mock_coordinator, "_write_config_to_json"
+    with (
+        patch("custom_components.keymaster.coordinator.delete_lovelace"),
+        patch.object(mock_coordinator, "_write_config_to_json"),
     ):
-
         # Call private method directly as it's usually called via callback
         await mock_coordinator._delete_lock(mock_lock, None)
 
@@ -100,9 +100,7 @@ async def test_delete_lock_not_pending(hass, mock_coordinator, mock_lock):
     mock_coordinator.kmlocks["test_entry"] = mock_lock
     mock_lock.pending_delete = False  # Simulate cancelled delete
 
-    with patch(
-        "custom_components.keymaster.coordinator.delete_lovelace"
-    ) as mock_delete_lovelace:
+    with patch("custom_components.keymaster.coordinator.delete_lovelace") as mock_delete_lovelace:
         await mock_coordinator._delete_lock(mock_lock, None)
 
         mock_delete_lovelace.assert_not_called()

--- a/tests/test_coordinator_sync.py
+++ b/tests/test_coordinator_sync.py
@@ -235,9 +235,7 @@ class TestParentChildSync:
         mock_coordinator.set_pin_on_lock.assert_not_called()
         mock_coordinator.clear_pin_from_lock.assert_not_called()
 
-    async def test_sync_skips_missing_child_slots(
-        self, mock_coordinator, parent_lock, child_lock
-    ):
+    async def test_sync_skips_missing_child_slots(self, mock_coordinator, parent_lock, child_lock):
         """Test that sync skips slots not present on child."""
         # Arrange: Parent has slot 5, child doesn't
         parent_slot = Mock(spec=KeymasterCodeSlot)
@@ -260,15 +258,9 @@ class TestParentChildSync:
         """Test syncing multiple code slots at once."""
         # Arrange: Multiple slots with different states
         parent_lock.code_slots = {
-            1: Mock(
-                code_slot_num=1, enabled=True, active=True, pin="1111", name="Slot 1"
-            ),
-            2: Mock(
-                code_slot_num=2, enabled=False, active=True, pin="2222", name="Slot 2"
-            ),
-            3: Mock(
-                code_slot_num=3, enabled=True, active=True, pin="3333", name="Slot 3"
-            ),
+            1: Mock(code_slot_num=1, enabled=True, active=True, pin="1111", name="Slot 1"),
+            2: Mock(code_slot_num=2, enabled=False, active=True, pin="2222", name="Slot 2"),
+            3: Mock(code_slot_num=3, enabled=True, active=True, pin="3333", name="Slot 3"),
         }
 
         child_lock.code_slots = {
@@ -302,9 +294,7 @@ class TestParentChildSync:
         assert mock_coordinator.set_pin_on_lock.call_count == 1
         assert mock_coordinator.clear_pin_from_lock.call_count == 1
 
-    async def test_sync_handles_none_parent_pin(
-        self, mock_coordinator, parent_lock, child_lock
-    ):
+    async def test_sync_handles_none_parent_pin(self, mock_coordinator, parent_lock, child_lock):
         """Test sync when parent has no PIN set."""
         # Arrange: Parent enabled but no PIN
         parent_slot = Mock(spec=KeymasterCodeSlot)
@@ -331,9 +321,7 @@ class TestParentChildSync:
         mock_coordinator.clear_pin_from_lock.assert_called_once()
         assert child_slot.pin is None
 
-    async def test_sync_empty_parent_slots(
-        self, mock_coordinator, parent_lock, child_lock
-    ):
+    async def test_sync_empty_parent_slots(self, mock_coordinator, parent_lock, child_lock):
         """Test that empty parent code_slots doesn't crash."""
         # Arrange
         parent_lock.code_slots = None  # or {}
@@ -346,9 +334,7 @@ class TestParentChildSync:
         mock_coordinator.set_pin_on_lock.assert_not_called()
         mock_coordinator.clear_pin_from_lock.assert_not_called()
 
-    async def test_sync_attribute_propagation(
-        self, mock_coordinator, parent_lock, child_lock
-    ):
+    async def test_sync_attribute_propagation(self, mock_coordinator, parent_lock, child_lock):
         """Test that all slot attributes are propagated to child."""
         # Arrange: Parent with all attributes set
         parent_slot = Mock(spec=KeymasterCodeSlot)
@@ -392,9 +378,7 @@ class TestParentChildSync:
         assert child_slot.accesslimit_count == 5
         assert child_slot.accesslimit_date_range_start == "2025-01-01"
 
-    async def test_sync_multiple_children_from_same_parent(
-        self, mock_coordinator, parent_lock
-    ):
+    async def test_sync_multiple_children_from_same_parent(self, mock_coordinator, parent_lock):
         """Test that one parent can sync to multiple children simultaneously."""
         # Arrange: One parent with 3 children
         parent_slot = Mock(spec=KeymasterCodeSlot)
@@ -482,9 +466,7 @@ class TestParentChildSync:
 class TestMultiLockScenarios:
     """Test scenarios with multiple locks and complex relationships."""
 
-    async def test_parent_with_multiple_children_cascading_updates(
-        self, mock_coordinator
-    ):
+    async def test_parent_with_multiple_children_cascading_updates(self, mock_coordinator):
         """Test that parent updates cascade to all children correctly."""
         # Arrange: 1 parent, 2 children
         parent = Mock(spec=KeymasterLock)
@@ -556,15 +538,11 @@ class TestMultiLockScenarios:
 class TestCodeSlotBoundaries:
     """Test code slot boundary conditions and validation."""
 
-    async def test_sync_slot_number_zero(
-        self, mock_coordinator, parent_lock, child_lock
-    ):
+    async def test_sync_slot_number_zero(self, mock_coordinator, parent_lock, child_lock):
         """Test handling of slot number 0 (invalid but possible)."""
         # Arrange: Slot 0
         parent_slot = Mock(code_slot_num=0, enabled=True, pin="1234")
-        child_slot = Mock(
-            code_slot_num=0, enabled=False, pin=None, override_parent=False
-        )
+        child_slot = Mock(code_slot_num=0, enabled=False, pin=None, override_parent=False)
 
         parent_lock.code_slots = {0: parent_slot}
         child_lock.code_slots = {0: child_slot}
@@ -575,15 +553,11 @@ class TestCodeSlotBoundaries:
         # Assert: Operation completed
         assert mock_coordinator.set_pin_on_lock.call_count >= 0
 
-    async def test_sync_slot_number_max(
-        self, mock_coordinator, parent_lock, child_lock
-    ):
+    async def test_sync_slot_number_max(self, mock_coordinator, parent_lock, child_lock):
         """Test handling of maximum slot number (typically 250 or 254)."""
         # Arrange: Slot 250
         parent_slot = Mock(code_slot_num=250, enabled=True, pin="1234")
-        child_slot = Mock(
-            code_slot_num=250, enabled=False, pin=None, override_parent=False
-        )
+        child_slot = Mock(code_slot_num=250, enabled=False, pin=None, override_parent=False)
 
         parent_lock.code_slots = {250: parent_slot}
         child_lock.code_slots = {250: child_slot}
@@ -599,9 +573,7 @@ class TestCodeSlotBoundaries:
             override=True,
         )
 
-    async def test_sync_with_sparse_slot_numbers(
-        self, mock_coordinator, parent_lock, child_lock
-    ):
+    async def test_sync_with_sparse_slot_numbers(self, mock_coordinator, parent_lock, child_lock):
         """Test sync with non-contiguous slot numbers (1, 5, 10, 100)."""
         # Arrange: Non-contiguous slots
         parent_lock.code_slots = {
@@ -799,9 +771,7 @@ class TestChildLockBehavior:
             override=True,
         )
 
-    async def test_child_switching_override_flag(
-        self, mock_coordinator, parent_lock, child_lock
-    ):
+    async def test_child_switching_override_flag(self, mock_coordinator, parent_lock, child_lock):
         """Test child behavior when switching override_parent flag on and off."""
         # Arrange: Start with override off
         parent_slot = Mock(spec=KeymasterCodeSlot)

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -140,10 +140,7 @@ async def test_datetime_entity_initialization(
     entity = KeymasterDateTime(entity_description=entity_description)
 
     assert entity._attr_native_value is None
-    assert (
-        entity.entity_description.key
-        == "datetime.code_slots:1.accesslimit_date_range_start"
-    )
+    assert entity.entity_description.key == "datetime.code_slots:1.accesslimit_date_range_start"
     assert isinstance(entity.entity_description.name, str)
     assert "Date Range Start" in entity.entity_description.name
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -242,9 +242,7 @@ async def test_entity_set_property_value_with_code_slot(
     assert kmlock.code_slots[1].enabled is True
 
 
-async def test_entity_get_code_slots_num(
-    hass: HomeAssistant, entity_config_entry, coordinator
-):
+async def test_entity_get_code_slots_num(hass: HomeAssistant, entity_config_entry, coordinator):
     """Test _get_code_slots_num extracts code slot number correctly."""
 
     kmlock = KeymasterLock(
@@ -304,9 +302,7 @@ async def test_entity_get_code_slots_num_returns_none_for_non_slot(
     assert slot_num is None
 
 
-async def test_entity_get_day_of_week_num(
-    hass: HomeAssistant, entity_config_entry, coordinator
-):
+async def test_entity_get_day_of_week_num(hass: HomeAssistant, entity_config_entry, coordinator):
     """Test _get_day_of_week_num extracts day of week number correctly."""
 
     kmlock = KeymasterLock(
@@ -366,9 +362,7 @@ async def test_entity_get_day_of_week_num_returns_none_for_non_dow(
     assert dow_num is None
 
 
-async def test_entity_available_property(
-    hass: HomeAssistant, entity_config_entry, coordinator
-):
+async def test_entity_available_property(hass: HomeAssistant, entity_config_entry, coordinator):
     """Test available property returns _attr_available."""
 
     kmlock = KeymasterLock(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -470,9 +470,7 @@ async def test_keymaster_timer_properties(hass):
     assert timer.is_running
     assert timer.end_time is not None
     assert timer.remaining_seconds is not None
-    assert (
-        timer.remaining_seconds > 0
-    )  # Time remaining (positive because end_time is in future)
+    assert timer.remaining_seconds > 0  # Time remaining (positive because end_time is in future)
 
 
 async def test_delete_code_slot_entities_removes_all(hass):
@@ -491,9 +489,7 @@ async def test_delete_code_slot_entities_removes_all(hass):
 
     mock_registry.async_get_entity_id.side_effect = mock_get_entity_id
 
-    with patch(
-        "custom_components.keymaster.helpers.er.async_get", return_value=mock_registry
-    ):
+    with patch("custom_components.keymaster.helpers.er.async_get", return_value=mock_registry):
         await delete_code_slot_entities(hass, config_entry_id, code_slot_num)
 
     # Check count.
@@ -517,13 +513,9 @@ async def test_delete_code_slot_entities_handles_errors(hass):
     """Test that deletion errors are logged but don't stop the process."""
     mock_registry = MagicMock()
     mock_registry.async_get_entity_id.return_value = "entity.test"
-    mock_registry.async_remove.side_effect = KeyError(
-        "Entity not found"
-    )  # Simulate error
+    mock_registry.async_remove.side_effect = KeyError("Entity not found")  # Simulate error
 
-    with patch(
-        "custom_components.keymaster.helpers.er.async_get", return_value=mock_registry
-    ):
+    with patch("custom_components.keymaster.helpers.er.async_get", return_value=mock_registry):
         await delete_code_slot_entities(hass, "entry", 1)
 
     # Should finish without raising exception and try to remove all
@@ -546,12 +538,12 @@ def test_async_using_zwave_js_checks(hass):
     mock_registry.async_get.side_effect = lambda eid: (
         mock_entity_zwave
         if eid == "lock.zwave"
-        else mock_entity_other if eid == "lock.other" else None
+        else mock_entity_other
+        if eid == "lock.other"
+        else None
     )
 
-    with patch(
-        "custom_components.keymaster.helpers.er.async_get", return_value=mock_registry
-    ):
+    with patch("custom_components.keymaster.helpers.er.async_get", return_value=mock_registry):
         # Test with entity_id
         assert async_using_zwave_js(hass, entity_id="lock.zwave") is True
         assert async_using_zwave_js(hass, entity_id="lock.other") is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -27,9 +27,7 @@ async def test_setup_entry(
 ):
     """Test setting up entities."""
 
-    entry = MockConfigEntry(
-        domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3
-    )
+    entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3)
 
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -54,9 +52,7 @@ async def test_setup_entry_core_state(
 ):
     """Test setting up entities."""
     with patch.object(hass, "state", return_value="STARTING"):
-        entry = MockConfigEntry(
-            domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3
-        )
+        entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3)
 
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
@@ -74,9 +70,7 @@ async def test_unload_entry(
     integration,
 ):
     """Test unloading entities."""
-    entry = MockConfigEntry(
-        domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3
-    )
+    entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3)
 
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/test_lock_dataclass.py
+++ b/tests/test_lock_dataclass.py
@@ -33,15 +33,15 @@ def test_type_lookup_consistency():
 
     for field in lock_fields:
         if field not in excluded_fields:
-            assert (
-                field in lookup_keys
-            ), f"Field '{field}' from KeymasterLock is missing in keymasterlock_type_lookup"
+            assert field in lookup_keys, (
+                f"Field '{field}' from KeymasterLock is missing in keymasterlock_type_lookup"
+            )
 
     for field in slot_fields:
         if field not in excluded_fields:
-            assert (
-                field in lookup_keys
-            ), f"Field '{field}' from KeymasterCodeSlot is missing in keymasterlock_type_lookup"
+            assert field in lookup_keys, (
+                f"Field '{field}' from KeymasterCodeSlot is missing in keymasterlock_type_lookup"
+            )
 
     # Verify types match (basic check)
     for key, type_hint in keymasterlock_type_lookup.items():  # noqa: B007, PERF102

--- a/tests/test_lovelace.py
+++ b/tests/test_lovelace.py
@@ -484,9 +484,7 @@ async def test_async_generate_lovelace_creates_folder(hass: HomeAssistant):
             "custom_components.keymaster.lovelace.er.async_get",
             return_value=mock_registry,
         ),
-        patch(
-            "custom_components.keymaster.lovelace._create_lovelace_folder"
-        ) as mock_create_folder,
+        patch("custom_components.keymaster.lovelace._create_lovelace_folder") as mock_create_folder,
         patch("custom_components.keymaster.lovelace._write_lovelace_yaml"),
     ):
         await async_generate_lovelace(
@@ -515,9 +513,7 @@ async def test_async_generate_lovelace_writes_yaml(hass: HomeAssistant):
             return_value=mock_registry,
         ),
         patch("custom_components.keymaster.lovelace._create_lovelace_folder"),
-        patch(
-            "custom_components.keymaster.lovelace._write_lovelace_yaml"
-        ) as mock_write_yaml,
+        patch("custom_components.keymaster.lovelace._write_lovelace_yaml") as mock_write_yaml,
     ):
         await async_generate_lovelace(
             hass=hass,
@@ -551,9 +547,7 @@ async def test_async_generate_lovelace_filename_matches_lock_name(hass: HomeAssi
             return_value=mock_registry,
         ),
         patch("custom_components.keymaster.lovelace._create_lovelace_folder"),
-        patch(
-            "custom_components.keymaster.lovelace._write_lovelace_yaml"
-        ) as mock_write_yaml,
+        patch("custom_components.keymaster.lovelace._write_lovelace_yaml") as mock_write_yaml,
     ):
         await async_generate_lovelace(
             hass=hass,
@@ -581,9 +575,7 @@ async def test_async_generate_lovelace_delegates_to_view_config(hass: HomeAssist
         ),
         patch("custom_components.keymaster.lovelace._create_lovelace_folder"),
         patch("custom_components.keymaster.lovelace._write_lovelace_yaml") as mock_write,
-        patch(
-            "custom_components.keymaster.lovelace.generate_view_config"
-        ) as mock_view_config,
+        patch("custom_components.keymaster.lovelace.generate_view_config") as mock_view_config,
     ):
         mock_view_config.return_value = {"type": "sections", "title": "test"}
 
@@ -650,9 +642,7 @@ def test_delete_lovelace_handles_missing_file(hass: HomeAssistant, tmp_path: Pat
         delete_lovelace(hass, "nonexistent")
 
 
-def test_delete_lovelace_handles_permission_error(
-    hass: HomeAssistant, tmp_path: Path, caplog
-):
+def test_delete_lovelace_handles_permission_error(hass: HomeAssistant, tmp_path: Path, caplog):
     """Test that delete_lovelace handles permission errors gracefully."""
     lovelace_dir = tmp_path / "custom_components" / "keymaster" / "lovelace"
     lovelace_dir.mkdir(parents=True)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -159,9 +159,7 @@ async def test_migrate_2to3_reload_failure(hass: HomeAssistant, mock_coordinator
             "custom_components.keymaster.migrate.KeymasterCoordinator",
             return_value=mock_coordinator,
         ),
-        patch(
-            "custom_components.keymaster.migrate._migrate_2to3_delete_lock_and_base_folder"
-        ),
+        patch("custom_components.keymaster.migrate._migrate_2to3_delete_lock_and_base_folder"),
         patch(
             "custom_components.keymaster.migrate._migrate_2to3_reload_package_platforms",
             return_value=False,

--- a/tests/test_migrate_helpers.py
+++ b/tests/test_migrate_helpers.py
@@ -12,40 +12,23 @@ from custom_components.keymaster.migrate import (
 async def test_convert_boolean():
     """Test converting boolean values."""
     # Test 'on' string -> True
-    assert (
-        await _migrate_2to3_validate_and_convert_property("test.prop", "enabled", "on")
-        is True
-    )
+    assert await _migrate_2to3_validate_and_convert_property("test.prop", "enabled", "on") is True
 
     # Test 'off' string -> False
-    assert (
-        await _migrate_2to3_validate_and_convert_property("test.prop", "enabled", "off")
-        is False
-    )
+    assert await _migrate_2to3_validate_and_convert_property("test.prop", "enabled", "off") is False
 
 
 async def test_convert_integer():
     """Test converting integer values."""
     # Test numeric string
-    assert (
-        await _migrate_2to3_validate_and_convert_property("test.prop", "number", "123")
-        == 123
-    )
+    assert await _migrate_2to3_validate_and_convert_property("test.prop", "number", "123") == 123
 
     # Test float string
-    assert (
-        await _migrate_2to3_validate_and_convert_property(
-            "test.prop", "number", "123.0"
-        )
-        == 123
-    )
+    assert await _migrate_2to3_validate_and_convert_property("test.prop", "number", "123.0") == 123
 
     # Test time string conversion to minutes (HH:MM:SS -> minutes)
     assert (
-        await _migrate_2to3_validate_and_convert_property(
-            "test.prop", "number", "01:00:00"
-        )
-        == 60
+        await _migrate_2to3_validate_and_convert_property("test.prop", "number", "01:00:00") == 60
     )
 
 
@@ -67,9 +50,7 @@ async def test_convert_datetime():
 async def test_convert_time():
     """Test converting time values."""
     time_str = "12:30:00"
-    result = await _migrate_2to3_validate_and_convert_property(
-        "test.prop", "time_start", time_str
-    )
+    result = await _migrate_2to3_validate_and_convert_property("test.prop", "time_start", time_str)
 
     assert isinstance(result, dt_time)
     assert result.hour == 12
@@ -81,10 +62,7 @@ async def test_conversion_failures():
     """Test conversion failure handling."""
     # Invalid int
     assert (
-        await _migrate_2to3_validate_and_convert_property(
-            "test.prop", "number", "invalid"
-        )
-        is None
+        await _migrate_2to3_validate_and_convert_property("test.prop", "number", "invalid") is None
     )
 
     # Invalid datetime
@@ -97,8 +75,6 @@ async def test_conversion_failures():
 
     # Invalid time
     assert (
-        await _migrate_2to3_validate_and_convert_property(
-            "test.prop", "time_start", "invalid-time"
-        )
+        await _migrate_2to3_validate_and_convert_property("test.prop", "time_start", "invalid-time")
         is None
     )

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -101,17 +101,13 @@ async def test_number_autolock_entities_have_correct_config(
     await async_setup_entry(hass, number_config_entry, mock_add_entities)
 
     # Find autolock entities
-    autolock_entities = [
-        e for e in entities if "Auto Lock" in e.entity_description.name
-    ]
+    autolock_entities = [e for e in entities if "Auto Lock" in e.entity_description.name]
     assert len(autolock_entities) == 2
 
     for entity in autolock_entities:
         # Check they're duration entities with minutes
         assert entity.entity_description.device_class == NumberDeviceClass.DURATION
-        assert (
-            entity.entity_description.native_unit_of_measurement == UnitOfTime.MINUTES
-        )
+        assert entity.entity_description.native_unit_of_measurement == UnitOfTime.MINUTES
         assert entity.entity_description.mode == NumberMode.BOX
         assert entity.entity_description.native_min_value == 1
         assert entity.entity_description.native_step == 1
@@ -131,9 +127,7 @@ async def test_number_accesslimit_entities_have_correct_config(
     await async_setup_entry(hass, number_config_entry, mock_add_entities)
 
     # Find access limit entities
-    accesslimit_entities = [
-        e for e in entities if "Uses Remaining" in e.entity_description.name
-    ]
+    accesslimit_entities = [e for e in entities if "Uses Remaining" in e.entity_description.name]
     assert len(accesslimit_entities) == 2
 
     for entity in accesslimit_entities:
@@ -144,9 +138,7 @@ async def test_number_accesslimit_entities_have_correct_config(
         assert entity.entity_description.native_step == 1
 
 
-async def test_number_entity_initialization(
-    hass: HomeAssistant, number_config_entry, coordinator
-):
+async def test_number_entity_initialization(hass: HomeAssistant, number_config_entry, coordinator):
     """Test number entity initialization."""
 
     entity_description = KeymasterNumberEntityDescription(
@@ -414,9 +406,7 @@ async def test_number_entity_available_when_autolock_enabled(
     assert entity._attr_native_value == 5
 
 
-async def test_number_entity_async_set_value(
-    hass: HomeAssistant, number_config_entry, coordinator
-):
+async def test_number_entity_async_set_value(hass: HomeAssistant, number_config_entry, coordinator):
     """Test setting number value updates coordinator."""
 
     # Create a connected lock with code slot and accesslimit enabled

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -60,9 +60,7 @@ def test_get_lovelace_resources_returns_none_when_missing(hass: HomeAssistant):
     assert result is None
 
 
-async def test_register_strategy_resource_creates_new(
-    hass: HomeAssistant, mock_storage_resources
-):
+async def test_register_strategy_resource_creates_new(hass: HomeAssistant, mock_storage_resources):
     """Test registering a new strategy resource."""
     hass.data[LOVELACE_DOMAIN] = MagicMock()
     hass.data[LOVELACE_DOMAIN].resources = mock_storage_resources
@@ -81,9 +79,7 @@ async def test_register_strategy_resource_already_exists(
     hass: HomeAssistant, mock_storage_resources
 ):
     """Test registering when resource already exists."""
-    mock_storage_resources.async_items.return_value = [
-        {"id": "existing_id", "url": STRATEGY_PATH}
-    ]
+    mock_storage_resources.async_items.return_value = [{"id": "existing_id", "url": STRATEGY_PATH}]
     hass.data[LOVELACE_DOMAIN] = MagicMock()
     hass.data[LOVELACE_DOMAIN].resources = mock_storage_resources
     hass.data[DOMAIN] = {}
@@ -133,13 +129,9 @@ async def test_register_strategy_resource_no_resources(hass: HomeAssistant):
     await async_register_strategy_resource(hass)
 
 
-async def test_cleanup_strategy_resource_removes(
-    hass: HomeAssistant, mock_storage_resources
-):
+async def test_cleanup_strategy_resource_removes(hass: HomeAssistant, mock_storage_resources):
     """Test cleaning up strategy resource."""
-    mock_storage_resources.async_items.return_value = [
-        {"id": "resource_id", "url": STRATEGY_PATH}
-    ]
+    mock_storage_resources.async_items.return_value = [{"id": "resource_id", "url": STRATEGY_PATH}]
     hass.data[LOVELACE_DOMAIN] = MagicMock()
     hass.data[LOVELACE_DOMAIN].resources = mock_storage_resources
 
@@ -160,9 +152,7 @@ async def test_cleanup_strategy_resource_not_auto_registered(
     mock_storage_resources.async_delete_item.assert_not_called()
 
 
-async def test_cleanup_strategy_resource_not_found(
-    hass: HomeAssistant, mock_storage_resources
-):
+async def test_cleanup_strategy_resource_not_found(hass: HomeAssistant, mock_storage_resources):
     """Test cleanup when resource not found."""
     mock_storage_resources.async_items.return_value = []  # No resources
     hass.data[LOVELACE_DOMAIN] = MagicMock()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -60,9 +60,7 @@ async def coordinator(hass: HomeAssistant, sensor_config_entry):
     return hass.data[DOMAIN][COORDINATOR]
 
 
-async def test_sensor_entity_initialization(
-    hass: HomeAssistant, sensor_config_entry, coordinator
-):
+async def test_sensor_entity_initialization(hass: HomeAssistant, sensor_config_entry, coordinator):
     """Test sensor entity initialization."""
 
     entity_description = KeymasterSensorEntityDescription(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -24,18 +24,14 @@ _LOGGER = logging.getLogger(__name__)
 
 async def test_service_regenerate_lovelace(hass, keymaster_integration, caplog):
     """Test generate_package_files."""
-    entry = MockConfigEntry(
-        domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3
-    )
+    entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3)
 
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
     servicedata: dict[Any, Any] = {}
-    await hass.services.async_call(
-        DOMAIN, SERVICE_REGENERATE_LOVELACE, servicedata, blocking=True
-    )
+    await hass.services.async_call(DOMAIN, SERVICE_REGENERATE_LOVELACE, servicedata, blocking=True)
     await hass.async_block_till_done()
 
     # Check for exception when unable to create directory

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -64,9 +64,7 @@ async def coordinator(hass: HomeAssistant, switch_config_entry):
     return hass.data[DOMAIN][COORDINATOR]
 
 
-async def test_switch_entity_initialization(
-    hass: HomeAssistant, switch_config_entry, coordinator
-):
+async def test_switch_entity_initialization(hass: HomeAssistant, switch_config_entry, coordinator):
     """Test switch entity initialization."""
 
     entity_description = KeymasterSwitchEntityDescription(
@@ -119,9 +117,7 @@ async def test_switch_entity_unavailable_when_not_connected(
     assert not entity._attr_available
 
 
-async def test_switch_async_turn_on(
-    hass: HomeAssistant, switch_config_entry, coordinator
-):
+async def test_switch_async_turn_on(hass: HomeAssistant, switch_config_entry, coordinator):
     """Test turning switch on updates coordinator."""
 
     # Create a connected lock
@@ -156,9 +152,7 @@ async def test_switch_async_turn_on(
         mock_refresh.assert_called_once()
 
 
-async def test_switch_async_turn_off(
-    hass: HomeAssistant, switch_config_entry, coordinator
-):
+async def test_switch_async_turn_off(hass: HomeAssistant, switch_config_entry, coordinator):
     """Test turning switch off updates coordinator."""
 
     # Create a connected lock
@@ -228,12 +222,10 @@ async def test_switch_enabled_turn_on_sets_pin(
     entity._attr_is_on = False
 
     # Mock coordinator methods
-    with patch.object(
-        coordinator, "update_slot_active_state", new=AsyncMock()
-    ) as mock_update, patch.object(
-        coordinator, "set_pin_on_lock", new=AsyncMock()
-    ) as mock_set_pin, patch.object(
-        coordinator, "async_refresh", new=AsyncMock()
+    with (
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()) as mock_update,
+        patch.object(coordinator, "set_pin_on_lock", new=AsyncMock()) as mock_set_pin,
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
     ):
         await entity.async_turn_on()
 
@@ -283,12 +275,10 @@ async def test_switch_enabled_turn_off_clears_pin(
     entity._attr_is_on = True
 
     # Mock coordinator methods
-    with patch.object(
-        coordinator, "update_slot_active_state", new=AsyncMock()
-    ) as mock_update, patch.object(
-        coordinator, "clear_pin_from_lock", new=AsyncMock()
-    ) as mock_clear_pin, patch.object(
-        coordinator, "async_refresh", new=AsyncMock()
+    with (
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()) as mock_update,
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()) as mock_clear_pin,
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
     ):
         await entity.async_turn_off()
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -158,9 +158,7 @@ async def test_text_pin_entity_text_mode_when_not_hiding_pins(hass: HomeAssistan
         assert entity.entity_description.mode == TextMode.TEXT
 
 
-async def test_text_entity_initialization(
-    hass: HomeAssistant, text_config_entry, coordinator
-):
+async def test_text_entity_initialization(hass: HomeAssistant, text_config_entry, coordinator):
     """Test text entity initialization."""
 
     entity_description = KeymasterTextEntityDescription(
@@ -248,9 +246,7 @@ async def test_text_entity_available_when_connected(
     assert entity._attr_native_value == "Test User"
 
 
-async def test_text_entity_async_set_pin_value(
-    hass: HomeAssistant, text_config_entry, coordinator
-):
+async def test_text_entity_async_set_pin_value(hass: HomeAssistant, text_config_entry, coordinator):
     """Test setting PIN value calls coordinator methods."""
 
     # Create a connected lock with code slot
@@ -320,9 +316,7 @@ async def test_text_entity_async_clear_pin_value(
 
     # Mock coordinator methods
     with (
-        patch.object(
-            coordinator, "clear_pin_from_lock", new=AsyncMock()
-        ) as mock_clear_pin,
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()) as mock_clear_pin,
         patch.object(coordinator, "async_refresh", new=AsyncMock()),
     ):
         await entity.async_set_value("")
@@ -365,9 +359,7 @@ async def test_text_entity_invalid_pin_ignored(
     # Mock coordinator methods
     with (
         patch.object(coordinator, "set_pin_on_lock", new=AsyncMock()) as mock_set_pin,
-        patch.object(
-            coordinator, "clear_pin_from_lock", new=AsyncMock()
-        ) as mock_clear_pin,
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()) as mock_clear_pin,
     ):
         # Invalid: too short
         await entity.async_set_value("123")

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -95,9 +95,7 @@ async def test_time_entity_not_created_without_advanced_dow(hass: HomeAssistant)
     assert len(entities) == 0
 
 
-async def test_time_entities_created_with_advanced_dow(
-    hass: HomeAssistant, time_config_entry
-):
+async def test_time_entities_created_with_advanced_dow(hass: HomeAssistant, time_config_entry):
     """Test time entities are created when advanced day of week is enabled."""
 
     entities = []
@@ -137,17 +135,12 @@ async def test_time_entity_initialization(hass: HomeAssistant, time_config_entry
     entity = KeymasterTime(entity_description=entity_description)
 
     assert entity._attr_native_value is None
-    assert (
-        entity.entity_description.key
-        == "time.code_slots:1.accesslimit_day_of_week:0.time_start"
-    )
+    assert entity.entity_description.key == "time.code_slots:1.accesslimit_day_of_week:0.time_start"
     assert isinstance(entity.entity_description.name, str)
     assert "Monday - Start Time" in entity.entity_description.name
 
 
-async def test_time_entity_unavailable_when_not_connected(
-    hass: HomeAssistant, time_config_entry
-):
+async def test_time_entity_unavailable_when_not_connected(hass: HomeAssistant, time_config_entry):
     """Test time entity is unavailable when lock is not connected."""
 
     coordinator = hass.data[DOMAIN][COORDINATOR]
@@ -290,9 +283,7 @@ async def test_time_entity_child_lock_ignores_change_without_override(
         assert "not set to override parent. Ignoring change" in caplog.text
 
 
-async def test_time_entity_unavailable_when_dow_not_enabled(
-    hass: HomeAssistant, time_config_entry
-):
+async def test_time_entity_unavailable_when_dow_not_enabled(hass: HomeAssistant, time_config_entry):
     """Test time entity is unavailable when day of week is not enabled."""
 
     coordinator = hass.data[DOMAIN][COORDINATOR]

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -35,9 +35,7 @@ def _create_mock_connection():
 
 async def test_async_setup_registers_commands(hass: HomeAssistant):
     """Test that async_setup registers the WebSocket commands."""
-    with patch(
-        "homeassistant.components.websocket_api.async_register_command"
-    ) as mock_register:
+    with patch("homeassistant.components.websocket_api.async_register_command") as mock_register:
         await async_setup(hass)
 
         assert mock_register.call_count == 3
@@ -424,7 +422,12 @@ async def test_ws_get_section_config_basic(hass: HomeAssistant):
         await websocket.ws_get_section_config.__wrapped__(
             hass,
             mock_connection,
-            {"id": 1, "type": f"{DOMAIN}/get_section_config", "config_entry_id": "test_entry_id", "slot_num": 2},
+            {
+                "id": 1,
+                "type": f"{DOMAIN}/get_section_config",
+                "config_entry_id": "test_entry_id",
+                "slot_num": 2,
+            },
         )
 
         mock_gen.assert_called_once()
@@ -464,7 +467,12 @@ async def test_ws_get_section_config_by_lock_name(hass: HomeAssistant):
         await websocket.ws_get_section_config.__wrapped__(
             hass,
             mock_connection,
-            {"id": 1, "type": f"{DOMAIN}/get_section_config", "lock_name": "frontdoor", "slot_num": 2},
+            {
+                "id": 1,
+                "type": f"{DOMAIN}/get_section_config",
+                "lock_name": "frontdoor",
+                "slot_num": 2,
+            },
         )
 
         mock_gen.assert_called_once()
@@ -495,7 +503,12 @@ async def test_ws_get_section_config_invalid_slot(hass: HomeAssistant):
     await websocket.ws_get_section_config.__wrapped__(
         hass,
         mock_connection,
-        {"id": 1, "type": f"{DOMAIN}/get_section_config", "config_entry_id": "test_entry_id", "slot_num": 10},
+        {
+            "id": 1,
+            "type": f"{DOMAIN}/get_section_config",
+            "config_entry_id": "test_entry_id",
+            "slot_num": 10,
+        },
     )
 
     mock_connection.send_error.assert_called_once()
@@ -512,7 +525,12 @@ async def test_ws_get_section_config_lock_not_found(hass: HomeAssistant):
     await websocket.ws_get_section_config.__wrapped__(
         hass,
         mock_connection,
-        {"id": 1, "type": f"{DOMAIN}/get_section_config", "config_entry_id": "nonexistent", "slot_num": 1},
+        {
+            "id": 1,
+            "type": f"{DOMAIN}/get_section_config",
+            "config_entry_id": "nonexistent",
+            "slot_num": 1,
+        },
     )
 
     mock_connection.send_error.assert_called_once()
@@ -547,7 +565,12 @@ async def test_ws_get_section_config_passes_parent_entry(hass: HomeAssistant):
         await websocket.ws_get_section_config.__wrapped__(
             hass,
             mock_connection,
-            {"id": 1, "type": f"{DOMAIN}/get_section_config", "config_entry_id": "child_entry_id", "slot_num": 1},
+            {
+                "id": 1,
+                "type": f"{DOMAIN}/get_section_config",
+                "config_entry_id": "child_entry_id",
+                "slot_num": 1,
+            },
         )
 
         call_kwargs = mock_gen.call_args[1]
@@ -579,7 +602,12 @@ async def test_ws_get_section_config_defaults(hass: HomeAssistant):
         await websocket.ws_get_section_config.__wrapped__(
             hass,
             mock_connection,
-            {"id": 1, "type": f"{DOMAIN}/get_section_config", "config_entry_id": "minimal_id", "slot_num": 1},
+            {
+                "id": 1,
+                "type": f"{DOMAIN}/get_section_config",
+                "config_entry_id": "minimal_id",
+                "slot_num": 1,
+            },
         )
 
         call_kwargs = mock_gen.call_args[1]


### PR DESCRIPTION
# Summary

Refactor CI workflow to run jobs in parallel with faster package installation.

## Proposed change

### CI Parallelization
Split the workflow into parallel jobs for faster feedback:
- **tests**: runs pytest with `requirements_test.txt`
- **lint**: runs ruff format/check with `requirements_lint.txt`
- **mypy**: runs mypy with `requirements_lint.txt`
- **coverage**: uploads coverage after tests complete (depends on tests job)

### Performance Improvements
- Use `uv` instead of `pip` for significantly faster package installation
- Each job installs only the dependencies it needs (no tox overhead)

### Code Formatting
- Applied `ruff format` to entire codebase (38 files reformatted)
- Removed deprecated `UP038` rule from ruff config (rule was removed from ruff)

### Dependency Cleanup
- Removed tox from requirements and pyproject.toml since CI runs commands directly
- Added `pytest-cov` to requirements_test.txt for coverage support

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: follows #544 (requirements split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)