### PR TITLE
docs: add Lovelace strategies section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ For more information, please see the topic for this package at the [Home
 Assistant Community
 Forum](https://community.home-assistant.io/t/simplified-zwave-keymaster/126765).
 
+## Lovelace Dashboard
+
+Keymaster includes Lovelace strategies that automatically generate dashboards
+for managing your locks. You can create a complete Keymaster dashboard with a
+single line of YAML, or add individual lock views to existing dashboards. See
+the [Lovelace Strategies](https://github.com/FutureTense/keymaster/wiki/Lovelace-Strategies)
+wiki page for setup instructions and configuration options.
+
 ## Installation
 
 Please visit this project's

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Forum](https://community.home-assistant.io/t/simplified-zwave-keymaster/126765).
 Keymaster includes Lovelace strategies that automatically generate dashboards
 for managing your locks. You can create a complete Keymaster dashboard with a
 single line of YAML, or add individual lock views to existing dashboards. See
-the [Lovelace Strategies](https://github.com/FutureTense/keymaster/wiki/Lovelace-Strategies)
+the [Lovelace Configuration](https://github.com/FutureTense/keymaster/wiki/Lovelace-Configuration-Automatic)
 wiki page for setup instructions and configuration options.
 
 ## Installation


### PR DESCRIPTION
# Summary

Add a brief mention of the Lovelace strategies feature to the README.

## Proposed change

Add a new "Lovelace Dashboard" section to the README that:
- Briefly describes the auto-generation capability
- Links to the wiki page for detailed documentation

## Type of change

- [x] Documentation

## Additional information

- This PR is related to issue: follows #536 (Lovelace strategies feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)