### PR TITLE
fix: accesslimit_count not decrementing on lock use

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -34,10 +34,7 @@ from zwave_js_server.util.node import dump_node_state
 
 from homeassistant.components.lock.const import DOMAIN as LOCK_DOMAIN, LockState
 from homeassistant.components.zwave_js import ZWAVE_JS_NOTIFICATION_EVENT
-from homeassistant.components.zwave_js.const import (
-    ATTR_PARAMETERS,
-    DOMAIN as ZWAVE_JS_DOMAIN,
-)
+from homeassistant.components.zwave_js.const import ATTR_PARAMETERS, DOMAIN as ZWAVE_JS_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_DEVICE_ID,

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -835,9 +835,9 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     accesslimit_count: int | None = parent_kmlock.code_slots[
                         code_slot_num
                     ].accesslimit_count
-                    if accesslimit_count is not None and accesslimit_count > 0:
+                    if isinstance(accesslimit_count, int) and accesslimit_count > 0:
                         parent_kmlock.code_slots[code_slot_num].accesslimit_count = (
-                            int(accesslimit_count) - 1
+                            accesslimit_count - 1
                         )
             elif kmlock.code_slots[code_slot_num].accesslimit_count_enabled:
                 accesslimit_count = kmlock.code_slots[code_slot_num].accesslimit_count
@@ -1529,7 +1529,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             return False
 
         if kmslot.accesslimit_count_enabled and (
-            not isinstance(kmslot.accesslimit_count, float) or kmslot.accesslimit_count <= 0
+            not isinstance(kmslot.accesslimit_count, int) or kmslot.accesslimit_count <= 0
         ):
             return False
 

--- a/custom_components/keymaster/number.py
+++ b/custom_components/keymaster/number.py
@@ -30,39 +30,39 @@ async def async_setup_entry(
     coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
 
     entities: list = [
-            KeymasterNumber(
-                entity_description=KeymasterNumberEntityDescription(
-                    key="number.autolock_min_day",
-                    name="Day Auto Lock",
-                    icon="mdi:timer-lock-outline",
-                    mode=NumberMode.BOX,
-                    native_min_value=1,
-                    native_step=1,
-                    device_class=NumberDeviceClass.DURATION,
-                    native_unit_of_measurement=UnitOfTime.MINUTES,
-                    entity_registry_enabled_default=True,
-                    hass=hass,
-                    config_entry=config_entry,
-                    coordinator=coordinator,
-                ),
+        KeymasterNumber(
+            entity_description=KeymasterNumberEntityDescription(
+                key="number.autolock_min_day",
+                name="Day Auto Lock",
+                icon="mdi:timer-lock-outline",
+                mode=NumberMode.BOX,
+                native_min_value=1,
+                native_step=1,
+                device_class=NumberDeviceClass.DURATION,
+                native_unit_of_measurement=UnitOfTime.MINUTES,
+                entity_registry_enabled_default=True,
+                hass=hass,
+                config_entry=config_entry,
+                coordinator=coordinator,
             ),
-            KeymasterNumber(
-                entity_description=KeymasterNumberEntityDescription(
-                    key="number.autolock_min_night",
-                    name="Night Auto Lock",
-                    icon="mdi:timer-lock",
-                    mode=NumberMode.BOX,
-                    native_min_value=1,
-                    native_step=1,
-                    device_class=NumberDeviceClass.DURATION,
-                    native_unit_of_measurement=UnitOfTime.MINUTES,
-                    entity_registry_enabled_default=True,
-                    hass=hass,
-                    config_entry=config_entry,
-                    coordinator=coordinator,
-                ),
+        ),
+        KeymasterNumber(
+            entity_description=KeymasterNumberEntityDescription(
+                key="number.autolock_min_night",
+                name="Night Auto Lock",
+                icon="mdi:timer-lock",
+                mode=NumberMode.BOX,
+                native_min_value=1,
+                native_step=1,
+                device_class=NumberDeviceClass.DURATION,
+                native_unit_of_measurement=UnitOfTime.MINUTES,
+                entity_registry_enabled_default=True,
+                hass=hass,
+                config_entry=config_entry,
+                coordinator=coordinator,
             ),
-        ]
+        ),
+    ]
 
     entities.extend(
         [

--- a/custom_components/keymaster/number.py
+++ b/custom_components/keymaster/number.py
@@ -29,10 +29,7 @@ async def async_setup_entry(
     """Create keymaster Number entities."""
     coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
 
-    entities: list = []
-
-    entities.extend(
-        [
+    entities: list = [
             KeymasterNumber(
                 entity_description=KeymasterNumberEntityDescription(
                     key="number.autolock_min_day",
@@ -66,7 +63,7 @@ async def async_setup_entry(
                 ),
             ),
         ]
-    )
+
     entities.extend(
         [
             KeymasterNumber(
@@ -187,6 +184,9 @@ class KeymasterNumber(KeymasterEntity, NumberEntity):
                 self._code_slot,
             )
             return
+        # Convert to int for accesslimit_count (NumberEntity returns float)
+        if self._property.split(".")[-1] == "accesslimit_count":
+            value = int(value)
         if self._set_property_value(value):
             self._attr_native_value = value
             await self.coordinator.async_refresh()

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -1,6 +1,5 @@
 """Services for keymaster."""
 
-import functools
 import logging
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/keymaster/time.py
+++ b/custom_components/keymaster/time.py
@@ -10,17 +10,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import (
-    CONF_ADVANCED_DAY_OF_WEEK,
-    CONF_SLOTS,
-    CONF_START,
-    COORDINATOR,
-    DAY_NAMES,
-    DOMAIN,
-)
+from .const import CONF_ADVANCED_DAY_OF_WEEK, CONF_SLOTS, CONF_START, COORDINATOR, DAY_NAMES, DOMAIN
 from .coordinator import KeymasterCoordinator
 from .entity import KeymasterEntity, KeymasterEntityDescription
-from .lock import KeymasterCodeSlot, KeymasterCodeSlotDayOfWeek
+from .lock import KeymasterCodeSlotDayOfWeek
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -14,10 +14,7 @@ from custom_components.keymaster.const import (
     DOMAIN,
 )
 from custom_components.keymaster.coordinator import KeymasterCoordinator
-from custom_components.keymaster.entity import (
-    KeymasterEntity,
-    KeymasterEntityDescription,
-)
+from custom_components.keymaster.entity import KeymasterEntity, KeymasterEntityDescription
 from custom_components.keymaster.lock import (
     KeymasterCodeSlot,
     KeymasterCodeSlotDayOfWeek,

--- a/tests/test_lovelace.py
+++ b/tests/test_lovelace.py
@@ -9,8 +9,6 @@ import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from custom_components.keymaster.lovelace import (
     async_generate_lovelace,
     delete_lovelace,

--- a/tests/test_migrate_helpers.py
+++ b/tests/test_migrate_helpers.py
@@ -2,11 +2,7 @@
 
 from datetime import datetime as dt, time as dt_time
 
-import pytest
-
-from custom_components.keymaster.migrate import (
-    _migrate_2to3_validate_and_convert_property,
-)
+from custom_components.keymaster.migrate import _migrate_2to3_validate_and_convert_property
 
 
 async def test_convert_boolean():

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -10,10 +10,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.keymaster.const import COORDINATOR, DOMAIN
-from custom_components.keymaster.services import (
-    SERVICE_REGENERATE_LOVELACE,
-    async_setup_services,
-)
+from custom_components.keymaster.services import SERVICE_REGENERATE_LOVELACE, async_setup_services
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import CONFIG_DATA

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -20,10 +20,7 @@ from custom_components.keymaster.const import (
 )
 from custom_components.keymaster.coordinator import KeymasterCoordinator
 from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
-from custom_components.keymaster.switch import (
-    KeymasterSwitch,
-    KeymasterSwitchEntityDescription,
-)
+from custom_components.keymaster.switch import KeymasterSwitch, KeymasterSwitchEntityDescription
 from homeassistant.core import HomeAssistant
 
 CONFIG_DATA_SWITCH = {

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -5,8 +5,6 @@ from unittest.mock import MagicMock, patch
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.config_entries import ConfigEntryDisabler
-
 from custom_components.keymaster import websocket
 from custom_components.keymaster.const import (
     CONF_ADVANCED_DATE_RANGE,
@@ -20,6 +18,7 @@ from custom_components.keymaster.const import (
     DOMAIN,
 )
 from custom_components.keymaster.websocket import async_setup
+from homeassistant.config_entries import ConfigEntryDisabler
 from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
# Summary

Fix access limit count not decrementing when a code slot is used to unlock the door.

## Proposed change

The `accesslimit_count` feature was not working because of a type mismatch:
- Home Assistant's `NumberEntity` returns `float` values when users set the count
- The decrement logic in `_lock_unlocked` checked `isinstance(accesslimit_count, int)` which failed for floats
- The `_is_slot_active` check inconsistently used `isinstance(..., float)`

**Fix:**
- Convert float to int when setting `accesslimit_count` in the number entity
- Update `_is_slot_active` to check for `int` (matching the dataclass type annotation)
- Make parent lock decrement check consistent with child lock check

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue: Access limit count feature not functioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)