### PR TITLE
style: fix ruff errors in compare_lovelace_output.py

### DIFF
--- a/scripts/compare_lovelace_output.py
+++ b/scripts/compare_lovelace_output.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: T201
 """Compare Lovelace view config output between two git branches.
 
 Usage:
@@ -11,13 +12,15 @@ This script will:
 1. Generate view configs from both branches using the test cases below
 2. Save the outputs to /tmp/<branch>_view_config.json
 3. Report the size difference and whether outputs are functionally equivalent
+
 """
 
 import argparse
 import json
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
+import tempfile
 from typing import Any
 
 # =============================================================================
@@ -71,7 +74,7 @@ TEST_CASES = [
 
 def generate_config_script() -> str:
     """Return the Python code to generate view configs."""
-    return '''
+    return """
 import json
 import sys
 sys.path.insert(0, ".")
@@ -97,14 +100,14 @@ with patch("custom_components.keymaster.lovelace.er"):
         results[name] = result
 
     print(json.dumps(results, indent=2, sort_keys=True))
-'''
+"""
 
 
 def deep_equal(obj1: Any, obj2: Any, path: str = "") -> list[str]:
     """Recursively compare two objects for semantic equality (ignoring key order)."""
     diffs = []
 
-    if type(obj1) != type(obj2):
+    if type(obj1) is not type(obj2):
         diffs.append(f"{path}: type mismatch {type(obj1).__name__} vs {type(obj2).__name__}")
         return diffs
 
@@ -112,11 +115,8 @@ def deep_equal(obj1: Any, obj2: Any, path: str = "") -> list[str]:
         keys1 = set(obj1.keys())
         keys2 = set(obj2.keys())
 
-        for key in sorted(keys1 - keys2):
-            diffs.append(f"{path}.{key}: only in first branch")
-
-        for key in sorted(keys2 - keys1):
-            diffs.append(f"{path}.{key}: only in second branch")
+        diffs.extend(f"{path}.{key}: only in first branch" for key in sorted(keys1 - keys2))
+        diffs.extend(f"{path}.{key}: only in second branch" for key in sorted(keys2 - keys1))
 
         for key in sorted(keys1 & keys2):
             diffs.extend(deep_equal(obj1[key], obj2[key], f"{path}.{key}"))
@@ -124,7 +124,7 @@ def deep_equal(obj1: Any, obj2: Any, path: str = "") -> list[str]:
     elif isinstance(obj1, list):
         if len(obj1) != len(obj2):
             diffs.append(f"{path}: list length {len(obj1)} vs {len(obj2)}")
-        for i, (item1, item2) in enumerate(zip(obj1, obj2)):
+        for i, (item1, item2) in enumerate(zip(obj1, obj2, strict=False)):
             diffs.extend(deep_equal(item1, item2, f"{path}[{i}]"))
 
     elif obj1 != obj2:
@@ -140,6 +140,7 @@ def generate_for_branch(branch: str, repo_root: Path) -> tuple[dict, int]:
         capture_output=True,
         text=True,
         cwd=repo_root,
+        check=False,
     ).stdout.strip()
 
     try:
@@ -153,15 +154,14 @@ def generate_for_branch(branch: str, repo_root: Path) -> tuple[dict, int]:
         )
 
         # Generate the config
-        script = generate_config_script().replace(
-            "TEST_CASES_PLACEHOLDER", repr(TEST_CASES)
-        )
+        script = generate_config_script().replace("TEST_CASES_PLACEHOLDER", repr(TEST_CASES))
 
         result = subprocess.run(
             [sys.executable, "-c", script],
             capture_output=True,
             text=True,
             cwd=repo_root,
+            check=False,
         )
 
         if result.returncode != 0:
@@ -181,10 +181,12 @@ def generate_for_branch(branch: str, repo_root: Path) -> tuple[dict, int]:
             capture_output=True,
             text=True,
             cwd=repo_root,
+            check=False,
         )
 
 
 def main() -> None:
+    """Run the comparison between two git branches."""
     parser = argparse.ArgumentParser(
         description="Compare Lovelace view config output between two git branches."
     )
@@ -193,8 +195,8 @@ def main() -> None:
     parser.add_argument(
         "--output-dir",
         type=Path,
-        default=Path("/tmp"),
-        help="Directory to save output JSON files (default: /tmp)",
+        default=Path(tempfile.gettempdir()),
+        help="Directory to save output JSON files (default: system temp dir)",
     )
     args = parser.parse_args()
 
@@ -213,7 +215,7 @@ def main() -> None:
     output1.write_text(json.dumps(config1, indent=2, sort_keys=True))
     output2.write_text(json.dumps(config2, indent=2, sort_keys=True))
 
-    print(f"\nOutputs saved to:")
+    print("\nOutputs saved to:")
     print(f"  {output1}")
     print(f"  {output2}")
 


### PR DESCRIPTION
# Summary

Fix all ruff linting errors in `scripts/compare_lovelace_output.py`.

## Proposed change

Addresses the following ruff violations:

- **E721**: Use `is not` instead of `!=` for type comparisons
- **PERF401**: Use `list.extend()` with generator expressions instead of for-loops with `append()`
- **B905**: Add explicit `strict=False` parameter to `zip()` calls
- **PLW1510**: Add explicit `check=False` to `subprocess.run()` calls that don't use `check=True`
- **T201**: Add file-level `# ruff: noqa: T201` comment (CLI script intentionally uses print for output)
- **D103**: Add docstring to `main()` function
- **S108**: Replace hardcoded `/tmp` with `tempfile.gettempdir()` for cross-platform compatibility

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: N/A