### PR TITLE
fix: immediately update UI when accesslimit_count changes

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -836,10 +836,20 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         parent_kmlock.code_slots[code_slot_num].accesslimit_count = (
                             accesslimit_count - 1
                         )
+                        # Immediately notify entities of the count change
+                        self.async_set_updated_data(dict(self.kmlocks))
+                        # Check if slot should be deactivated (e.g., count reached 0)
+                        await self._update_slot(
+                            parent_kmlock, parent_kmlock.code_slots[code_slot_num], code_slot_num
+                        )
             elif kmlock.code_slots[code_slot_num].accesslimit_count_enabled:
                 accesslimit_count = kmlock.code_slots[code_slot_num].accesslimit_count
                 if isinstance(accesslimit_count, int) and accesslimit_count > 0:
                     kmlock.code_slots[code_slot_num].accesslimit_count = accesslimit_count - 1
+                    # Immediately notify entities of the count change
+                    self.async_set_updated_data(dict(self.kmlocks))
+                    # Check if slot should be deactivated (e.g., count reached 0)
+                    await self._update_slot(kmlock, kmlock.code_slots[code_slot_num], code_slot_num)
 
             if kmlock.code_slots[code_slot_num].notifications and not kmlock.lock_notifications:
                 if kmlock.code_slots[code_slot_num].name:

--- a/custom_components/keymaster/number.py
+++ b/custom_components/keymaster/number.py
@@ -193,4 +193,5 @@ class KeymasterNumber(KeymasterEntity, NumberEntity):
             value = int(value)
         if self._set_property_value(value):
             self._attr_native_value = value
+            self.async_write_ha_state()  # Immediate UI update
             await self.coordinator.async_refresh()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -442,12 +442,16 @@ async def test_number_entity_async_set_value(hass: HomeAssistant, number_config_
 
     entity = KeymasterNumber(entity_description=entity_description)
 
-    # Mock coordinator.async_refresh
-    with patch.object(coordinator, "async_refresh", new=AsyncMock()) as mock_refresh:
+    # Mock coordinator.async_refresh and async_write_ha_state (entity not registered)
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()) as mock_refresh,
+        patch.object(entity, "async_write_ha_state") as mock_write_state,
+    ):
         await entity.async_set_native_value(5)
 
-        # Should update value and call refresh
+        # Should update value, write state immediately, and call refresh
         assert entity._attr_native_value == 5
+        mock_write_state.assert_called_once()
         mock_refresh.assert_called_once()
 
 
@@ -541,8 +545,11 @@ async def test_number_entity_converts_float_to_int_for_accesslimit_count(
 
     entity = KeymasterNumber(entity_description=entity_description)
 
-    # Mock coordinator.async_refresh
-    with patch.object(coordinator, "async_refresh", new=AsyncMock()):
+    # Mock coordinator.async_refresh and async_write_ha_state (entity not registered)
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(entity, "async_write_ha_state"),
+    ):
         # Pass a float value (like NumberEntity would from the frontend)
         await entity.async_set_native_value(5.0)
 


### PR DESCRIPTION
## Summary
- Add `async_set_updated_data()` calls after decrementing `accesslimit_count` in `_lock_unlocked()` for both parent and child locks
- Call `_update_slot()` after decrement to check if slot should be deactivated and clear PIN from lock when count reaches 0
- Add `async_write_ha_state()` in number entity's `async_set_native_value()` for immediate UI feedback when user changes the value

The UI notification happens before `_update_slot()` so users see the count change immediately, even before the potentially slow PIN clear operation completes.

## Test plan
- [ ] Set a code slot to allow only 1 use
- [ ] Use the code to unlock the door
- [ ] Verify the "Uses Remaining" entity updates immediately (within ~1 second)
- [ ] Verify the code is cleared from the lock when count reaches 0 (not 30+ seconds later)
- [ ] Manually change the "Uses Remaining" value in the UI
- [ ] Verify the change reflects immediately without waiting for refresh

## Related
Reported in PR #538 comments by @tykeal

🤖 Generated with [Claude Code](https://claude.com/claude-code)