### PR TITLE
Fix clearing codes on Schlage locks with user codes sizes other than 4

### DIFF
--- a/custom_components/keymaster/providers/zwave_js.py
+++ b/custom_components/keymaster/providers/zwave_js.py
@@ -554,8 +554,11 @@ class ZWaveJSLockProvider(BaseLockProvider):
         # Verify the code was cleared
         try:
             usercode = get_usercode(self._node, slot_num)
-            # Treat both "" and "0000" as cleared (Schlage BE469 firmware bug workaround)
-            if usercode[ZWAVEJS_ATTR_USERCODE] not in ("", "0000"):
+            # Treat both "" and full string of "0" as cleared (Schlage BE469 firmware bug workaround)
+            if not (
+                usercode[ZWAVEJS_ATTR_USERCODE] == ""
+                or all(char == "0" for char in usercode[ZWAVEJS_ATTR_USERCODE])
+            ):
                 _LOGGER.debug(
                     "[ZWaveJSProvider] Slot %s not yet cleared, will retry",
                     slot_num,

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -401,6 +401,42 @@ class TestZWaveJSLockProviderUsercodes:
 
         assert result is False
 
+    async def test_clear_usercode_schlage_bug_length_4(self, zwave_provider, mock_zwave_node):
+        """Test clear_usercode returns True when the returned value is 0000. Tests Schlage Bug."""
+        zwave_provider._node = mock_zwave_node
+
+        with (
+            patch(
+                "custom_components.keymaster.providers.zwave_js.clear_usercode",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "custom_components.keymaster.providers.zwave_js.get_usercode",
+                return_value={"usercode": "0000"},
+            ),
+        ):
+            result = await zwave_provider.async_clear_usercode(1)
+
+        assert result is True
+
+    async def test_clear_usercode_schlage_bug_length_6(self, zwave_provider, mock_zwave_node):
+        """Test clear_usercode returns True when the returned value is 000000. Tests Schlage Bug."""
+        zwave_provider._node = mock_zwave_node
+
+        with (
+            patch(
+                "custom_components.keymaster.providers.zwave_js.clear_usercode",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "custom_components.keymaster.providers.zwave_js.get_usercode",
+                return_value={"usercode": "000000"},
+            ),
+        ):
+            result = await zwave_provider.async_clear_usercode(1)
+
+        assert result is True
+
 
 class TestZWaveJSLockProviderEventSubscription:
     """Test ZWaveJSLockProvider event subscription."""


### PR DESCRIPTION
## Proposed change
Add logic to handle user code lengths other than 4, for Schlage locks that return ("0"*code_length) after clearing the user code.

I added a couple of tests as well. Could probably drop it to one test, and run through a few different lengths, but this seemed to at least test the core of the change.

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #556 
