### PR TITLE
fix: resolve KeyError when YAML-mode resources lack 'id' field

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -120,6 +120,25 @@ async def test_register_strategy_resource_yaml_mode_warning(
     assert STRATEGY_PATH in caplog.text
 
 
+async def test_register_strategy_resource_yaml_mode_already_exists(
+    hass: HomeAssistant, mock_yaml_resources, caplog
+):
+    """Test no error when resource already exists in YAML mode (no 'id' field)."""
+    mock_yaml_resources.async_items.return_value = [
+        {"url": "/local/other.js", "type": "module"},
+        {"url": STRATEGY_PATH, "type": "module"},
+    ]
+    hass.data[LOVELACE_DOMAIN] = MagicMock()
+    hass.data[LOVELACE_DOMAIN].resources = mock_yaml_resources
+    hass.data[DOMAIN] = {}
+
+    with caplog.at_level(logging.DEBUG):
+        await async_register_strategy_resource(hass)
+
+    assert "already registered" in caplog.text
+    assert "YAML mode" not in caplog.text
+
+
 async def test_register_strategy_resource_no_resources(hass: HomeAssistant):
     """Test registering when no resources available."""
     # No lovelace domain


### PR DESCRIPTION
# Summary

Fixes a `KeyError: 'id'` exception during HA startup when users have YAML-mode Lovelace resources with the keymaster resource already manually added.

## Proposed change

YAML-mode Lovelace resources don't include an `'id'` field — they only have `'url'` and `'type'`. When users followed the warning message and manually added the keymaster resource to their YAML config, the generator expression in `async_register_strategy_resource` crashed on `data['id']` before the `StopIteration` handler (which correctly handles YAML mode) could run.

Restructured the function to check resource existence by URL first using `any()` (works for both YAML and storage collection types), then branch on the result:
- **Already registered** → log and return (no `id` access needed)
- **Not registered + YAML mode** → warn user to add manually
- **Not registered + storage mode** → create the resource automatically

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #560
- This PR is related to issue: