### PR TITLE
feat: show battery level badge on dashboard when available

### DIFF
--- a/custom_components/keymaster/lovelace.py
+++ b/custom_components/keymaster/lovelace.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import yaml
 
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import slugify
@@ -36,7 +36,7 @@ def _find_battery_entity(hass: HomeAssistant, lock_entity_id: str) -> str | None
 
     for entry in er.async_entries_for_device(entity_registry, device_entry.id):
         if (
-            entry.domain == "sensor"
+            entry.domain == SENSOR_DOMAIN
             and entry.original_device_class == SensorDeviceClass.BATTERY
             and not entry.disabled
         ):
@@ -330,7 +330,7 @@ def _get_entity_id(
             unique_id=f"{keymaster_config_entry_id}_{slugify(prop)}",
         )
     # If not found in registry, assume it's already a complete entity ID
-    return entity_id if entity_id else prop
+    return entity_id or prop
 
 
 # Lovelace Card Generation Helpers

--- a/custom_components/keymaster/lovelace.py
+++ b/custom_components/keymaster/lovelace.py
@@ -10,13 +10,39 @@ from typing import Any
 
 import yaml
 
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import slugify
 
 from .const import DAY_NAMES, DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+@callback
+def _find_battery_entity(hass: HomeAssistant, lock_entity_id: str) -> str | None:
+    """Find a battery sensor entity on the same device as the lock."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    lock_entry = entity_registry.async_get(lock_entity_id)
+    if not lock_entry or not lock_entry.device_id:
+        return None
+
+    device_entry = device_registry.async_get(lock_entry.device_id)
+    if not device_entry:
+        return None
+
+    for entry in er.async_entries_for_device(entity_registry, device_entry.id):
+        if (
+            entry.domain == "sensor"
+            and entry.original_device_class == SensorDeviceClass.BATTERY
+            and not entry.disabled
+        ):
+            return entry.entity_id
+
+    return None
 
 
 @callback
@@ -34,6 +60,7 @@ def generate_badges_config(
     badges_list: list[MutableMapping[str, Any]] = _generate_lock_badges(
         lock_entity=lock_entity,
         door_sensor=door_sensor,
+        battery_entity=_find_battery_entity(hass, lock_entity),
         child=bool(parent_config_entry_id),
     )
     mapped_badges_list: MutableMapping[str, Any] | list[MutableMapping[str, Any]] = (
@@ -495,10 +522,12 @@ def _generate_code_slot_dict(
 def _generate_lock_badges(
     lock_entity: str,
     door_sensor: str | None = None,
+    battery_entity: str | None = None,
     child: bool = False,
 ) -> list[MutableMapping[str, Any]]:
     """Generate the Lovelace badges configuration for a keymaster lock."""
     door = door_sensor is not None
+    battery = battery_entity is not None
     return [
         _generate_badge_ll_config(
             entity, name, visibility=visibility, show_name=show_name, tap_action=tap_action
@@ -511,6 +540,7 @@ def _generate_lock_badges(
             ("switch.door_notifications", "Door Notifications", False, True, "toggle", door),
             (lock_entity, "Lock", False, True, "toggle", True),
             (door_sensor, "Door", False, True, "none", door),
+            (battery_entity, "Battery", False, True, "none", battery),
             ("switch.autolock_enabled", "Auto Lock", False, True, "toggle", True),
             ("switch.retry_lock", "Retry Lock", True, True, "toggle", door),
             ("number.autolock_min_day", "Day Auto Lock", True, True, None, True),

--- a/tests/test_lovelace.py
+++ b/tests/test_lovelace.py
@@ -9,12 +9,17 @@ import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 from custom_components.keymaster.lovelace import (
+    _find_battery_entity,
     async_generate_lovelace,
     delete_lovelace,
     generate_view_config,
 )
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -317,6 +322,179 @@ async def test_generate_view_config_badges_without_battery(hass: HomeAssistant):
 
     # Battery badge should NOT be present
     assert not any(b.get("name") == "Battery" for b in badges)
+
+
+# ---------------------------------------------------------------------------
+# _find_battery_entity direct tests (real registry lookups)
+# ---------------------------------------------------------------------------
+
+
+async def test_find_battery_entity_returns_battery_sensor(hass: HomeAssistant):
+    """Test that _find_battery_entity finds a battery sensor on the same device."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    config_entry = MockConfigEntry(domain="zwave_js", data={})
+    config_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("zwave_js", "lock_device")},
+        name="Front Door Lock",
+    )
+
+    entity_registry.async_get_or_create(
+        "lock",
+        "zwave_js",
+        "lock_front_door",
+        config_entry=config_entry,
+        device_id=device.id,
+        suggested_object_id="front_door",
+    )
+
+    entity_registry.async_get_or_create(
+        "sensor",
+        "zwave_js",
+        "battery_front_door",
+        config_entry=config_entry,
+        device_id=device.id,
+        original_device_class=SensorDeviceClass.BATTERY,
+        suggested_object_id="front_door_battery",
+    )
+
+    result = _find_battery_entity(hass, "lock.front_door")
+    assert result == "sensor.front_door_battery"
+
+
+async def test_find_battery_entity_no_battery_sensor(hass: HomeAssistant):
+    """Test that _find_battery_entity returns None when no battery sensor exists."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    config_entry = MockConfigEntry(domain="zwave_js", data={})
+    config_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("zwave_js", "lock_device_no_bat")},
+        name="Back Door Lock",
+    )
+
+    entity_registry.async_get_or_create(
+        "lock",
+        "zwave_js",
+        "lock_back_door",
+        config_entry=config_entry,
+        device_id=device.id,
+        suggested_object_id="back_door",
+    )
+
+    result = _find_battery_entity(hass, "lock.back_door")
+    assert result is None
+
+
+async def test_find_battery_entity_skips_disabled_sensor(hass: HomeAssistant):
+    """Test that _find_battery_entity ignores disabled battery sensors."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    config_entry = MockConfigEntry(domain="zwave_js", data={})
+    config_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("zwave_js", "lock_device_disabled")},
+        name="Garage Lock",
+    )
+
+    entity_registry.async_get_or_create(
+        "lock",
+        "zwave_js",
+        "lock_garage",
+        config_entry=config_entry,
+        device_id=device.id,
+        suggested_object_id="garage",
+    )
+
+    battery_entry = entity_registry.async_get_or_create(
+        "sensor",
+        "zwave_js",
+        "battery_garage",
+        config_entry=config_entry,
+        device_id=device.id,
+        original_device_class=SensorDeviceClass.BATTERY,
+        suggested_object_id="garage_battery",
+    )
+
+    entity_registry.async_update_entity(
+        battery_entry.entity_id,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    result = _find_battery_entity(hass, "lock.garage")
+    assert result is None
+
+
+async def test_find_battery_entity_lock_not_in_registry(hass: HomeAssistant):
+    """Test that _find_battery_entity returns None for unknown lock entity."""
+    result = _find_battery_entity(hass, "lock.nonexistent")
+    assert result is None
+
+
+async def test_find_battery_entity_lock_no_device(hass: HomeAssistant):
+    """Test that _find_battery_entity returns None when lock has no device."""
+    entity_registry = er.async_get(hass)
+
+    config_entry = MockConfigEntry(domain="zwave_js", data={})
+    config_entry.add_to_hass(hass)
+
+    entity_registry.async_get_or_create(
+        "lock",
+        "zwave_js",
+        "lock_orphan",
+        config_entry=config_entry,
+        suggested_object_id="orphan",
+    )
+
+    result = _find_battery_entity(hass, "lock.orphan")
+    assert result is None
+
+
+async def test_find_battery_entity_ignores_non_battery_sensors(hass: HomeAssistant):
+    """Test that _find_battery_entity ignores sensors that aren't battery class."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    config_entry = MockConfigEntry(domain="zwave_js", data={})
+    config_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("zwave_js", "lock_device_temp")},
+        name="Side Door Lock",
+    )
+
+    entity_registry.async_get_or_create(
+        "lock",
+        "zwave_js",
+        "lock_side_door",
+        config_entry=config_entry,
+        device_id=device.id,
+        suggested_object_id="side_door",
+    )
+
+    entity_registry.async_get_or_create(
+        "sensor",
+        "zwave_js",
+        "temperature_side_door",
+        config_entry=config_entry,
+        device_id=device.id,
+        original_device_class=SensorDeviceClass.TEMPERATURE,
+        suggested_object_id="side_door_temperature",
+    )
+
+    result = _find_battery_entity(hass, "lock.side_door")
+    assert result is None
 
 
 async def test_generate_view_config_badges_with_door(hass: HomeAssistant):


### PR DESCRIPTION
# Summary
Users have asked for battery information to be displayed on the dynamic
dashboard for locks that have a battery sensor.
<!--
  Please include a summary of the change and which issue is fixed or linked.
  Please also include relevant motivation and context.
-->

## Proposed change
Discover the battery sensor entity on the lock's device via the
entity and device registries. If found, add a Battery badge to the
dynamic dashboard. Locks without a battery entity are unaffected.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #549
- This PR is related to issue:
