### PR TITLE
fix: use effective device_class for battery entity lookup

### DIFF
--- a/custom_components/keymaster/lovelace.py
+++ b/custom_components/keymaster/lovelace.py
@@ -37,7 +37,7 @@ def _find_battery_entity(hass: HomeAssistant, lock_entity_id: str) -> str | None
     for entry in er.async_entries_for_device(entity_registry, device_entry.id):
         if (
             entry.domain == SENSOR_DOMAIN
-            and entry.original_device_class == SensorDeviceClass.BATTERY
+            and (entry.device_class or entry.original_device_class) == SensorDeviceClass.BATTERY
             and not entry.disabled
         ):
             return entry.entity_id


### PR DESCRIPTION
## Summary

The battery entity lookup introduced in PR #569 used `original_device_class` to find battery sensors on lock devices. This only checks the integration-set device class and misses entities where the device class is resolved via user override.

## Fix

Use `(entry.device_class or entry.original_device_class)` to mirror Home Assistant's own resolution logic for the effective device class, matching both user-overridden and integration-set values.

Fixes #549