### PR TITLE
fix: preserve pre-existing lock codes during onboarding

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1178,7 +1178,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         # Use provider if available
         if kmlock.provider:
-            success = await kmlock.provider.async_set_usercode(code_slot_num, pin)
+            slot_name = kmlock.code_slots[code_slot_num].name
+            success = await kmlock.provider.async_set_usercode(code_slot_num, pin, name=slot_name)
             if not success:
                 _LOGGER.error(
                     "[Coordinator] %s: Code Slot %s: Unable to set PIN via provider",
@@ -1565,6 +1566,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             return
 
         kmslot.active = new_active
+
+        # No local PIN yet (initial state) — don't push or clear; let
+        # _sync_usercode handle importing any pre-existing lock code.
+        if kmslot.pin is None:
+            return
+
         if not kmslot.active or not kmslot.pin or not kmslot.enabled:
             await self.clear_pin_from_lock(
                 config_entry_id=kmlock.keymaster_config_entry_id,
@@ -1590,6 +1597,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         if not km_code_slot:
             return
+
+        # Import name from lock when the keymaster slot has no name yet
+        if km_code_slot.name is None and usercode_slot.name:
+            km_code_slot.name = usercode_slot.name
 
         # Refresh from lock if slot claims to have a code but we don't have the value
         # (e.g., masked responses where in_use=True but code is None or all one
@@ -1633,6 +1644,13 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     pin=str(slot.pin),
                     override=True,
                 )
+            return
+
+        # Import pre-existing lock code when keymaster slot has never had a PIN
+        if slot.pin is None and usercode.isdigit():
+            slot.pin = usercode
+            slot.active = await KeymasterCoordinator._is_slot_active(slot)
+            slot.synced = Synced.SYNCED
             return
 
         # Slot disabled or inactive -> ensure lock is cleared

--- a/custom_components/keymaster/text.py
+++ b/custom_components/keymaster/text.py
@@ -164,4 +164,24 @@ class KeymasterText(KeymasterEntity, TextEntity):
             return
         if self._set_property_value(value):
             self._attr_native_value = value
+            # When the slot name changes, re-push the code to the lock so the
+            # provider can update the name on the device (e.g., Schlage tag).
+            slot_pin: str | None = None
+            code_slot: int | None = self._code_slot
+            if (
+                self._property.endswith(".name")
+                and self._kmlock
+                and code_slot
+                and self._kmlock.code_slots
+                and code_slot in self._kmlock.code_slots
+                and self._kmlock.code_slots[code_slot].active
+            ):
+                slot_pin = self._kmlock.code_slots[code_slot].pin
+            if slot_pin and code_slot:
+                await self.coordinator.set_pin_on_lock(
+                    config_entry_id=self._config_entry.entry_id,
+                    code_slot_num=code_slot,
+                    pin=slot_pin,
+                    override=True,
+                )
             await self.coordinator.async_refresh()

--- a/tests/test_coordinator_code_import.py
+++ b/tests/test_coordinator_code_import.py
@@ -1,0 +1,340 @@
+"""Tests for coordinator code import and name sync logic.
+
+Tests the behavior added to preserve pre-existing lock codes during
+onboarding, import code names from the lock, and pass slot names to the
+provider when setting codes.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from custom_components.keymaster.const import Synced
+from custom_components.keymaster.coordinator import KeymasterCoordinator
+from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
+from custom_components.keymaster.providers._base import BaseLockProvider, CodeSlot
+from homeassistant.core import HomeAssistant
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = Mock(spec=HomeAssistant)
+    hass.config_entries = Mock()
+    hass.config = Mock()
+    hass.config.path = Mock(return_value="/test/path")
+    return hass
+
+
+@pytest.fixture
+def mock_coordinator(mock_hass):
+    """Create a mock KeymasterCoordinator with PIN operations mocked."""
+    with patch.object(KeymasterCoordinator, "__init__", return_value=None):
+        coordinator = KeymasterCoordinator(mock_hass)
+        coordinator.hass = mock_hass
+        coordinator.kmlocks = {}
+        coordinator._quick_refresh = False
+        coordinator.set_pin_on_lock = AsyncMock()
+        coordinator.clear_pin_from_lock = AsyncMock()
+        coordinator.async_set_updated_data = Mock()
+        coordinator._initial_setup_done_event = AsyncMock()
+        coordinator._initial_setup_done_event.wait = AsyncMock()
+        return coordinator
+
+
+@pytest.fixture
+def kmlock():
+    """Create a KeymasterLock with default code slots."""
+    lock = KeymasterLock(
+        lock_name="Test Lock",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="test_entry_id",
+    )
+    lock.connected = True
+    return lock
+
+
+# ---------------------------------------------------------------------------
+# _update_slot: skip clear when pin is None
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSlotInitialState:
+    """Tests for _update_slot with initial (pin=None) slots."""
+
+    async def test_update_slot_skips_clear_when_pin_is_none(self, mock_coordinator, kmlock):
+        """Slot with pin=None should not trigger clear_pin_from_lock."""
+        kmlock.code_slots = {
+            1: KeymasterCodeSlot(number=1, pin=None, active=True, enabled=True),
+        }
+        mock_coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+        # active=True -> _is_slot_active returns False (pin is None) -> active changes
+        await mock_coordinator._update_slot(kmlock, kmlock.code_slots[1], 1)
+
+        mock_coordinator.clear_pin_from_lock.assert_not_called()
+        mock_coordinator.set_pin_on_lock.assert_not_called()
+        # active should be updated to False (no pin)
+        assert kmlock.code_slots[1].active is False
+
+    async def test_update_slot_clears_when_pin_is_empty_string(self, mock_coordinator, kmlock):
+        """Slot with pin='' (explicitly cleared) should still trigger clear."""
+        kmlock.code_slots = {
+            1: KeymasterCodeSlot(number=1, pin="", active=True, enabled=True),
+        }
+        mock_coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+        await mock_coordinator._update_slot(kmlock, kmlock.code_slots[1], 1)
+
+        mock_coordinator.clear_pin_from_lock.assert_called_once()
+
+    async def test_update_slot_sets_pin_when_active_and_has_pin(self, mock_coordinator, kmlock):
+        """Slot that transitions to active with a PIN should push to lock."""
+        slot = KeymasterCodeSlot(number=1, pin="1234", active=False, enabled=True)
+        kmlock.code_slots = {1: slot}
+        mock_coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+        # Force _is_slot_active to return True
+        with patch.object(
+            KeymasterCoordinator, "_is_slot_active", new=AsyncMock(return_value=True)
+        ):
+            await mock_coordinator._update_slot(kmlock, slot, 1)
+
+        mock_coordinator.set_pin_on_lock.assert_called_once()
+
+    async def test_update_slot_noop_when_active_unchanged(self, mock_coordinator, kmlock):
+        """No action when active state hasn't changed."""
+        slot = KeymasterCodeSlot(number=1, pin="1234", active=True, enabled=True)
+        kmlock.code_slots = {1: slot}
+
+        with patch.object(
+            KeymasterCoordinator, "_is_slot_active", new=AsyncMock(return_value=True)
+        ):
+            await mock_coordinator._update_slot(kmlock, slot, 1)
+
+        mock_coordinator.set_pin_on_lock.assert_not_called()
+        mock_coordinator.clear_pin_from_lock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _sync_pin: import code when slot.pin is None
+# ---------------------------------------------------------------------------
+
+
+class TestSyncPinImport:
+    """Tests for _sync_pin code import behavior."""
+
+    async def test_sync_pin_imports_code_when_pin_is_none(self, mock_coordinator, kmlock):
+        """Lock-reported code should be imported when slot has never had a PIN."""
+        slot = KeymasterCodeSlot(number=1, pin=None, active=True, enabled=True)
+        kmlock.code_slots = {1: slot}
+
+        await mock_coordinator._sync_pin(kmlock, 1, "5678")
+
+        assert slot.pin == "5678"
+        assert slot.synced == Synced.SYNCED
+        # Should not try to clear or set on lock
+        mock_coordinator.clear_pin_from_lock.assert_not_called()
+        mock_coordinator.set_pin_on_lock.assert_not_called()
+
+    async def test_sync_pin_import_reevaluates_active(self, mock_coordinator, kmlock):
+        """After importing, active state should be re-evaluated."""
+        slot = KeymasterCodeSlot(number=1, pin=None, active=False, enabled=True)
+        kmlock.code_slots = {1: slot}
+
+        await mock_coordinator._sync_pin(kmlock, 1, "5678")
+
+        assert slot.pin == "5678"
+        # active should now be True since pin is set and slot is enabled
+        assert slot.active is True
+
+    async def test_sync_pin_import_disabled_slot(self, mock_coordinator, kmlock):
+        """Import should store PIN but mark slot inactive when disabled."""
+        slot = KeymasterCodeSlot(number=1, pin=None, active=True, enabled=False)
+        kmlock.code_slots = {1: slot}
+
+        await mock_coordinator._sync_pin(kmlock, 1, "5678")
+
+        # PIN is imported even when slot is disabled
+        assert slot.pin == "5678"
+        # But active should be False because enabled=False
+        assert slot.active is False
+
+    async def test_sync_pin_import_skips_non_numeric(self, mock_coordinator, kmlock):
+        """Non-numeric usercode should not be imported when pin is None."""
+        slot = KeymasterCodeSlot(number=1, pin=None, active=True, enabled=True)
+        kmlock.code_slots = {1: slot}
+
+        await mock_coordinator._sync_pin(kmlock, 1, "****")
+
+        # pin should remain None, no import
+        assert slot.pin is None
+
+    async def test_sync_pin_does_not_import_when_pin_is_set(self, mock_coordinator, kmlock):
+        """Existing local PIN should not be overwritten by import logic."""
+        slot = KeymasterCodeSlot(
+            number=1, pin="1234", active=True, enabled=True, synced=Synced.SYNCED
+        )
+        kmlock.code_slots = {1: slot}
+
+        await mock_coordinator._sync_pin(kmlock, 1, "5678")
+
+        # Should follow normal sync logic, not import
+        assert slot.pin == "5678"  # Normal sync overwrites
+        assert slot.synced == Synced.SYNCED
+
+    async def test_sync_pin_empty_code_with_none_pin(self, mock_coordinator, kmlock):
+        """Empty usercode with None pin should set DISCONNECTED."""
+        slot = KeymasterCodeSlot(number=1, pin=None, active=False, enabled=True)
+        kmlock.code_slots = {1: slot}
+
+        await mock_coordinator._sync_pin(kmlock, 1, "")
+
+        assert slot.synced == Synced.DISCONNECTED
+        assert slot.pin is None
+
+
+# ---------------------------------------------------------------------------
+# _sync_usercode: import name from lock
+# ---------------------------------------------------------------------------
+
+
+class TestSyncUsercodeNameImport:
+    """Tests for _sync_usercode name import behavior."""
+
+    async def test_sync_usercode_imports_name_when_none(self, mock_coordinator, kmlock):
+        """Lock code name should be imported when keymaster slot has no name."""
+        slot = KeymasterCodeSlot(number=1, pin=None, name=None, enabled=True, active=True)
+        kmlock.code_slots = {1: slot}
+        mock_coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+        usercode = CodeSlot(slot_num=1, code="1234", in_use=True, name="Guest")
+
+        await mock_coordinator._sync_usercode(kmlock, usercode)
+
+        assert slot.name == "Guest"
+
+    async def test_sync_usercode_preserves_existing_name(self, mock_coordinator, kmlock):
+        """Existing keymaster slot name should not be overwritten."""
+        slot = KeymasterCodeSlot(number=1, pin="1234", name="My Name", enabled=True, active=True)
+        kmlock.code_slots = {1: slot}
+        mock_coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+        usercode = CodeSlot(slot_num=1, code="1234", in_use=True, name="Lock Name")
+
+        await mock_coordinator._sync_usercode(kmlock, usercode)
+
+        assert slot.name == "My Name"
+
+    async def test_sync_usercode_skips_empty_lock_name(self, mock_coordinator, kmlock):
+        """Empty lock name should not be imported."""
+        slot = KeymasterCodeSlot(number=1, pin=None, name=None, enabled=True, active=True)
+        kmlock.code_slots = {1: slot}
+        mock_coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+        usercode = CodeSlot(slot_num=1, code="1234", in_use=True, name="")
+
+        await mock_coordinator._sync_usercode(kmlock, usercode)
+
+        assert slot.name is None
+
+    async def test_sync_usercode_skips_none_lock_name(self, mock_coordinator, kmlock):
+        """None lock name should not be imported."""
+        slot = KeymasterCodeSlot(number=1, pin=None, name=None, enabled=True, active=True)
+        kmlock.code_slots = {1: slot}
+        mock_coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+        usercode = CodeSlot(slot_num=1, code="1234", in_use=True, name=None)
+
+        await mock_coordinator._sync_usercode(kmlock, usercode)
+
+        assert slot.name is None
+
+    async def test_sync_usercode_ignores_unknown_slot(self, mock_coordinator, kmlock):
+        """Usercode for a slot not in kmlock should be silently ignored."""
+        kmlock.code_slots = {}
+        mock_coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+        usercode = CodeSlot(slot_num=99, code="1234", in_use=True, name="Unknown")
+
+        # Should not raise
+        await mock_coordinator._sync_usercode(kmlock, usercode)
+
+
+# ---------------------------------------------------------------------------
+# set_pin_on_lock: passes slot name to provider
+# ---------------------------------------------------------------------------
+
+
+class TestSetPinPassesName:
+    """Tests that set_pin_on_lock passes the slot name to the provider."""
+
+    @pytest.fixture
+    def real_coordinator(self, mock_hass):
+        """Coordinator with real set_pin_on_lock (not mocked)."""
+        with patch.object(KeymasterCoordinator, "__init__", return_value=None):
+            coordinator = KeymasterCoordinator(mock_hass)
+            coordinator.hass = mock_hass
+            coordinator.kmlocks = {}
+            coordinator._quick_refresh = False
+            coordinator._initial_setup_done_event = AsyncMock()
+            coordinator._initial_setup_done_event.wait = AsyncMock()
+            coordinator.async_set_updated_data = Mock()
+            return coordinator
+
+    async def test_set_pin_passes_name_to_provider(self, real_coordinator):
+        """set_pin_on_lock should pass the slot name to async_set_usercode."""
+        provider = Mock(spec=BaseLockProvider)
+        provider.async_set_usercode = AsyncMock(return_value=True)
+
+        lock = KeymasterLock(
+            lock_name="Test Lock",
+            lock_entity_id="lock.test",
+            keymaster_config_entry_id="test_entry",
+        )
+        lock.connected = True
+        lock.provider = provider
+        lock.code_slots = {
+            1: KeymasterCodeSlot(number=1, pin="1234", name="Guest", active=True, enabled=True),
+        }
+        real_coordinator.kmlocks["test_entry"] = lock
+
+        result = await real_coordinator.set_pin_on_lock(
+            config_entry_id="test_entry",
+            code_slot_num=1,
+            pin="5678",
+            override=True,
+        )
+
+        assert result is True
+        provider.async_set_usercode.assert_called_once_with(1, "5678", name="Guest")
+
+    async def test_set_pin_passes_none_name(self, real_coordinator):
+        """set_pin_on_lock should pass None name when slot has no name."""
+        provider = Mock(spec=BaseLockProvider)
+        provider.async_set_usercode = AsyncMock(return_value=True)
+
+        lock = KeymasterLock(
+            lock_name="Test Lock",
+            lock_entity_id="lock.test",
+            keymaster_config_entry_id="test_entry",
+        )
+        lock.connected = True
+        lock.provider = provider
+        lock.code_slots = {
+            1: KeymasterCodeSlot(number=1, pin="1234", name=None, active=True, enabled=True),
+        }
+        real_coordinator.kmlocks["test_entry"] = lock
+
+        await real_coordinator.set_pin_on_lock(
+            config_entry_id="test_entry",
+            code_slot_num=1,
+            pin="5678",
+            override=True,
+        )
+
+        provider.async_set_usercode.assert_called_once_with(1, "5678", name=None)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -372,6 +372,127 @@ async def test_text_entity_invalid_pin_ignored(
         mock_clear_pin.assert_not_called()
 
 
+async def test_text_entity_name_change_repushes_code(
+    hass: HomeAssistant, text_config_entry, coordinator
+):
+    """Test that renaming a slot re-pushes the code to the lock."""
+
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=text_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Old Name", pin="1234", active=True, enabled=True)
+    }
+    coordinator.kmlocks[text_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterTextEntityDescription(
+        key="text.code_slots:1.name",
+        name="Code Slot 1: Name",
+        icon="mdi:form-textbox-lock",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=text_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterText(entity_description=entity_description)
+
+    with (
+        patch.object(coordinator, "set_pin_on_lock", new=AsyncMock()) as mock_set_pin,
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+    ):
+        await entity.async_set_value("New Name")
+
+        # Name should be updated locally
+        assert kmlock.code_slots[1].name == "New Name"
+        # Code should be re-pushed to lock with the new name
+        mock_set_pin.assert_called_once_with(
+            config_entry_id=text_config_entry.entry_id,
+            code_slot_num=1,
+            pin="1234",
+            override=True,
+        )
+
+
+async def test_text_entity_name_change_no_repush_without_pin(
+    hass: HomeAssistant, text_config_entry, coordinator
+):
+    """Test that renaming a slot without a PIN does not re-push."""
+
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=text_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Old Name", pin=None, active=True, enabled=True)
+    }
+    coordinator.kmlocks[text_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterTextEntityDescription(
+        key="text.code_slots:1.name",
+        name="Code Slot 1: Name",
+        icon="mdi:form-textbox-lock",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=text_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterText(entity_description=entity_description)
+
+    with (
+        patch.object(coordinator, "set_pin_on_lock", new=AsyncMock()) as mock_set_pin,
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+    ):
+        await entity.async_set_value("New Name")
+
+        assert kmlock.code_slots[1].name == "New Name"
+        mock_set_pin.assert_not_called()
+
+
+async def test_text_entity_name_change_no_repush_when_inactive(
+    hass: HomeAssistant, text_config_entry, coordinator
+):
+    """Test that renaming an inactive slot does not re-push."""
+
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=text_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Old Name", pin="1234", active=False, enabled=True)
+    }
+    coordinator.kmlocks[text_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterTextEntityDescription(
+        key="text.code_slots:1.name",
+        name="Code Slot 1: Name",
+        icon="mdi:form-textbox-lock",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=text_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterText(entity_description=entity_description)
+
+    with (
+        patch.object(coordinator, "set_pin_on_lock", new=AsyncMock()) as mock_set_pin,
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+    ):
+        await entity.async_set_value("New Name")
+
+        assert kmlock.code_slots[1].name == "New Name"
+        mock_set_pin.assert_not_called()
+
+
 async def test_text_entity_child_lock_ignores_name_change_without_override(
     hass: HomeAssistant, text_config_entry, coordinator, caplog
 ):


### PR DESCRIPTION
## Summary

During initial setup, keymaster would clear codes already on the lock because `_update_slot()` ran before `_sync_usercode()` and found no local PIN. This PR fixes the coordinator sync logic and adds name passthrough support.

## Changes

### coordinator.py
- **`_update_slot()`**: Skip clear when `slot.pin is None` (initial state), letting `_sync_usercode` handle importing any pre-existing lock code.
- **`_sync_pin()`**: When the lock reports a valid code and the keymaster slot has never had a PIN, import the code and re-evaluate active state instead of clearing.
- **`_sync_usercode()`**: Import the code name from the lock when the keymaster slot has no name yet.
- **`set_pin_on_lock()`**: Pass the keymaster slot name to the provider's `async_set_usercode()`, so providers that store names (e.g., Schlage) use the real name instead of a fallback like "Code Slot N".

### text.py
- When a slot name is changed in the UI and the slot has an active PIN, re-push the code to the lock so the provider can update the on-device name.

## Context

These fixes are a prerequisite for the upcoming Schlage WiFi lock provider, but benefit any provider that supports named codes. The changes are backward-compatible — Z-Wave JS accepts the optional `name` parameter but currently ignores it.