### PR TITLE
feat: add Akuvox lock provider with event routing fixes

### DIFF
--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -34,12 +34,10 @@ async def async_setup_entry(
         _LOGGER.error("Lock not found for config entry %s", config_entry.entry_id)
         raise PlatformNotReady
 
-    # Provider is guaranteed to exist - config flow filters to supported platforms
-    # and coordinator fails setup if provider creation fails
-    assert kmlock.provider is not None
-
-    # Add connection status sensor if provider supports it
-    if kmlock.provider.supports_connection_status:
+    # Add connection status sensor if provider supports it (or doesn't exist yet).
+    # Provider may not yet exist during startup due to concurrent config entry setup;
+    # the sensor is created as unavailable and becomes available once the provider connects.
+    if not kmlock.provider or kmlock.provider.supports_connection_status:
         entities.append(
             KeymasterBinarySensor(
                 entity_description=KeymasterBinarySensorEntityDescription(

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -454,17 +454,29 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if temp_new_state := self.hass.states.get(kmlock.lock_entity_id):
             new_state = temp_new_state.state
 
+        # Determine the intended action from event semantics first, since
+        # provider events may arrive before the entity state has updated.
+        # Fall back to entity state only when the event label is ambiguous.
+        label_lower = event_label.lower() if event_label else ""
+        if "unlock" in label_lower:
+            inferred_action = LockState.UNLOCKED
+        elif "lock" in label_lower and "jam" not in label_lower:
+            inferred_action = LockState.LOCKED
+        else:
+            inferred_action = new_state
+
         _LOGGER.debug(
             "[handle_lock_event_from_provider] %s: event_label: %s, new_state: %s, "
-            "code_slot_num: %s, action_code: %s",
+            "inferred_action: %s, code_slot_num: %s, action_code: %s",
             kmlock.lock_name,
             event_label,
             new_state,
+            inferred_action,
             code_slot_num,
             action_code,
         )
 
-        if new_state == LockState.UNLOCKED:
+        if inferred_action == LockState.UNLOCKED:
             await self._lock_unlocked(
                 kmlock=kmlock,
                 code_slot_num=code_slot_num,
@@ -472,7 +484,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 event_label=event_label,
                 action_code=action_code,
             )
-        elif new_state == LockState.LOCKED:
+        elif inferred_action == LockState.LOCKED:
             await self._lock_locked(
                 kmlock=kmlock,
                 source="event",
@@ -483,7 +495,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(
                 "[handle_lock_event_from_provider] %s: Unknown lock state: %s",
                 kmlock.lock_name,
-                new_state,
+                inferred_action,
             )
 
     async def _handle_door_state_change(
@@ -949,6 +961,20 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 self.kmlocks[kmlock.keymaster_config_entry_id].pending_delete = False
                 await self._update_lock(kmlock)
                 return
+            # Ensure provider exists for platform setup even if connection
+            # hasn't completed yet (async_refresh may still be in progress).
+            # Connection will happen during the next coordinator refresh cycle.
+            existing_lock = self.kmlocks[kmlock.keymaster_config_entry_id]
+            if not existing_lock.provider:
+                keymaster_entry = self.hass.config_entries.async_get_entry(
+                    existing_lock.keymaster_config_entry_id
+                )
+                if keymaster_entry:
+                    existing_lock.provider = create_provider(
+                        hass=self.hass,
+                        lock_entity_id=existing_lock.lock_entity_id,
+                        keymaster_config_entry=keymaster_entry,
+                    )
             _LOGGER.debug("[add_lock] %s: Lock already exists, not adding", kmlock.lock_name)
             return
         _LOGGER.debug("[add_lock] %s", kmlock.lock_name)

--- a/custom_components/keymaster/manifest.json
+++ b/custom_components/keymaster/manifest.json
@@ -8,6 +8,7 @@
     "input_datetime",
     "input_number",
     "input_text",
+    "local_akuvox",
     "mqtt",
     "ozw",
     "script",

--- a/custom_components/keymaster/providers/__init__.py
+++ b/custom_components/keymaster/providers/__init__.py
@@ -9,16 +9,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from ._base import BaseLockProvider, CodeSlot, ConnectionCallback, LockEventCallback
+from .akuvox import AkuvoxLockProvider
 from .zwave_js import ZWaveJSLockProvider
 
 _LOGGER = logging.getLogger(__name__)
 
 # Provider registry - maps platform domain to provider class
 PROVIDER_MAP: dict[str, type[BaseLockProvider]] = {
+    "local_akuvox": AkuvoxLockProvider,
     "zwave_js": ZWaveJSLockProvider,
-    # Future providers would be registered here:
-    # "zha": ZHALockProvider,
-    # "mqtt": Zigbee2MQTTLockProvider,
 }
 
 

--- a/custom_components/keymaster/providers/akuvox.py
+++ b/custom_components/keymaster/providers/akuvox.py
@@ -1,0 +1,594 @@
+"""Local Akuvox lock provider for keymaster.
+
+Akuvox door controllers manage access codes as *users* identified by an
+internal device ID, not by numeric slot numbers.  This provider bridges
+that gap by tagging user names with a slot prefix in the format
+``[KM:<slot>] <friendly name>``.  Pre-existing users discovered on the
+device are automatically tagged and assigned to the next available slot
+number.
+
+All operations go through the Home Assistant ``local_akuvox`` integration
+services (``list_users``, ``add_user``, ``modify_user``, ``delete_user``)
+rather than importing pylocal-akuvox directly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+import functools
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from custom_components.keymaster.const import CONF_SLOTS, CONF_START
+from homeassistant.core import Event
+from homeassistant.exceptions import HomeAssistantError
+
+from ._base import BaseLockProvider, CodeSlot, LockEventCallback
+
+if TYPE_CHECKING:
+    from custom_components.keymaster.lock import KeymasterLock
+
+_LOGGER = logging.getLogger(__name__)
+
+AKUVOX_DOMAIN = "local_akuvox"
+AKUVOX_WEBHOOK_EVENT = "local_akuvox_webhook_received"
+
+# Regex to parse the keymaster slot tag from user names.
+# Format: [KM:XX] Friendly Name
+_SLOT_TAG_RE = re.compile(r"^\[KM:(\d+)\]\s*(.*)")
+
+# Default schedule/relay values for keymaster-managed users.
+# These are required by the Akuvox add_user service but are not
+# meaningful for keymaster's code-slot abstraction.
+_DEFAULT_SCHEDULE_IDS = "1001"  # "Always" schedule on Akuvox devices
+_DEFAULT_LIFT_FLOOR_NUM = "1"
+
+# Local users have source_type "1"; cloud-provisioned users ("2") cannot
+# be managed and must be filtered out.
+_LOCAL_SOURCE_TYPE = "1"
+
+
+def _make_tagged_name(slot_num: int, name: str | None = None) -> str:
+    """Create a tagged user name with keymaster slot number."""
+    base = name or f"Code Slot {slot_num}"
+    return f"[KM:{slot_num}] {base}"
+
+
+def _parse_tag(name: str) -> tuple[int | None, str]:
+    """Parse a keymaster slot tag from a user name.
+
+    Returns ``(slot_num, friendly_name)`` when a tag is present, or
+    ``(None, original_name)`` when no tag is found.
+    """
+    match = _SLOT_TAG_RE.match(name)
+    if match:
+        return int(match.group(1)), match.group(2)
+    return None, name
+
+
+@dataclass
+class AkuvoxLockProvider(BaseLockProvider):
+    """Local Akuvox lock provider implementation.
+
+    Users on Akuvox controllers are identified by a device-internal ID
+    and a name, not by slot numbers.  This provider assigns virtual slot
+    numbers by embedding a ``[KM:<slot>]`` tag in each user's name.
+    """
+
+    _akuvox_device_id: str | None = field(default=None, init=False, repr=False)
+
+    @property
+    def domain(self) -> str:
+        """Return the integration domain."""
+        return AKUVOX_DOMAIN
+
+    @property
+    def supports_connection_status(self) -> bool:
+        """Whether provider can report lock connection status."""
+        return True
+
+    @property
+    def supports_push_updates(self) -> bool:
+        """Whether provider supports real-time event updates."""
+        return True
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    async def async_connect(self) -> bool:
+        """Connect to the Akuvox lock."""
+        self._connected = False
+
+        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
+        if not lock_entry:
+            _LOGGER.error(
+                "[AkuvoxProvider] Can't find lock in Entity Registry: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        self.lock_config_entry_id = lock_entry.config_entry_id
+        if not self.lock_config_entry_id:
+            _LOGGER.error(
+                "[AkuvoxProvider] Lock has no config entry: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        akuvox_entry = self.hass.config_entries.async_get_entry(self.lock_config_entry_id)
+        if not akuvox_entry:
+            _LOGGER.error(
+                "[AkuvoxProvider] Can't find local_akuvox config entry: %s",
+                self.lock_config_entry_id,
+            )
+            return False
+
+        akuvox_data = self.hass.data.get(AKUVOX_DOMAIN, {})
+        if self.lock_config_entry_id not in akuvox_data:
+            _LOGGER.error(
+                "[AkuvoxProvider] Can't find Akuvox coordinator in hass.data for entry: %s",
+                self.lock_config_entry_id,
+            )
+            return False
+
+        # Get the device identifier from the device registry.
+        device_entry = None
+        if lock_entry.device_id:
+            device_entry = self.device_registry.async_get(lock_entry.device_id)
+        if not device_entry:
+            _LOGGER.error(
+                "[AkuvoxProvider] Can't find lock in Device Registry: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        akuvox_device_id: str | None = None
+        for identifier in device_entry.identifiers:
+            if identifier[0] == AKUVOX_DOMAIN:
+                akuvox_device_id = identifier[1]
+                break
+
+        if not akuvox_device_id:
+            _LOGGER.error(
+                "[AkuvoxProvider] Unable to get Akuvox device ID for lock: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        self._akuvox_device_id = akuvox_device_id
+        self._connected = True
+        _LOGGER.debug(
+            "[AkuvoxProvider] Connected to lock %s (device_id %s)",
+            self.lock_entity_id,
+            akuvox_device_id,
+        )
+        return True
+
+    async def async_is_connected(self) -> bool:
+        """Check if Akuvox lock connection is active."""
+        if not self._akuvox_device_id:
+            self._connected = False
+            return False
+
+        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
+        if not lock_entry or not lock_entry.config_entry_id:
+            self._connected = False
+            return False
+
+        akuvox_entry = self.hass.config_entries.async_get_entry(lock_entry.config_entry_id)
+        if not akuvox_entry:
+            self._connected = False
+            return False
+
+        akuvox_data = self.hass.data.get(AKUVOX_DOMAIN, {})
+        lock_config_entry_id = lock_entry.config_entry_id
+        if self.lock_config_entry_id != lock_config_entry_id:
+            self.lock_config_entry_id = lock_config_entry_id
+
+        connected = lock_config_entry_id in akuvox_data
+
+        self._connected = connected
+        return connected
+
+    # ------------------------------------------------------------------
+    # Event subscription
+    # ------------------------------------------------------------------
+
+    def subscribe_lock_events(
+        self, kmlock: KeymasterLock, callback: LockEventCallback
+    ) -> Callable[[], None]:
+        """Subscribe to Akuvox webhook events for this lock.
+
+        Listens for ``local_akuvox_webhook_received`` events on the HA
+        event bus and translates them into keymaster lock event callbacks.
+
+        Relevant event types from the Akuvox device:
+        - ``valid_code_entered``: A valid PIN was used (includes user info)
+        - ``invalid_code_entered``: An invalid PIN was entered
+        - ``relay_a_triggered`` / ``relay_b_triggered``: Relay opened
+        - ``relay_a_closed`` / ``relay_b_closed``: Relay returned to locked
+        """
+        unsub_list: list[Callable[[], None]] = []
+
+        async def handle_akuvox_webhook(event: Event) -> None:
+            """Handle incoming Akuvox webhook event."""
+            data = event.data or {}
+
+            # Verify this event is for our lock's config entry.
+            event_config_entry_id = data.get("config_entry_id")
+            if event_config_entry_id != self.lock_config_entry_id:
+                _LOGGER.debug(
+                    "[AkuvoxProvider] Ignoring event for config_entry_id %s (ours is %s)",
+                    event_config_entry_id,
+                    self.lock_config_entry_id,
+                )
+                return
+
+            event_type: str = data.get("event_type", "")
+            raw_payload = data.get("payload")
+            payload: dict[str, Any] = raw_payload if isinstance(raw_payload, dict) else {}
+
+            code_slot_num = 0
+            event_label = "Unknown Lock Event"
+            action_code: int | None = None
+
+            if event_type == "valid_code_entered":
+                event_label = "Unlocked via Keypad"
+                # Resolve the code slot from the user name tag.
+                username = payload.get("username", "")
+                if username:
+                    slot_num, _ = _parse_tag(username)
+                    if slot_num is not None:
+                        code_slot_num = slot_num
+                action_code = 1
+
+            elif event_type == "invalid_code_entered":
+                event_label = "Invalid Code Entered"
+                action_code = 2
+
+            elif event_type in ("relay_a_triggered", "relay_b_triggered"):
+                event_label = "Unlocked"
+                action_code = 3
+
+            elif event_type in ("relay_a_closed", "relay_b_closed"):
+                event_label = "Locked"
+                action_code = 4
+
+            elif event_type in ("input_a_triggered", "input_b_triggered"):
+                event_label = "Input Triggered"
+                action_code = 5
+
+            elif event_type in ("input_a_closed", "input_b_closed"):
+                event_label = "Input Closed"
+                action_code = 6
+
+            else:
+                event_label = f"Unknown: {event_type}"
+
+            _LOGGER.debug(
+                "[AkuvoxProvider] Dispatching event: type=%s, slot=%d, label=%s, action_code=%s",
+                event_type,
+                code_slot_num,
+                event_label,
+                action_code,
+            )
+            self.hass.async_create_task(callback(code_slot_num, event_label, action_code))
+
+        unsub = self.hass.bus.async_listen(
+            AKUVOX_WEBHOOK_EVENT,
+            functools.partial(handle_akuvox_webhook),
+        )
+        unsub_list.append(unsub)
+        self._listeners.append(unsub)
+
+        def unsubscribe_all() -> None:
+            """Unsubscribe from all event sources."""
+            for unsub_fn in unsub_list:
+                unsub_fn()
+
+        return unsubscribe_all
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _async_list_users(self) -> list[dict[str, Any]]:
+        """Call ``local_akuvox.list_users`` and return the user list.
+
+        Returns a list of user dicts with keys: id, name, user_id,
+        private_pin, card_code, schedule_relay, lift_floor_num, etc.
+        """
+        try:
+            response = await self.hass.services.async_call(
+                AKUVOX_DOMAIN,
+                "list_users",
+                target={"entity_id": self.lock_entity_id},
+                blocking=True,
+                return_response=True,
+            )
+        except HomeAssistantError as err:
+            _LOGGER.error(
+                "[AkuvoxProvider] Failed to list users: %s: %s",
+                err.__class__.__qualname__,
+                err,
+            )
+            return []
+
+        if not isinstance(response, dict):
+            return []
+
+        # Platform entity services wrap the response per entity_id.
+        entity_response = response.get(self.lock_entity_id, response)
+        if isinstance(entity_response, dict):
+            return entity_response.get("users", [])
+        return []
+
+    async def _async_add_user(self, name: str, pin: str) -> None:
+        """Add a new user with the given name and PIN."""
+        await self.hass.services.async_call(
+            AKUVOX_DOMAIN,
+            "add_user",
+            service_data={
+                "name": name,
+                "private_pin": pin,
+                "schedules": _DEFAULT_SCHEDULE_IDS,
+                "lift_floor_num": _DEFAULT_LIFT_FLOOR_NUM,
+            },
+            target={"entity_id": self.lock_entity_id},
+            blocking=True,
+        )
+
+    async def _async_modify_user(
+        self,
+        device_user_id: str,
+        *,
+        name: str | None = None,
+        pin: str | None = None,
+    ) -> None:
+        """Modify an existing user."""
+        service_data: dict[str, Any] = {"id": device_user_id}
+        if name is not None:
+            service_data["name"] = name
+        if pin is not None:
+            service_data["private_pin"] = pin
+        await self.hass.services.async_call(
+            AKUVOX_DOMAIN,
+            "modify_user",
+            service_data=service_data,
+            target={"entity_id": self.lock_entity_id},
+            blocking=True,
+        )
+
+    async def _async_delete_user(self, device_user_id: str) -> None:
+        """Delete a user by their device-internal ID."""
+        await self.hass.services.async_call(
+            AKUVOX_DOMAIN,
+            "delete_user",
+            service_data={"id": device_user_id},
+            target={"entity_id": self.lock_entity_id},
+            blocking=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Code slot operations
+    # ------------------------------------------------------------------
+
+    async def async_get_usercodes(self) -> list[CodeSlot]:
+        """Get all user codes from the Akuvox lock.
+
+        Users already bearing a ``[KM:<slot>]`` tag in their name are
+        mapped to the embedded slot number.  Untagged users that have a
+        PIN are assigned to the next available slot and their names are
+        updated on the device to include the tag (via ``modify_user``).
+
+        Only codes whose slot numbers fall within the configured managed
+        range are returned.
+        """
+        users = await self._async_list_users()
+        if not users:
+            return []
+
+        slot_start: int = self.keymaster_config_entry.data.get(CONF_START, 1)
+        slot_count: int = self.keymaster_config_entry.data.get(CONF_SLOTS, 0)
+        managed_range = set(range(slot_start, slot_start + slot_count))
+
+        result: list[CodeSlot] = []
+        assigned_slots: set[int] = set()
+
+        # (device_id, pin, slot, friendly_name)
+        tagged: list[tuple[str, str, int, str]] = []
+        # (device_id, pin, original_name)
+        untagged: list[tuple[str, str, str]] = []
+
+        for user in users:
+            # Skip cloud-provisioned users — we can only manage local ones.
+            if str(user.get("source_type", "")) != _LOCAL_SOURCE_TYPE:
+                continue
+            name = user.get("name", "")
+            pin = user.get("private_pin", "")
+            device_id = str(user.get("id", ""))
+            slot_num, friendly_name = _parse_tag(name)
+            if slot_num is not None:
+                tagged.append((device_id, pin, slot_num, friendly_name))
+                assigned_slots.add(slot_num)
+            elif pin:
+                # Only track untagged users that have a PIN set.
+                untagged.append((device_id, pin, name))
+
+        # Emit already-tagged codes that fall within the managed range.
+        for _device_id, pin, slot_num, friendly_name in tagged:
+            if slot_num not in managed_range:
+                _LOGGER.debug(
+                    "[AkuvoxProvider] Ignoring tagged user slot %d: outside managed range %d-%d",
+                    slot_num,
+                    slot_start,
+                    slot_start + slot_count - 1,
+                )
+                continue
+            result.append(
+                CodeSlot(
+                    slot_num=slot_num,
+                    code=pin or None,
+                    in_use=bool(pin),
+                    name=friendly_name,
+                )
+            )
+
+        # Assign virtual slots to untagged users and tag them on the device.
+        next_slot = slot_start
+        for device_id, pin, original_name in untagged:
+            while next_slot in assigned_slots and next_slot in managed_range:
+                next_slot += 1
+            if next_slot not in managed_range:
+                _LOGGER.debug(
+                    "[AkuvoxProvider] No managed slot available for untagged user '%s'; "
+                    "leaving untouched",
+                    original_name,
+                )
+                continue
+            slot_num = next_slot
+            assigned_slots.add(slot_num)
+            next_slot += 1
+
+            tagged_name = _make_tagged_name(slot_num, original_name)
+            try:
+                await self._async_modify_user(device_id, name=tagged_name)
+                _LOGGER.debug(
+                    "[AkuvoxProvider] Tagged user '%s' (id=%s) as slot %d: '%s'",
+                    original_name,
+                    device_id,
+                    slot_num,
+                    tagged_name,
+                )
+            except HomeAssistantError as err:
+                _LOGGER.error(
+                    "[AkuvoxProvider] Failed to tag user '%s' for slot %d: %s: %s",
+                    original_name,
+                    slot_num,
+                    err.__class__.__qualname__,
+                    err,
+                )
+
+            result.append(
+                CodeSlot(
+                    slot_num=slot_num,
+                    code=pin or None,
+                    in_use=bool(pin),
+                    name=original_name,
+                )
+            )
+
+        return result
+
+    async def async_get_usercode(self, slot_num: int) -> CodeSlot | None:
+        """Get a specific user code from the lock."""
+        users = await self._async_list_users()
+        for user in users:
+            if str(user.get("source_type", "")) != _LOCAL_SOURCE_TYPE:
+                continue
+            name = user.get("name", "")
+            parsed_slot, friendly_name = _parse_tag(name)
+            if parsed_slot == slot_num:
+                pin = user.get("private_pin", "")
+                return CodeSlot(
+                    slot_num=slot_num,
+                    code=pin or None,
+                    in_use=bool(pin),
+                    name=friendly_name,
+                )
+        return None
+
+    async def async_set_usercode(self, slot_num: int, code: str, name: str | None = None) -> bool:
+        """Set user code on a virtual slot.
+
+        If a user already exists for the given slot, the PIN (and
+        optionally the name) is updated via ``modify_user``.  Otherwise
+        a new user is created via ``add_user``.
+        """
+        users = await self._async_list_users()
+
+        existing_device_id: str | None = None
+        existing_friendly_name: str | None = None
+        for user in users:
+            if str(user.get("source_type", "")) != _LOCAL_SOURCE_TYPE:
+                continue
+            user_name = user.get("name", "")
+            parsed_slot, friendly = _parse_tag(user_name)
+            if parsed_slot == slot_num:
+                existing_device_id = str(user.get("id", ""))
+                existing_friendly_name = friendly
+                break
+
+        effective_name = name or existing_friendly_name
+        tagged_name = _make_tagged_name(slot_num, effective_name)
+
+        try:
+            if existing_device_id:
+                await self._async_modify_user(existing_device_id, name=tagged_name, pin=code)
+            else:
+                await self._async_add_user(tagged_name, code)
+        except HomeAssistantError as err:
+            _LOGGER.error(
+                "[AkuvoxProvider] Failed to set usercode on slot %s: %s: %s",
+                slot_num,
+                err.__class__.__qualname__,
+                err,
+            )
+            return False
+
+        _LOGGER.debug("[AkuvoxProvider] Set usercode on slot %s", slot_num)
+        return True
+
+    async def async_clear_usercode(self, slot_num: int) -> bool:
+        """Clear user code from a virtual slot.
+
+        Deletes the user from the device entirely.
+        """
+        users = await self._async_list_users()
+        target_device_id: str | None = None
+        for user in users:
+            if str(user.get("source_type", "")) != _LOCAL_SOURCE_TYPE:
+                continue
+            parsed_slot, _ = _parse_tag(user.get("name", ""))
+            if parsed_slot == slot_num:
+                target_device_id = str(user.get("id", ""))
+                break
+
+        if not target_device_id:
+            _LOGGER.debug(
+                "[AkuvoxProvider] No user found for slot %s, already clear",
+                slot_num,
+            )
+            return True
+
+        try:
+            await self._async_delete_user(target_device_id)
+        except HomeAssistantError as err:
+            _LOGGER.error(
+                "[AkuvoxProvider] Failed to clear usercode from slot %s: %s: %s",
+                slot_num,
+                err.__class__.__qualname__,
+                err,
+            )
+            return False
+
+        _LOGGER.debug("[AkuvoxProvider] Cleared usercode from slot %s", slot_num)
+        return True
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
+    def get_platform_data(self) -> dict[str, Any]:
+        """Get Akuvox-specific diagnostic data."""
+        data = super().get_platform_data()
+        data.update(
+            {
+                "akuvox_device_id": self._akuvox_device_id,
+                "lock_config_entry_id": self.lock_config_entry_id,
+            }
+        )
+        return data

--- a/tests/providers/test_akuvox.py
+++ b/tests/providers/test_akuvox.py
@@ -1,0 +1,1039 @@
+"""Tests for the Local Akuvox lock provider."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from custom_components.keymaster.providers.akuvox import (
+    AKUVOX_DOMAIN,
+    AKUVOX_WEBHOOK_EVENT,
+    AkuvoxLockProvider,
+    _make_tagged_name,
+    _parse_tag,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.bus = MagicMock()
+    hass.bus.async_listen = MagicMock(return_value=MagicMock())
+    hass.async_create_task = MagicMock()
+    return hass
+
+
+@pytest.fixture
+def mock_entity_registry():
+    """Create a mock entity registry."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_device_registry():
+    """Create a mock device registry."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_config_entry():
+    """Create a mock keymaster config entry."""
+    entry = MagicMock()
+    entry.entry_id = "keymaster_test_entry"
+    entry.data = {"start_from": 1, "slots": 6}
+    return entry
+
+
+@pytest.fixture
+def provider(mock_hass, mock_entity_registry, mock_device_registry, mock_config_entry):
+    """Create an AkuvoxLockProvider instance."""
+    return AkuvoxLockProvider(
+        hass=mock_hass,
+        lock_entity_id="lock.akuvox_relay_a",
+        keymaster_config_entry=mock_config_entry,
+        device_registry=mock_device_registry,
+        entity_registry=mock_entity_registry,
+    )
+
+
+def _make_user(
+    device_id: str,
+    name: str,
+    private_pin: str = "",
+    source_type: str = "1",
+) -> dict:
+    """Create a user dict matching list_users response format."""
+    return {
+        "id": device_id,
+        "name": name,
+        "private_pin": private_pin,
+        "source_type": source_type,
+        "user_id": f"uid_{device_id}",
+        "card_code": "",
+        "schedule_relay": "1001-1",
+        "lift_floor_num": "1",
+        "web_relay": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestHelperFunctions:
+    """Tests for module-level helpers."""
+
+    def test_make_tagged_name_with_name(self):
+        """Test tagged name with friendly name."""
+        assert _make_tagged_name(1, "Guest") == "[KM:1] Guest"
+
+    def test_make_tagged_name_without_name(self):
+        """Test tagged name defaults to 'Code Slot N'."""
+        assert _make_tagged_name(5) == "[KM:5] Code Slot 5"
+
+    def test_make_tagged_name_none_name(self):
+        """Test tagged name with explicit None."""
+        assert _make_tagged_name(3, None) == "[KM:3] Code Slot 3"
+
+    def test_parse_tag_valid(self):
+        """Test parsing a valid tag."""
+        assert _parse_tag("[KM:1] Guest") == (1, "Guest")
+
+    def test_parse_tag_large_slot(self):
+        """Test parsing a large slot number."""
+        assert _parse_tag("[KM:99] Family") == (99, "Family")
+
+    def test_parse_tag_no_tag(self):
+        """Test parsing name without a tag."""
+        assert _parse_tag("Guest Code") == (None, "Guest Code")
+
+    def test_parse_tag_empty_string(self):
+        """Test parsing an empty string."""
+        assert _parse_tag("") == (None, "")
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+class TestProperties:
+    """Tests for provider properties."""
+
+    def test_domain(self, provider):
+        """Test domain property."""
+        assert provider.domain == "local_akuvox"
+
+    def test_supports_connection_status(self, provider):
+        """Test supports_connection_status property."""
+        assert provider.supports_connection_status is True
+
+    def test_supports_push_updates(self, provider):
+        """Test supports_push_updates property."""
+        assert provider.supports_push_updates is True
+
+
+# ---------------------------------------------------------------------------
+# async_connect
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncConnect:
+    """Tests for async_connect."""
+
+    async def test_connect_success(self, provider):
+        """Test successful connection to lock."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "akuvox_entry_1"
+        lock_entry.device_id = "device_1"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        akuvox_entry = MagicMock()
+        provider.hass.config_entries.async_get_entry.return_value = akuvox_entry
+
+        provider.hass.data = {AKUVOX_DOMAIN: {"akuvox_entry_1": MagicMock()}}
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {(AKUVOX_DOMAIN, "aabbccddee")}
+        provider.device_registry.async_get.return_value = device_entry
+
+        result = await provider.async_connect()
+        assert result is True
+        assert provider._connected is True
+        assert provider._akuvox_device_id == "aabbccddee"
+        assert provider.lock_config_entry_id == "akuvox_entry_1"
+
+    async def test_connect_lock_not_in_entity_registry(self, provider):
+        """Test connect fails when lock entity not found."""
+        provider.entity_registry.async_get.return_value = None
+
+        result = await provider.async_connect()
+        assert result is False
+        assert provider._connected is False
+
+    async def test_connect_lock_no_config_entry(self, provider):
+        """Test connect fails when lock has no config entry."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = None
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        result = await provider.async_connect()
+        assert result is False
+
+    async def test_connect_akuvox_config_entry_not_found(self, provider):
+        """Test connect fails when akuvox config entry doesn't exist."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "akuvox_entry_1"
+        provider.entity_registry.async_get.return_value = lock_entry
+        provider.hass.config_entries.async_get_entry.return_value = None
+
+        result = await provider.async_connect()
+        assert result is False
+
+    async def test_connect_runtime_data_missing(self, provider):
+        """Test connect fails when coordinator not in hass.data."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "akuvox_entry_1"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        akuvox_entry = MagicMock()
+        provider.hass.config_entries.async_get_entry.return_value = akuvox_entry
+
+        provider.hass.data = {}
+
+        result = await provider.async_connect()
+        assert result is False
+
+    async def test_connect_no_device_entry(self, provider):
+        """Test connect fails when device not in registry."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "akuvox_entry_1"
+        lock_entry.device_id = "device_1"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        akuvox_entry = MagicMock()
+        provider.hass.config_entries.async_get_entry.return_value = akuvox_entry
+
+        provider.hass.data = {AKUVOX_DOMAIN: {"akuvox_entry_1": MagicMock()}}
+        provider.device_registry.async_get.return_value = None
+
+        result = await provider.async_connect()
+        assert result is False
+
+    async def test_connect_no_device_id_on_lock(self, provider):
+        """Test connect fails when lock entity has no device_id."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "akuvox_entry_1"
+        lock_entry.device_id = None
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        akuvox_entry = MagicMock()
+        provider.hass.config_entries.async_get_entry.return_value = akuvox_entry
+
+        provider.hass.data = {AKUVOX_DOMAIN: {"akuvox_entry_1": MagicMock()}}
+
+        result = await provider.async_connect()
+        assert result is False
+
+    async def test_connect_no_akuvox_identifier(self, provider):
+        """Test connect fails when device has no local_akuvox identifier."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "akuvox_entry_1"
+        lock_entry.device_id = "device_1"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        akuvox_entry = MagicMock()
+        provider.hass.config_entries.async_get_entry.return_value = akuvox_entry
+
+        provider.hass.data = {AKUVOX_DOMAIN: {"akuvox_entry_1": MagicMock()}}
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {("other_domain", "some_id")}
+        provider.device_registry.async_get.return_value = device_entry
+
+        result = await provider.async_connect()
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# async_is_connected
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncIsConnected:
+    """Tests for async_is_connected."""
+
+    async def test_connected_when_all_checks_pass(self, provider):
+        """Test is_connected returns True when everything is valid."""
+        provider._akuvox_device_id = "aabbccddee"
+        provider.lock_config_entry_id = "akuvox_entry_1"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "akuvox_entry_1"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        provider.hass.config_entries.async_get_entry.return_value = MagicMock()
+        provider.hass.data = {AKUVOX_DOMAIN: {"akuvox_entry_1": MagicMock()}}
+
+        result = await provider.async_is_connected()
+        assert result is True
+        assert provider._connected is True
+
+    async def test_not_connected_no_device_id(self, provider):
+        """Test is_connected returns False when no akuvox_device_id."""
+        provider._akuvox_device_id = None
+
+        result = await provider.async_is_connected()
+        assert result is False
+
+    async def test_not_connected_no_lock_entry(self, provider):
+        """Test is_connected returns False when lock not in registry."""
+        provider._akuvox_device_id = "aabbccddee"
+        provider.entity_registry.async_get.return_value = None
+
+        result = await provider.async_is_connected()
+        assert result is False
+
+    async def test_not_connected_no_config_entry(self, provider):
+        """Test is_connected returns False when config entry missing."""
+        provider._akuvox_device_id = "aabbccddee"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "akuvox_entry_1"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        provider.hass.config_entries.async_get_entry.return_value = None
+
+        result = await provider.async_is_connected()
+        assert result is False
+
+    async def test_not_connected_coordinator_missing(self, provider):
+        """Test is_connected returns False when coordinator not in hass.data."""
+        provider._akuvox_device_id = "aabbccddee"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "akuvox_entry_1"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        provider.hass.config_entries.async_get_entry.return_value = MagicMock()
+        provider.hass.data = {}
+
+        result = await provider.async_is_connected()
+        assert result is False
+
+    async def test_syncs_stale_config_entry_id(self, provider):
+        """Test is_connected syncs lock_config_entry_id from entity registry."""
+        provider._akuvox_device_id = "aabbccddee"
+        provider.lock_config_entry_id = "old_entry_id"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "new_entry_id"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        provider.hass.config_entries.async_get_entry.return_value = MagicMock()
+        provider.hass.data = {AKUVOX_DOMAIN: {"new_entry_id": MagicMock()}}
+
+        result = await provider.async_is_connected()
+        assert result is True
+        assert provider.lock_config_entry_id == "new_entry_id"
+
+
+# ---------------------------------------------------------------------------
+# async_get_usercodes
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncGetUsercodes:
+    """Tests for async_get_usercodes."""
+
+    async def test_returns_tagged_codes(self, provider):
+        """Test tagged users are returned with correct slot numbers."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user("10", "[KM:1] Guest", "1234"),
+                    _make_user("11", "[KM:2] Family", "5678"),
+                ]
+            }
+        }
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 2
+        assert result[0].slot_num == 1
+        assert result[0].code == "1234"
+        assert result[0].name == "Guest"
+        assert result[1].slot_num == 2
+        assert result[1].code == "5678"
+        assert result[1].name == "Family"
+
+    async def test_empty_users(self, provider):
+        """Test returns empty list when no users."""
+        provider.hass.services.async_call.return_value = {"lock.akuvox_relay_a": {"users": []}}
+        result = await provider.async_get_usercodes()
+        assert result == []
+
+    async def test_service_error_returns_empty(self, provider):
+        """Test returns empty list on service error."""
+        provider.hass.services.async_call.side_effect = HomeAssistantError("boom")
+        result = await provider.async_get_usercodes()
+        assert result == []
+
+    async def test_non_dict_response(self, provider):
+        """Test returns empty list on non-dict response."""
+        provider.hass.services.async_call.return_value = None
+        result = await provider.async_get_usercodes()
+        assert result == []
+
+    async def test_non_dict_entity_response(self, provider):
+        """Test returns empty list when per-entity response is not a dict."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": "unexpected_string"
+        }
+        result = await provider.async_get_usercodes()
+        assert result == []
+
+    async def test_tags_untagged_users_via_modify(self, provider):
+        """Test untagged users with PINs get tagged via modify_user."""
+        provider.hass.services.async_call.side_effect = [
+            # list_users response
+            {
+                "lock.akuvox_relay_a": {
+                    "users": [
+                        _make_user("10", "Front Door Guest", "1234"),
+                    ]
+                }
+            },
+            # modify_user call (tagging)
+            None,
+        ]
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 1
+        assert result[0].slot_num == 1
+        assert result[0].code == "1234"
+        assert result[0].name == "Front Door Guest"
+
+        # Verify modify_user was called with the tagged name
+        modify_call = provider.hass.services.async_call.call_args_list[1]
+        assert modify_call == call(
+            AKUVOX_DOMAIN,
+            "modify_user",
+            service_data={"id": "10", "name": "[KM:1] Front Door Guest"},
+            target={"entity_id": "lock.akuvox_relay_a"},
+            blocking=True,
+        )
+
+    async def test_untagged_users_without_pin_ignored(self, provider):
+        """Test untagged users without a PIN are not assigned slots."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user("10", "No PIN User", ""),
+                ]
+            }
+        }
+
+        result = await provider.async_get_usercodes()
+        assert result == []
+
+    async def test_cloud_users_filtered_out(self, provider):
+        """Test cloud-provisioned users are excluded."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user("10", "[KM:1] Local", "1234", source_type="1"),
+                    _make_user("20", "[KM:2] Cloud", "5678", source_type="2"),
+                ]
+            }
+        }
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 1
+        assert result[0].slot_num == 1
+        assert result[0].name == "Local"
+
+    async def test_tagged_outside_managed_range_ignored(self, provider):
+        """Test tagged users outside managed range are excluded."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user("10", "[KM:1] InRange", "1234"),
+                    _make_user("11", "[KM:99] OutOfRange", "5678"),
+                ]
+            }
+        }
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 1
+        assert result[0].slot_num == 1
+
+    async def test_untagged_no_available_slot(self, provider):
+        """Test untagged users are skipped when no slots available."""
+        # Config: slots 1-6, fill all 6 tagged
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user(str(i), f"[KM:{i}] User{i}", f"{1000 + i}") for i in range(1, 7)
+                ]
+                + [_make_user("99", "Overflow", "9999")]
+            }
+        }
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 6
+
+    async def test_tagging_failure_still_returns_code(self, provider):
+        """Test that tagging failure doesn't prevent code from being returned."""
+        provider.hass.services.async_call.side_effect = [
+            # list_users
+            {"lock.akuvox_relay_a": {"users": [_make_user("10", "FailTag", "1234")]}},
+            # modify_user raises
+            HomeAssistantError("modify failed"),
+        ]
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 1
+        assert result[0].slot_num == 1
+        assert result[0].code == "1234"
+
+    async def test_mixed_tagged_and_untagged(self, provider):
+        """Test mixed tagged/untagged users are handled correctly."""
+        provider.hass.services.async_call.side_effect = [
+            # list_users
+            {
+                "lock.akuvox_relay_a": {
+                    "users": [
+                        _make_user("10", "[KM:2] Existing", "1111"),
+                        _make_user("11", "New User", "2222"),
+                    ]
+                }
+            },
+            # modify_user for tagging (slot 1, since 2 is taken)
+            None,
+        ]
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 2
+        slots = {r.slot_num for r in result}
+        assert slots == {1, 2}
+
+    async def test_response_unwrap_without_entity_key(self, provider):
+        """Test response handling when not wrapped in entity key."""
+        provider.hass.services.async_call.return_value = {
+            "users": [_make_user("10", "[KM:1] Direct", "1234")]
+        }
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 1
+        assert result[0].name == "Direct"
+
+
+# ---------------------------------------------------------------------------
+# async_get_usercode
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncGetUsercode:
+    """Tests for async_get_usercode."""
+
+    async def test_get_existing_code(self, provider):
+        """Test getting an existing tagged code."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user("10", "[KM:3] Guest", "1234"),
+                ]
+            }
+        }
+
+        result = await provider.async_get_usercode(3)
+        assert result is not None
+        assert result.slot_num == 3
+        assert result.code == "1234"
+        assert result.name == "Guest"
+        assert result.in_use is True
+
+    async def test_get_nonexistent_code(self, provider):
+        """Test getting a code for an unused slot."""
+        provider.hass.services.async_call.return_value = {"lock.akuvox_relay_a": {"users": []}}
+
+        result = await provider.async_get_usercode(5)
+        assert result is None
+
+    async def test_get_code_skips_cloud_users(self, provider):
+        """Test that cloud users are skipped when looking up a code."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user("10", "[KM:1] Cloud", "1234", source_type="2"),
+                ]
+            }
+        }
+
+        result = await provider.async_get_usercode(1)
+        assert result is None
+
+    async def test_get_code_empty_pin(self, provider):
+        """Test getting a code with no PIN set."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user("10", "[KM:1] NoPIN", ""),
+                ]
+            }
+        }
+
+        result = await provider.async_get_usercode(1)
+        assert result is not None
+        assert result.code is None
+        assert result.in_use is False
+
+
+# ---------------------------------------------------------------------------
+# async_set_usercode
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncSetUsercode:
+    """Tests for async_set_usercode."""
+
+    async def test_set_new_code(self, provider):
+        """Test setting a code on an empty slot creates a new user."""
+        provider.hass.services.async_call.side_effect = [
+            # list_users: no existing user for slot 1
+            {"lock.akuvox_relay_a": {"users": []}},
+            # add_user
+            None,
+        ]
+
+        result = await provider.async_set_usercode(1, "1234", "Guest")
+        assert result is True
+
+        add_call = provider.hass.services.async_call.call_args_list[1]
+        assert add_call == call(
+            AKUVOX_DOMAIN,
+            "add_user",
+            service_data={
+                "name": "[KM:1] Guest",
+                "private_pin": "1234",
+                "schedules": "1001",
+                "lift_floor_num": "1",
+            },
+            target={"entity_id": "lock.akuvox_relay_a"},
+            blocking=True,
+        )
+
+    async def test_update_existing_code(self, provider):
+        """Test updating an existing user's code."""
+        provider.hass.services.async_call.side_effect = [
+            # list_users: existing user for slot 1
+            {"lock.akuvox_relay_a": {"users": [_make_user("10", "[KM:1] Guest", "1234")]}},
+            # modify_user
+            None,
+        ]
+
+        result = await provider.async_set_usercode(1, "5678")
+        assert result is True
+
+        modify_call = provider.hass.services.async_call.call_args_list[1]
+        assert modify_call == call(
+            AKUVOX_DOMAIN,
+            "modify_user",
+            service_data={
+                "id": "10",
+                "name": "[KM:1] Guest",
+                "private_pin": "5678",
+            },
+            target={"entity_id": "lock.akuvox_relay_a"},
+            blocking=True,
+        )
+
+    async def test_update_existing_with_new_name(self, provider):
+        """Test updating both name and code on existing user."""
+        provider.hass.services.async_call.side_effect = [
+            {"lock.akuvox_relay_a": {"users": [_make_user("10", "[KM:1] OldName", "1234")]}},
+            None,
+        ]
+
+        result = await provider.async_set_usercode(1, "5678", "NewName")
+        assert result is True
+
+        modify_call = provider.hass.services.async_call.call_args_list[1]
+        assert modify_call[1]["service_data"]["name"] == "[KM:1] NewName"
+
+    async def test_set_code_service_error(self, provider):
+        """Test set_usercode returns False on service error."""
+        provider.hass.services.async_call.side_effect = [
+            {"lock.akuvox_relay_a": {"users": []}},
+            HomeAssistantError("add failed"),
+        ]
+
+        result = await provider.async_set_usercode(1, "1234")
+        assert result is False
+
+    async def test_set_code_skips_cloud_users(self, provider):
+        """Test set_usercode ignores cloud users when searching."""
+        provider.hass.services.async_call.side_effect = [
+            {
+                "lock.akuvox_relay_a": {
+                    "users": [
+                        _make_user("10", "[KM:1] Cloud", "1234", source_type="2"),
+                    ]
+                }
+            },
+            # add_user (creates new since cloud user was skipped)
+            None,
+        ]
+
+        result = await provider.async_set_usercode(1, "5678", "Local")
+        assert result is True
+
+        add_call = provider.hass.services.async_call.call_args_list[1]
+        assert add_call[0][1] == "add_user"
+
+
+# ---------------------------------------------------------------------------
+# async_clear_usercode
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncClearUsercode:
+    """Tests for async_clear_usercode."""
+
+    async def test_clear_existing_code(self, provider):
+        """Test clearing an existing user code deletes the user."""
+        provider.hass.services.async_call.side_effect = [
+            {"lock.akuvox_relay_a": {"users": [_make_user("10", "[KM:1] Guest", "1234")]}},
+            # delete_user
+            None,
+        ]
+
+        result = await provider.async_clear_usercode(1)
+        assert result is True
+
+        delete_call = provider.hass.services.async_call.call_args_list[1]
+        assert delete_call == call(
+            AKUVOX_DOMAIN,
+            "delete_user",
+            service_data={"id": "10"},
+            target={"entity_id": "lock.akuvox_relay_a"},
+            blocking=True,
+        )
+
+    async def test_clear_nonexistent_code(self, provider):
+        """Test clearing a code that doesn't exist returns True."""
+        provider.hass.services.async_call.return_value = {"lock.akuvox_relay_a": {"users": []}}
+
+        result = await provider.async_clear_usercode(5)
+        assert result is True
+
+    async def test_clear_code_service_error(self, provider):
+        """Test clear_usercode returns False on service error."""
+        provider.hass.services.async_call.side_effect = [
+            {"lock.akuvox_relay_a": {"users": [_make_user("10", "[KM:1] Guest", "1234")]}},
+            HomeAssistantError("delete failed"),
+        ]
+
+        result = await provider.async_clear_usercode(1)
+        assert result is False
+
+    async def test_clear_skips_cloud_users(self, provider):
+        """Test clear_usercode ignores cloud users."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user("10", "[KM:1] Cloud", "1234", source_type="2"),
+                ]
+            }
+        }
+
+        result = await provider.async_clear_usercode(1)
+        assert result is True
+        # Only list_users was called, no delete_user
+        assert provider.hass.services.async_call.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# subscribe_lock_events
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribeLockEvents:
+    """Tests for subscribe_lock_events."""
+
+    def test_subscribe_registers_listener(self, provider):
+        """Test that subscribing registers an event bus listener."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        kmlock = MagicMock()
+        callback = AsyncMock()
+
+        unsub = provider.subscribe_lock_events(kmlock, callback)
+
+        provider.hass.bus.async_listen.assert_called_once()
+        listen_args = provider.hass.bus.async_listen.call_args
+        assert listen_args[0][0] == AKUVOX_WEBHOOK_EVENT
+        assert callable(unsub)
+
+    def test_unsubscribe_calls_unsub(self, provider):
+        """Test that unsubscribe function calls the bus unsub."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        unsub_mock = MagicMock()
+        provider.hass.bus.async_listen.return_value = unsub_mock
+
+        kmlock = MagicMock()
+        callback = AsyncMock()
+
+        unsub = provider.subscribe_lock_events(kmlock, callback)
+        unsub()
+
+        unsub_mock.assert_called_once()
+
+    async def test_valid_code_entered_with_tagged_user(self, provider):
+        """Test valid_code_entered resolves slot from tagged username."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+
+        # Get the handler that was registered
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "akuvox_entry_1",
+            "event_type": "valid_code_entered",
+            "payload": {"username": "[KM:3] Guest"},
+        }
+
+        await handler(event)
+
+        # async_create_task is called with the callback coroutine
+        provider.hass.async_create_task.assert_called_once()
+        callback.assert_called_once_with(3, "Unlocked via Keypad", 1)
+
+    async def test_valid_code_entered_untagged_user(self, provider):
+        """Test valid_code_entered with untagged user has slot 0."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "akuvox_entry_1",
+            "event_type": "valid_code_entered",
+            "payload": {"username": "Untagged User"},
+        }
+
+        await handler(event)
+        callback.assert_called_once_with(0, "Unlocked via Keypad", 1)
+
+    async def test_invalid_code_entered(self, provider):
+        """Test invalid_code_entered event."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "akuvox_entry_1",
+            "event_type": "invalid_code_entered",
+            "payload": {},
+        }
+
+        await handler(event)
+        callback.assert_called_once_with(0, "Invalid Code Entered", 2)
+
+    async def test_relay_triggered(self, provider):
+        """Test relay_a_triggered event."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "akuvox_entry_1",
+            "event_type": "relay_a_triggered",
+            "payload": {},
+        }
+
+        await handler(event)
+        callback.assert_called_once_with(0, "Unlocked", 3)
+
+    async def test_relay_closed(self, provider):
+        """Test relay_b_closed event."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "akuvox_entry_1",
+            "event_type": "relay_b_closed",
+            "payload": {},
+        }
+
+        await handler(event)
+        callback.assert_called_once_with(0, "Locked", 4)
+
+    async def test_input_triggered(self, provider):
+        """Test input_a_triggered event."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "akuvox_entry_1",
+            "event_type": "input_a_triggered",
+            "payload": {},
+        }
+
+        await handler(event)
+        callback.assert_called_once_with(0, "Input Triggered", 5)
+
+    async def test_input_closed(self, provider):
+        """Test input_b_closed event."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "akuvox_entry_1",
+            "event_type": "input_b_closed",
+            "payload": {},
+        }
+
+        await handler(event)
+        callback.assert_called_once_with(0, "Input Closed", 6)
+
+    async def test_unknown_event_type(self, provider):
+        """Test unknown event type is labeled correctly."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "akuvox_entry_1",
+            "event_type": "some_new_event",
+            "payload": {},
+        }
+
+        await handler(event)
+        callback.assert_called_once_with(0, "Unknown: some_new_event", None)
+
+    async def test_event_ignored_for_different_config_entry(self, provider):
+        """Test events for a different config entry are ignored."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "some_other_entry",
+            "event_type": "valid_code_entered",
+            "payload": {"username": "[KM:1] Guest"},
+        }
+
+        await handler(event)
+        provider.hass.async_create_task.assert_not_called()
+
+    async def test_valid_code_no_username(self, provider):
+        """Test valid_code_entered with no username in payload."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "akuvox_entry_1",
+            "event_type": "valid_code_entered",
+            "payload": {},
+        }
+
+        await handler(event)
+        callback.assert_called_once_with(0, "Unlocked via Keypad", 1)
+
+    async def test_non_dict_payload_handled_gracefully(self, provider):
+        """Test event with non-dict payload doesn't raise."""
+        provider.lock_config_entry_id = "akuvox_entry_1"
+        callback = AsyncMock()
+        kmlock = MagicMock()
+
+        provider.subscribe_lock_events(kmlock, callback)
+        handler = provider.hass.bus.async_listen.call_args[0][1]
+
+        event = MagicMock()
+        event.data = {
+            "config_entry_id": "akuvox_entry_1",
+            "event_type": "valid_code_entered",
+            "payload": None,
+        }
+
+        await handler(event)
+        callback.assert_called_once_with(0, "Unlocked via Keypad", 1)
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlatformData:
+    """Tests for get_platform_data."""
+
+    def test_platform_data_includes_akuvox_fields(self, provider):
+        """Test platform data includes akuvox-specific fields."""
+        provider._akuvox_device_id = "aabbccddee"
+        provider.lock_config_entry_id = "akuvox_entry_1"
+
+        data = provider.get_platform_data()
+        assert data["akuvox_device_id"] == "aabbccddee"
+        assert data["lock_config_entry_id"] == "akuvox_entry_1"
+        assert data["domain"] == "local_akuvox"
+        assert data["lock_entity_id"] == "lock.akuvox_relay_a"
+
+    def test_platform_data_none_values(self, provider):
+        """Test platform data with None device_id."""
+        data = provider.get_platform_data()
+        assert data["akuvox_device_id"] is None
+        assert data["lock_config_entry_id"] is None

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,10 +1,14 @@
 """Test keymaster binary sensors."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from zwave_js_server.event import Event
 
-from custom_components.keymaster.const import DOMAIN
+from custom_components.keymaster.binary_sensor import async_setup_entry
+from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
+from custom_components.keymaster.lock import KeymasterLock
 from homeassistant.components.lock.const import LockState
 from homeassistant.config_entries import ConfigEntryState
 
@@ -12,6 +16,106 @@ from .const import CONFIG_DATA_910
 
 NETWORK_READY_ENTITY = "binary_sensor.frontdoor_network"
 KWIKSET_910_LOCK_ENTITY = "lock.garage_door"
+
+
+async def test_setup_entry_creates_connection_sensor_when_provider_none(hass):
+    """Test that connection sensor is created even when provider is None.
+
+    During startup, HA may set up config entries concurrently. The second
+    entry's binary_sensor platform can run before the provider is created
+    by the first entry's async_refresh. The connection sensor should still
+    be created (it will be unavailable until the provider connects).
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_lock",
+        data={**CONFIG_DATA_910, CONF_START: 1, CONF_SLOTS: 3},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_lock = MagicMock(spec=KeymasterLock)
+    mock_lock.provider = None
+    mock_lock.lock_name = "Test Lock"
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_lock_by_config_entry_id = AsyncMock(return_value=mock_lock)
+    mock_coordinator.sync_get_lock_by_config_entry_id = MagicMock(return_value=mock_lock)
+
+    hass.data.setdefault(DOMAIN, {})[COORDINATOR] = mock_coordinator
+
+    added_entities: list = []
+    await async_setup_entry(hass, config_entry, lambda entities, _: added_entities.extend(entities))
+
+    connection_sensors = [
+        e for e in added_entities if "binary_sensor.connected" in e.entity_description.key
+    ]
+    slot_sensors = [e for e in added_entities if "code_slots" in e.entity_description.key]
+    assert len(connection_sensors) == 1
+    assert len(slot_sensors) == 3
+
+
+async def test_setup_entry_creates_connection_sensor_when_provider_supports_it(hass):
+    """Test that connection sensor IS created when provider supports connection status."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_lock",
+        data={**CONFIG_DATA_910, CONF_START: 1, CONF_SLOTS: 2},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_provider = MagicMock()
+    mock_provider.supports_connection_status = True
+
+    mock_lock = MagicMock(spec=KeymasterLock)
+    mock_lock.provider = mock_provider
+    mock_lock.lock_name = "Test Lock"
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_lock_by_config_entry_id = AsyncMock(return_value=mock_lock)
+    mock_coordinator.sync_get_lock_by_config_entry_id = MagicMock(return_value=mock_lock)
+
+    hass.data.setdefault(DOMAIN, {})[COORDINATOR] = mock_coordinator
+
+    added_entities: list = []
+    await async_setup_entry(hass, config_entry, lambda entities, _: added_entities.extend(entities))
+
+    connection_sensors = [
+        e for e in added_entities if "binary_sensor.connected" in e.entity_description.key
+    ]
+    slot_sensors = [e for e in added_entities if "code_slots" in e.entity_description.key]
+    assert len(connection_sensors) == 1
+    assert len(slot_sensors) == 2
+
+
+async def test_setup_entry_no_connection_sensor_when_provider_unsupported(hass):
+    """Test that connection sensor is skipped when provider doesn't support it."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_lock",
+        data={**CONFIG_DATA_910, CONF_START: 1, CONF_SLOTS: 2},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_provider = MagicMock()
+    mock_provider.supports_connection_status = False
+
+    mock_lock = MagicMock(spec=KeymasterLock)
+    mock_lock.provider = mock_provider
+    mock_lock.lock_name = "Test Lock"
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.get_lock_by_config_entry_id = AsyncMock(return_value=mock_lock)
+    mock_coordinator.sync_get_lock_by_config_entry_id = MagicMock(return_value=mock_lock)
+
+    hass.data.setdefault(DOMAIN, {})[COORDINATOR] = mock_coordinator
+
+    added_entities: list = []
+    await async_setup_entry(hass, config_entry, lambda entities, _: added_entities.extend(entities))
+
+    connection_sensors = [
+        e for e in added_entities if "binary_sensor.connected" in e.entity_description.key
+    ]
+    assert len(connection_sensors) == 0
 
 
 async def test_zwavejs_network_ready(hass, client, lock_kwikset_910, integration, caplog):

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -109,6 +109,84 @@ async def test_handle_provider_lock_event_unknown_state(hass, mock_coordinator, 
     mock_coordinator._lock_unlocked.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_handle_provider_lock_event_label_overrides_stale_state(
+    hass, mock_coordinator, mock_lock
+):
+    """Test that event label is trusted over stale entity state.
+
+    Provider events (e.g., Akuvox webhooks) can arrive before entity state
+    updates. An "Unlocked via Keypad" event should trigger _lock_unlocked
+    even if the entity still shows "locked".
+    """
+    # Entity state is stale (still locked), but event says unlock happened
+    hass.states.async_set(mock_lock.lock_entity_id, LockState.LOCKED)
+
+    await mock_coordinator._handle_provider_lock_event(
+        kmlock=mock_lock,
+        code_slot_num=1,
+        event_label="Unlocked via Keypad",
+        action_code=1,
+    )
+
+    mock_coordinator._lock_unlocked.assert_called_once()
+    mock_coordinator._lock_locked.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_provider_lock_event_lock_label_overrides_stale_state(
+    hass, mock_coordinator, mock_lock
+):
+    """Test that a lock label is trusted over stale unlocked entity state."""
+    # Entity state is stale (still unlocked), but event says lock happened
+    hass.states.async_set(mock_lock.lock_entity_id, LockState.UNLOCKED)
+
+    await mock_coordinator._handle_provider_lock_event(
+        kmlock=mock_lock,
+        code_slot_num=0,
+        event_label="Locked",
+        action_code=4,
+    )
+
+    mock_coordinator._lock_locked.assert_called_once()
+    mock_coordinator._lock_unlocked.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_provider_lock_event_empty_label_falls_back_to_state(
+    hass, mock_coordinator, mock_lock
+):
+    """Test that empty event label falls back to entity state."""
+    hass.states.async_set(mock_lock.lock_entity_id, LockState.UNLOCKED)
+
+    await mock_coordinator._handle_provider_lock_event(
+        kmlock=mock_lock,
+        code_slot_num=0,
+        event_label="",
+        action_code=0,
+    )
+
+    mock_coordinator._lock_unlocked.assert_called_once()
+    mock_coordinator._lock_locked.assert_not_called()
+
+
+async def test_handle_provider_lock_event_jam_label_falls_back_to_state(
+    hass, mock_coordinator, mock_lock
+):
+    """Test that 'Lock Jammed' label falls back to entity state (not treated as lock)."""
+    hass.states.async_set(mock_lock.lock_entity_id, LockState.UNLOCKED)
+
+    await mock_coordinator._handle_provider_lock_event(
+        kmlock=mock_lock,
+        code_slot_num=0,
+        event_label="Lock Jammed",
+        action_code=0,
+    )
+
+    mock_coordinator._lock_unlocked.assert_called_once()
+    mock_coordinator._lock_locked.assert_not_called()
+
+
 @pytest.fixture
 def coordinator_for_unlock_test(hass):
     """Create a coordinator for testing _lock_unlocked method directly."""

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -76,6 +76,70 @@ async def test_add_lock_existing_no_update(mock_coordinator, mock_lock):
     mock_coordinator._update_lock.assert_not_called()
 
 
+async def test_add_lock_existing_creates_provider_when_none(hass, mock_coordinator, mock_lock):
+    """Test that add_lock creates provider when lock exists but provider is None.
+
+    This handles the race condition where HA sets up config entries concurrently:
+    the first entry's async_refresh may still be creating providers when the
+    second entry's add_lock runs. The provider must exist before platform setup.
+    """
+    mock_lock.provider = None
+    mock_lock.lock_entity_id = "lock.test"
+    mock_coordinator.kmlocks["test_entry"] = mock_lock
+    mock_coordinator._update_lock = AsyncMock()
+
+    mock_config_entry = MagicMock()
+    hass.config_entries.async_get_entry = MagicMock(return_value=mock_config_entry)
+
+    mock_provider = MagicMock()
+    with patch(
+        "custom_components.keymaster.coordinator.create_provider",
+        return_value=mock_provider,
+    ) as mock_create:
+        await mock_coordinator.add_lock(mock_lock, update=False)
+
+    mock_create.assert_called_once_with(
+        hass=hass,
+        lock_entity_id="lock.test",
+        keymaster_config_entry=mock_config_entry,
+    )
+    assert mock_coordinator.kmlocks["test_entry"].provider == mock_provider
+    mock_coordinator._update_lock.assert_not_called()
+
+
+async def test_add_lock_existing_skips_provider_when_already_set(hass, mock_coordinator, mock_lock):
+    """Test that add_lock does not recreate provider when it already exists."""
+    existing_provider = MagicMock()
+    mock_lock.provider = existing_provider
+    mock_coordinator.kmlocks["test_entry"] = mock_lock
+    mock_coordinator._update_lock = AsyncMock()
+
+    with patch(
+        "custom_components.keymaster.coordinator.create_provider",
+    ) as mock_create:
+        await mock_coordinator.add_lock(mock_lock, update=False)
+
+    mock_create.assert_not_called()
+    assert mock_coordinator.kmlocks["test_entry"].provider == existing_provider
+
+
+async def test_add_lock_existing_no_config_entry(hass, mock_coordinator, mock_lock):
+    """Test that add_lock handles missing config entry gracefully."""
+    mock_lock.provider = None
+    mock_coordinator.kmlocks["test_entry"] = mock_lock
+    mock_coordinator._update_lock = AsyncMock()
+
+    hass.config_entries.async_get_entry = MagicMock(return_value=None)
+
+    with patch(
+        "custom_components.keymaster.coordinator.create_provider",
+    ) as mock_create:
+        await mock_coordinator.add_lock(mock_lock, update=False)
+
+    mock_create.assert_not_called()
+    assert mock_coordinator.kmlocks["test_entry"].provider is None
+
+
 async def test_delete_lock(hass, mock_coordinator, mock_lock):
     """Test deleting a lock."""
     # Pre-populate


### PR DESCRIPTION
## Summary

Add Local Akuvox (`local_akuvox`) as a supported lock provider for keymaster, enabling code slot management and event handling for Akuvox door controllers.

## Changes

### Akuvox provider (`providers/akuvox.py`)
- Maps keymaster slots to Akuvox users via `[KM:<slot>]` name tags
- Handles webhook events: valid_code_entered, relay triggered/closed, input triggered/closed, invalid_code_entered
- CRUD operations for user codes via local_akuvox service calls
- Filters cloud-sourced users (source_type '2') from management
- Accesses Akuvox coordinator via `hass.data` (not `runtime_data`)

### Provider registration
- Added `AkuvoxLockProvider` to `PROVIDER_MAP` in `providers/__init__.py`
- Added `local_akuvox` to `after_dependencies` in `manifest.json`

### Coordinator event routing fix
- Fixed race condition where provider events arrive before entity state updates (e.g., Akuvox webhooks fire before lock entity shows unlocked)
- Event label semantics now take priority: 'unlock' in label → unlocked, 'lock' in label → locked, ambiguous labels fall back to entity state
- Compatible with existing Z-Wave labels (Manual Unlock, RF Lock, etc.)

### Binary sensor startup fix
- Replaced hard `assert` on `kmlock.provider` with graceful None check
- Added provider creation in `add_lock` 'already exists' path to ensure provider is available before platform setup during concurrent entry init
- Fixes `AssertionError` crash when HA sets up config entries concurrently

## Tests
- 48 tests for Akuvox provider (connect, codes, events, CRUD, diagnostics)
- 3 tests for event label inference (label overrides stale state, fallback)
- 3 tests for add_lock provider creation (None, already set, no config)
- 3 tests for binary sensor setup (provider None, supported, unsupported)
- All 456 tests pass, 83.27% coverage