### PR TITLE
CI: Update release-drafter for autolabeling

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+---
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
@@ -6,25 +7,96 @@ categories:
   - title: "💥 Breaking Change 💥"
     labels:
       - "breaking-change"
-  - title: "⚡ Enhancements ⚡"
-    labels:
-      - "enhancement"
   - title: "✨ New Features ✨"
     labels:
+      - "enhancement"
       - "feature"
   - title: "🐛 Bug Fixes 🐛"
     labels:
       - "fix"
       - "bugfix"
       - "bug"
+  - title: "⚡ Performance ⚡"
+    labels:
+      - "performance"
   - title: "🔧 Maintenance 🔧"
     labels:
       - "chore"
-      - "repo"
+      - "documentation"
       - "maintenance"
+      - "repo"
+      - "dependencies"
+      - "github_actions"
+      - "refactor"
+      - "style"
+      - "build"
+      - "revert"
   - title: "🎓 Code Quality 🎓"
     labels:
       - "code-quality"
+      - "CI"
+      - "test"
+autolabeler:
+  - label: "breaking-change"
+    title:
+      - '/^[a-z]+(\([^)]+\))?!:/i'
+  - label: "feature"
+    title:
+      - '/^feat(\([^)]+\))?:/i'
+  - label: "bugfix"
+    title:
+      - '/^fix(\([^)]+\))?:/i'
+  - label: "refactor"
+    title:
+      - '/^refactor(\([^)]+\))?:/i'
+  - label: "code-quality"
+    title:
+      - '/^test(\([^)]+\))?:/i'
+  - label: "CI"
+    title:
+      - '/^ci(\([^)]+\))?:/i'
+  - label: "chore"
+    title:
+      - '/^chore(\([^)]+\))?:/i'
+  - label: "documentation"
+    title:
+      - '/^docs(\([^)]+\))?:/i'
+  - label: "style"
+    title:
+      - '/^style(\([^)]+\))?:/i'
+  - label: "performance"
+    title:
+      - '/^perf(\([^)]+\))?:/i'
+  - label: "revert"
+    title:
+      - '/^revert(\([^)]+\))?:/i'
+  - label: "build"
+    title:
+      - '/^build(\([^)]+\))?:/i'
+version-resolver:
+  major:
+    labels:
+      - "breaking-change"
+  minor:
+    labels:
+      - "feature"
+      - "enhancement"
+  patch:
+    labels:
+      - "bug"
+      - "fix"
+      - "bugfix"
+      - "performance"
+      - "refactor"
+      - "style"
+      - "build"
+      - "chore"
+      - "documentation"
+      - "CI"
+      - "test"
+      - "code-quality"
+      - "revert"
+  default: patch
 # yamllint disable rule:line-length
 template: |
   [![Downloads for this release](https://img.shields.io/github/downloads/FutureTense/keymaster/v$RESOLVED_VERSION/total.svg)](https://github.com/FutureTense/keymaster/releases/v$RESOLVED_VERSION)

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,14 +1,76 @@
+---
 name: Release Drafter
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:
       - main
+  # pull_request is required for autolabeler
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  # pull_request_target is required for autolabeler on PRs from forks
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions: {}
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: ${{ github.event.pull_request.number && format('rd-{0}-pr-{1}', github.event_name, github.event.pull_request.number) || format('rd-push-{0}', github.ref) }}
+  cancel-in-progress: true
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    name: 'Update Release Draft'
+    # Run on pull_request_target for forks, or pull_request for same-repo PRs
+    # This prevents duplicate runs for same-repo PRs
+    # yamllint disable rule:line-length
+    if: >
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork) ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
+      github.event_name == 'push'
+    # yamllint enable rule:line-length
+    # SECURITY: pull_request_target with write permissions is safe here because:
+    # 1. This workflow does NOT checkout any code from the PR
+    # 2. The workflow code itself runs from the base branch (not the fork)
+    # 3. release-drafter only makes GitHub API calls (no code execution)
+    # 4. pull_request_target is needed ONLY for autolabeling fork PRs
+    permissions:
+      # write permission is required to create releases
+      contents: write
+      # write permission is required for autolabeler
+      pull-requests: write
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 3
     steps:
-      - uses: release-drafter/release-drafter@v5
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Show concurrency group'
+        shell: bash
+        # yamllint disable rule:line-length
+        run: |
+          # Show concurrency group
+          GROUP="${{ github.event.pull_request.number && format('rd-{0}-pr-{1}', github.event_name, github.event.pull_request.number) || format('rd-push-{0}', github.ref) }}"
+          {
+            echo '## Release Drafter'
+            echo "Concurrency group: ${GROUP}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Concurrency group: ${GROUP}"
+        # yamllint enable rule:line-length
+
+      - name: 'Update draft release'
+        # yamllint disable-line rule:line-length
+        uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6.2.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Summary
Configure release-drafter to use autolabeling for determining version bumps.

## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
Enable autolabeling in release-drafter and add autolabeler configuration
to .github/release-drafter.yml. This allows release-drafter to
automatically label PRs based on their titles, which in turn allows it
to determine the correct version bump (major, minor, patch) for the
release.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
