### PR TITLE
fix(akuvox): handle X916 user filtering where source_type is None

### DIFF
--- a/custom_components/keymaster/providers/akuvox.py
+++ b/custom_components/keymaster/providers/akuvox.py
@@ -45,9 +45,20 @@ _SLOT_TAG_RE = re.compile(r"^\[KM:(\d+)\]\s*(.*)")
 _DEFAULT_SCHEDULE_IDS = "1001"  # "Always" schedule on Akuvox devices
 _DEFAULT_LIFT_FLOOR_NUM = "1"
 
-# Local users have source_type "1"; cloud-provisioned users ("2") cannot
-# be managed and must be filtered out.
+# Akuvox firmware varies in how it marks local vs cloud users:
+#   A08S / E18C: source_type "1" = local, "2" = cloud, user_type "0" for both
+#   X916:        source_type None for all, user_type "-1" = local, "0" = cloud
 _LOCAL_SOURCE_TYPE = "1"
+_LOCAL_USER_TYPE = "-1"
+
+
+def _is_local_user(user: dict[str, Any]) -> bool:
+    """Return True if *user* was created locally on the device."""
+    source_type = user.get("source_type")
+    if source_type is not None:
+        return str(source_type) == _LOCAL_SOURCE_TYPE
+    # source_type absent — fall back to user_type (X916 pattern)
+    return str(user.get("user_type", "")) == _LOCAL_USER_TYPE
 
 
 def _make_tagged_name(slot_num: int, name: str | None = None) -> str:
@@ -405,7 +416,7 @@ class AkuvoxLockProvider(BaseLockProvider):
 
         for user in users:
             # Skip cloud-provisioned users — we can only manage local ones.
-            if str(user.get("source_type", "")) != _LOCAL_SOURCE_TYPE:
+            if not _is_local_user(user):
                 continue
             name = user.get("name", "")
             pin = user.get("private_pin", "")
@@ -487,7 +498,7 @@ class AkuvoxLockProvider(BaseLockProvider):
         """Get a specific user code from the lock."""
         users = await self._async_list_users()
         for user in users:
-            if str(user.get("source_type", "")) != _LOCAL_SOURCE_TYPE:
+            if not _is_local_user(user):
                 continue
             name = user.get("name", "")
             parsed_slot, friendly_name = _parse_tag(name)
@@ -513,7 +524,7 @@ class AkuvoxLockProvider(BaseLockProvider):
         existing_device_id: str | None = None
         existing_friendly_name: str | None = None
         for user in users:
-            if str(user.get("source_type", "")) != _LOCAL_SOURCE_TYPE:
+            if not _is_local_user(user):
                 continue
             user_name = user.get("name", "")
             parsed_slot, friendly = _parse_tag(user_name)
@@ -550,7 +561,7 @@ class AkuvoxLockProvider(BaseLockProvider):
         users = await self._async_list_users()
         target_device_id: str | None = None
         for user in users:
-            if str(user.get("source_type", "")) != _LOCAL_SOURCE_TYPE:
+            if not _is_local_user(user):
                 continue
             parsed_slot, _ = _parse_tag(user.get("name", ""))
             if parsed_slot == slot_num:

--- a/tests/providers/test_akuvox.py
+++ b/tests/providers/test_akuvox.py
@@ -10,6 +10,7 @@ from custom_components.keymaster.providers.akuvox import (
     AKUVOX_DOMAIN,
     AKUVOX_WEBHOOK_EVENT,
     AkuvoxLockProvider,
+    _is_local_user,
     _make_tagged_name,
     _parse_tag,
 )
@@ -71,7 +72,8 @@ def _make_user(
     device_id: str,
     name: str,
     private_pin: str = "",
-    source_type: str = "1",
+    source_type: str | None = "1",
+    user_type: str = "0",
 ) -> dict:
     """Create a user dict matching list_users response format."""
     return {
@@ -79,6 +81,7 @@ def _make_user(
         "name": name,
         "private_pin": private_pin,
         "source_type": source_type,
+        "user_type": user_type,
         "user_id": f"uid_{device_id}",
         "card_code": "",
         "schedule_relay": "1001-1",
@@ -122,6 +125,32 @@ class TestHelperFunctions:
     def test_parse_tag_empty_string(self):
         """Test parsing an empty string."""
         assert _parse_tag("") == (None, "")
+
+    # -- _is_local_user -------------------------------------------------------
+
+    def test_is_local_user_source_type_1(self):
+        """A08S/E18C pattern: source_type '1' is local."""
+        assert _is_local_user({"source_type": "1", "user_type": "0"}) is True
+
+    def test_is_local_user_source_type_2(self):
+        """A08S/E18C pattern: source_type '2' is cloud."""
+        assert _is_local_user({"source_type": "2", "user_type": "0"}) is False
+
+    def test_is_local_user_none_source_local_user_type(self):
+        """X916 pattern: source_type None, user_type '-1' is local."""
+        assert _is_local_user({"source_type": None, "user_type": "-1"}) is True
+
+    def test_is_local_user_none_source_cloud_user_type(self):
+        """X916 pattern: source_type None, user_type '0' is cloud."""
+        assert _is_local_user({"source_type": None, "user_type": "0"}) is False
+
+    def test_is_local_user_missing_source_type(self):
+        """Missing source_type key falls back to user_type."""
+        assert _is_local_user({"user_type": "-1"}) is True
+
+    def test_is_local_user_missing_both(self):
+        """Missing both fields is not local."""
+        assert _is_local_user({}) is False
 
 
 # ---------------------------------------------------------------------------
@@ -464,6 +493,34 @@ class TestAsyncGetUsercodes:
         assert result[0].slot_num == 1
         assert result[0].name == "Local"
 
+    async def test_x916_local_users_accepted(self, provider):
+        """X916 pattern: source_type None, user_type '-1' accepted as local."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user(
+                        "10",
+                        "[KM:1] Local",
+                        "1234",
+                        source_type=None,
+                        user_type="-1",
+                    ),
+                    _make_user(
+                        "20",
+                        "Cloud User",
+                        "5678",
+                        source_type=None,
+                        user_type="0",
+                    ),
+                ]
+            }
+        }
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 1
+        assert result[0].slot_num == 1
+        assert result[0].name == "Local"
+
     async def test_tagged_outside_managed_range_ignored(self, provider):
         """Test tagged users outside managed range are excluded."""
         provider.hass.services.async_call.return_value = {
@@ -585,7 +642,18 @@ class TestAsyncGetUsercode:
         result = await provider.async_get_usercode(1)
         assert result is None
 
-    async def test_get_code_empty_pin(self, provider):
+    async def test_get_code_skips_x916_cloud_users(self, provider):
+        """X916 pattern: cloud users (source_type=None, user_type='0') skipped."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user("10", "[KM:1] Cloud", "1234", source_type=None, user_type="0"),
+                ]
+            }
+        }
+
+        result = await provider.async_get_usercode(1)
+        assert result is None
         """Test getting a code with no PIN set."""
         provider.hass.services.async_call.return_value = {
             "lock.akuvox_relay_a": {
@@ -703,9 +771,32 @@ class TestAsyncSetUsercode:
         add_call = provider.hass.services.async_call.call_args_list[1]
         assert add_call[0][1] == "add_user"
 
+    async def test_set_code_skips_x916_cloud_users(self, provider):
+        """X916 pattern: cloud users skipped, triggers add_user."""
+        provider.hass.services.async_call.side_effect = [
+            {
+                "lock.akuvox_relay_a": {
+                    "users": [
+                        _make_user(
+                            "10",
+                            "[KM:1] Cloud",
+                            "1234",
+                            source_type=None,
+                            user_type="0",
+                        ),
+                    ]
+                }
+            },
+            None,
+        ]
 
-# ---------------------------------------------------------------------------
-# async_clear_usercode
+        result = await provider.async_set_usercode(1, "5678", "Local")
+        assert result is True
+
+        add_call = provider.hass.services.async_call.call_args_list[1]
+        assert add_call[0][1] == "add_user"
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -762,6 +853,26 @@ class TestAsyncClearUsercode:
         result = await provider.async_clear_usercode(1)
         assert result is True
         # Only list_users was called, no delete_user
+        assert provider.hass.services.async_call.call_count == 1
+
+    async def test_clear_skips_x916_cloud_users(self, provider):
+        """X916 pattern: cloud users (source_type=None, user_type='0') skipped."""
+        provider.hass.services.async_call.return_value = {
+            "lock.akuvox_relay_a": {
+                "users": [
+                    _make_user(
+                        "10",
+                        "[KM:1] Cloud",
+                        "1234",
+                        source_type=None,
+                        user_type="0",
+                    ),
+                ]
+            }
+        }
+
+        result = await provider.async_clear_usercode(1)
+        assert result is True
         assert provider.hass.services.async_call.call_count == 1
 
 

--- a/tests/providers/test_akuvox.py
+++ b/tests/providers/test_akuvox.py
@@ -654,6 +654,8 @@ class TestAsyncGetUsercode:
 
         result = await provider.async_get_usercode(1)
         assert result is None
+
+    async def test_get_code_empty_pin(self, provider):
         """Test getting a code with no PIN set."""
         provider.hass.services.async_call.return_value = {
             "lock.akuvox_relay_a": {


### PR DESCRIPTION
## Problem

The Akuvox provider filters local vs cloud users by checking `source_type == "1"`. This works for A08S and E18C models, but the X916 firmware does not populate `source_type` at all (returns `None` for all users). This causes the provider to skip **every** user on X916 devices, breaking user code management entirely.

Observed symptoms on X916:
- `async_get_usercodes()` returns empty list
- `async_set_usercode()` always calls `add_user` instead of `modify_user`, causing `FAILED` errors when a user already exists
- `async_clear_usercode()` silently does nothing

## Solution

Replace the inline `source_type` check with a `_is_local_user()` helper that handles both firmware patterns:

| Model | Local user | Cloud user |
|-------|-----------|------------|
| A08S / E18C | `source_type="1"` | `source_type="2"` |
| X916 | `source_type=None, user_type="-1"` | `source_type=None, user_type="0"` |

Logic:
1. If `source_type` is present (not None): check `== "1"`
2. If `source_type` is None/absent: fall back to `user_type == "-1"`

## Testing

- 6 new unit tests for `_is_local_user()` covering all branches
- 4 new X916-pattern integration tests across all CRUD methods
- 75 total tests pass, 100% coverage on `akuvox.py`

## Verified against real hardware

Tested against three device models:
- **A08S** (FW 108.30.10.144) — `source_type="1"` for local users ✅
- **E18C** (FW 18.30.10.111) — `source_type="1"`/`"2"` for local/cloud ✅  
- **X916** (FW 916.30.10.114) — `source_type=None`, `user_type="-1"`/`"0"` ✅