### PR TITLE
fix: slugify lock name when generating default notification script name

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.core_config import Config
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.event import async_call_later
+from homeassistant.util import slugify
 
 from .const import (
     CONF_ADVANCED_DATE_RANGE,
@@ -114,7 +115,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     if not updated_config.get(CONF_NOTIFY_SCRIPT_NAME):
         updated_config[CONF_NOTIFY_SCRIPT_NAME] = (
-            f"keymaster_{updated_config.get(CONF_LOCK_NAME)}_manual_notify"
+            f"keymaster_{slugify(updated_config.get(CONF_LOCK_NAME, ''))}_manual_notify"
         )
     elif isinstance(updated_config.get(CONF_NOTIFY_SCRIPT_NAME), str) and updated_config[
         CONF_NOTIFY_SCRIPT_NAME

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,9 +3,22 @@
 import logging
 from unittest.mock import patch
 
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.keymaster.const import DOMAIN
+from custom_components.keymaster import async_setup_entry
+from custom_components.keymaster.const import (
+    CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
+    CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
+    CONF_DOOR_SENSOR_ENTITY_ID,
+    CONF_HIDE_PINS,
+    CONF_LOCK_ENTITY_ID,
+    CONF_LOCK_NAME,
+    CONF_NOTIFY_SCRIPT_NAME,
+    CONF_SLOTS,
+    CONF_START,
+    DOMAIN,
+)
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 
 from .const import CONFIG_DATA
@@ -88,3 +101,28 @@ async def test_unload_entry(
     assert await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
+
+
+async def test_notify_script_name_slugified(hass):
+    """Test that default notify script name is slugified for lock names with spaces."""
+    config_data = {
+        CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID: "sensor.fake",
+        CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID: "sensor.fake",
+        CONF_LOCK_ENTITY_ID: "lock.akuvox_relay_a",
+        CONF_LOCK_NAME: "Akuvox Relay A",
+        CONF_DOOR_SENSOR_ENTITY_ID: "binary_sensor.fake",
+        CONF_SLOTS: 1,
+        CONF_START: 1,
+        CONF_NOTIFY_SCRIPT_NAME: None,
+        CONF_HIDE_PINS: False,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, title="Akuvox Relay A", data=config_data, version=4)
+    entry.add_to_hass(hass)
+
+    # async_setup_entry updates config data before coordinator setup, which
+    # requires hass.data[DOMAIN] to exist. We only need to verify the config
+    # update, so raise KeyError is expected when services setup runs.
+    with pytest.raises(KeyError, match="keymaster"):
+        await async_setup_entry(hass, entry)
+
+    assert entry.data[CONF_NOTIFY_SCRIPT_NAME] == "keymaster_akuvox_relay_a_manual_notify"


### PR DESCRIPTION
## Summary

Fixes a bug where lock names with spaces or uppercase characters (e.g. "Akuvox Relay A") were used directly in the notification script entity ID, producing invalid IDs like `script.keymaster_Akuvox Relay A_manual_notify` instead of `script.keymaster_akuvox_relay_a_manual_notify`.

This caused notification scripts to silently fail to fire since the entity ID didn't match any registered script.

## Changes

- **`custom_components/keymaster/__init__.py`**: Added `slugify()` call around the lock name when generating the default notification script name
- **`tests/test_init.py`**: Added `test_notify_script_name_slugified` test verifying that lock names with spaces and uppercase are properly slugified

## Root Cause

In `async_setup_entry()`, the default notification script name was built using raw `CONF_LOCK_NAME` without slugification:
```python
# Before (bug)
f"keymaster_{updated_config.get(CONF_LOCK_NAME)}_manual_notify"

# After (fix)
f"keymaster_{slugify(updated_config.get(CONF_LOCK_NAME, ''))}_manual_notify"
```

Home Assistant entity IDs must be lowercase with underscores. The `slugify()` function was already imported and used correctly in `config_flow.py`, `coordinator.py`, and `helpers.py` — it was simply missing from this one code path in `__init__.py`.

Fixes: #506