### PR TITLE
feat: add Schlage WiFi lock provider

### DIFF
--- a/custom_components/keymaster/manifest.json
+++ b/custom_components/keymaster/manifest.json
@@ -11,6 +11,7 @@
     "local_akuvox",
     "mqtt",
     "ozw",
+    "schlage",
     "script",
     "template",
     "zwave",

--- a/custom_components/keymaster/manifest.json
+++ b/custom_components/keymaster/manifest.json
@@ -17,7 +17,12 @@
     "zwave",
     "zwave_js"
   ],
-  "codeowners": ["@FutureTense", "@firstof9", "@raman325"],
+  "codeowners": [
+    "@FutureTense",
+    "@firstof9",
+    "@raman325",
+    "@tykeal"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/FutureTense/keymaster",

--- a/custom_components/keymaster/providers/__init__.py
+++ b/custom_components/keymaster/providers/__init__.py
@@ -10,13 +10,19 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from ._base import BaseLockProvider, CodeSlot, ConnectionCallback, LockEventCallback
 from .akuvox import AkuvoxLockProvider
+from .schlage import SchlageLockProvider
 from .zwave_js import ZWaveJSLockProvider
 
 _LOGGER = logging.getLogger(__name__)
 
-# Provider registry - maps platform domain to provider class
+# Provider registry - maps platform domain to provider class.
+# The entity-registry lookup in get_provider_class_for_lock() ensures a
+# provider is only instantiated when a lock entity with the matching
+# platform exists, which requires the corresponding integration to be
+# configured in Home Assistant.
 PROVIDER_MAP: dict[str, type[BaseLockProvider]] = {
     "local_akuvox": AkuvoxLockProvider,
+    "schlage": SchlageLockProvider,
     "zwave_js": ZWaveJSLockProvider,
 }
 

--- a/custom_components/keymaster/providers/schlage.py
+++ b/custom_components/keymaster/providers/schlage.py
@@ -1,0 +1,443 @@
+"""Schlage WiFi lock provider for keymaster.
+
+Schlage locks manage access codes by name rather than numeric slot numbers.
+This provider bridges that gap by tagging code names with a slot prefix
+in the format ``[KM:<slot>] <friendly name>``.  Pre-existing codes
+discovered on the lock are automatically tagged and assigned to the next
+available slot number.
+
+All lock operations go through the Home Assistant Schlage integration
+services (``schlage.get_codes``, ``schlage.add_code``,
+``schlage.delete_code``) rather than importing pyschlage directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+import re
+from typing import Any
+
+from custom_components.keymaster.const import CONF_SLOTS, CONF_START
+from homeassistant.exceptions import HomeAssistantError
+
+from ._base import BaseLockProvider, CodeSlot
+
+_LOGGER = logging.getLogger(__name__)
+
+SCHLAGE_DOMAIN = "schlage"
+
+# Regex to parse the keymaster slot tag from code names.
+# Format: [KM:XX] Friendly Name
+_SLOT_TAG_RE = re.compile(r"^\[KM:(\d+)\]\s*(.*)")
+
+
+def _make_tagged_name(slot_num: int, name: str | None = None) -> str:
+    """Create a tagged code name with keymaster slot number."""
+    base = name or f"Code Slot {slot_num}"
+    return f"[KM:{slot_num}] {base}"
+
+
+def _parse_tag(name: str) -> tuple[int | None, str]:
+    """Parse a keymaster slot tag from a code name.
+
+    Returns ``(slot_num, friendly_name)`` when a tag is present, or
+    ``(None, original_name)`` when no tag is found.
+    """
+    match = _SLOT_TAG_RE.match(name)
+    if match:
+        return int(match.group(1)), match.group(2)
+    return None, name
+
+
+@dataclass
+class SchlageLockProvider(BaseLockProvider):
+    """Schlage WiFi lock provider implementation.
+
+    Codes on Schlage locks are identified by friendly name, not by slot
+    number.  This provider assigns virtual slot numbers by embedding a
+    ``[KM:<slot>]`` tag in each code's name.
+    """
+
+    _schlage_device_id: str | None = field(default=None, init=False, repr=False)
+
+    @property
+    def domain(self) -> str:
+        """Return the integration domain."""
+        return SCHLAGE_DOMAIN
+
+    @property
+    def supports_connection_status(self) -> bool:
+        """Whether provider can report lock connection status."""
+        return True
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    async def async_connect(self) -> bool:
+        """Connect to the Schlage lock."""
+        self._connected = False
+
+        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
+        if not lock_entry:
+            _LOGGER.error(
+                "[SchlageProvider] Can't find lock in Entity Registry: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        self.lock_config_entry_id = lock_entry.config_entry_id
+        if not self.lock_config_entry_id:
+            _LOGGER.error(
+                "[SchlageProvider] Lock has no config entry: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        schlage_entry = self.hass.config_entries.async_get_entry(self.lock_config_entry_id)
+        if not schlage_entry:
+            _LOGGER.error(
+                "[SchlageProvider] Can't find Schlage config entry: %s",
+                self.lock_config_entry_id,
+            )
+            return False
+
+        try:
+            coordinator = schlage_entry.runtime_data
+        except (AttributeError, TypeError) as e:
+            _LOGGER.error(
+                "[SchlageProvider] Can't access Schlage coordinator: %s: %s",
+                e.__class__.__qualname__,
+                e,
+            )
+            return False
+
+        # Get Schlage device_id from device registry identifiers.
+        device_entry = None
+        if lock_entry.device_id:
+            device_entry = self.device_registry.async_get(lock_entry.device_id)
+        if not device_entry:
+            _LOGGER.error(
+                "[SchlageProvider] Can't find lock in Device Registry: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        schlage_device_id: str | None = None
+        for identifier in device_entry.identifiers:
+            if identifier[0] == SCHLAGE_DOMAIN:
+                schlage_device_id = identifier[1]
+                break
+
+        if not schlage_device_id:
+            _LOGGER.error(
+                "[SchlageProvider] Unable to get Schlage device ID for lock: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        if schlage_device_id not in coordinator.data.locks:
+            _LOGGER.error(
+                "[SchlageProvider] Lock %s not found in Schlage coordinator data",
+                schlage_device_id,
+            )
+            return False
+
+        self._schlage_device_id = schlage_device_id
+        self._connected = True
+        _LOGGER.debug(
+            "[SchlageProvider] Connected to lock %s (device_id %s)",
+            self.lock_entity_id,
+            schlage_device_id,
+        )
+        return True
+
+    async def async_is_connected(self) -> bool:
+        """Check if Schlage lock connection is active."""
+        if not self._schlage_device_id:
+            self._connected = False
+            return False
+
+        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
+        if not lock_entry or not lock_entry.config_entry_id:
+            self._connected = False
+            return False
+
+        schlage_entry = self.hass.config_entries.async_get_entry(lock_entry.config_entry_id)
+        if not schlage_entry:
+            self._connected = False
+            return False
+
+        try:
+            coordinator = schlage_entry.runtime_data
+            connected = self._schlage_device_id in coordinator.data.locks
+        except (AttributeError, TypeError):
+            connected = False
+
+        self._connected = connected
+        return connected
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _async_get_codes(self) -> dict[str, dict[str, str]]:
+        """Call ``schlage.get_codes`` and return the response dict.
+
+        Returns a dict mapping access-code IDs to ``{"name": ..., "code": ...}``.
+        """
+        try:
+            response = await self.hass.services.async_call(
+                SCHLAGE_DOMAIN,
+                "get_codes",
+                target={"entity_id": self.lock_entity_id},
+                blocking=True,
+                return_response=True,
+            )
+        except HomeAssistantError as e:
+            _LOGGER.error(
+                "[SchlageProvider] Failed to get codes: %s: %s",
+                e.__class__.__qualname__,
+                e,
+            )
+            return {}
+
+        if not isinstance(response, dict):
+            return {}
+
+        # Platform entity services wrap the response per entity_id.
+        entity_response = response.get(self.lock_entity_id, response)
+        if isinstance(entity_response, dict):
+            return entity_response
+        return {}
+
+    async def _async_delete_code(self, name: str) -> None:
+        """Delete a code by its *full* name (including any KM tag)."""
+        await self.hass.services.async_call(
+            SCHLAGE_DOMAIN,
+            "delete_code",
+            service_data={"name": name},
+            target={"entity_id": self.lock_entity_id},
+            blocking=True,
+        )
+
+    async def _async_add_code(self, name: str, code: str) -> None:
+        """Add a new code with the given name and PIN."""
+        await self.hass.services.async_call(
+            SCHLAGE_DOMAIN,
+            "add_code",
+            service_data={"name": name, "code": code},
+            target={"entity_id": self.lock_entity_id},
+            blocking=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Code slot operations
+    # ------------------------------------------------------------------
+
+    async def async_get_usercodes(self) -> list[CodeSlot]:
+        """Get all user codes from the Schlage lock.
+
+        Codes already bearing a ``[KM:<slot>]`` tag are mapped to the
+        embedded slot number.  Untagged codes are assigned to the next
+        available slot and their names are updated on the lock to include
+        the tag (via delete + re-add with the same PIN).
+
+        Only codes whose slot numbers fall within the configured managed
+        range are returned.  Tagged codes outside the range and untagged
+        codes that cannot be assigned to a managed slot are left untouched.
+        """
+        codes = await self._async_get_codes()
+        if not codes:
+            return []
+
+        # Determine the managed slot range from the keymaster config.
+        slot_start: int = self.keymaster_config_entry.data.get(CONF_START, 1)
+        slot_count: int = self.keymaster_config_entry.data.get(CONF_SLOTS, 0)
+        managed_range = set(range(slot_start, slot_start + slot_count))
+
+        result: list[CodeSlot] = []
+        assigned_slots: set[int] = set()
+
+        # (code_id, pin, slot, friendly_name)
+        tagged: list[tuple[str, str, int, str]] = []
+        # (code_id, pin, original_name)
+        untagged: list[tuple[str, str, str]] = []
+
+        for code_id, code_data in codes.items():
+            name = code_data.get("name", "")
+            pin = code_data.get("code", "")
+            slot_num, friendly_name = _parse_tag(name)
+            if slot_num is not None:
+                tagged.append((code_id, pin, slot_num, friendly_name))
+                assigned_slots.add(slot_num)
+            else:
+                untagged.append((code_id, pin, name))
+
+        # Emit already-tagged codes that fall within the managed range.
+        for _code_id, pin, slot_num, friendly_name in tagged:
+            if slot_num not in managed_range:
+                _LOGGER.debug(
+                    "[SchlageProvider] Ignoring tagged code slot %d: outside managed range %d-%d",
+                    slot_num,
+                    slot_start,
+                    slot_start + slot_count - 1,
+                )
+                continue
+            result.append(
+                CodeSlot(
+                    slot_num=slot_num,
+                    code=pin or None,
+                    in_use=bool(pin),
+                    name=friendly_name,
+                )
+            )
+
+        # Assign virtual slots to untagged codes and tag them on the lock.
+        # Only assign to slots within the managed range.
+        next_slot = slot_start
+        for _code_id, pin, original_name in untagged:
+            while next_slot in assigned_slots and next_slot in managed_range:
+                next_slot += 1
+            if next_slot not in managed_range:
+                _LOGGER.debug(
+                    "[SchlageProvider] No managed slot available for untagged code '%s'; "
+                    "leaving untouched",
+                    original_name,
+                )
+                continue
+            slot_num = next_slot
+            assigned_slots.add(slot_num)
+            next_slot += 1
+
+            tagged_name = _make_tagged_name(slot_num, original_name)
+            try:
+                await self._async_delete_code(original_name)
+                await self._async_add_code(tagged_name, pin)
+                _LOGGER.info(
+                    "[SchlageProvider] Tagged code '%s' as slot %d: '%s'",
+                    original_name,
+                    slot_num,
+                    tagged_name,
+                )
+            except HomeAssistantError as e:
+                _LOGGER.error(
+                    "[SchlageProvider] Failed to tag code '%s' for slot %d: %s: %s",
+                    original_name,
+                    slot_num,
+                    e.__class__.__qualname__,
+                    e,
+                )
+
+            # Include the code regardless of whether tagging succeeded.
+            result.append(
+                CodeSlot(
+                    slot_num=slot_num,
+                    code=pin or None,
+                    in_use=bool(pin),
+                    name=original_name,
+                )
+            )
+
+        return result
+
+    async def async_get_usercode(self, slot_num: int) -> CodeSlot | None:
+        """Get a specific user code from the lock."""
+        codes = await self._async_get_codes()
+        for code_data in codes.values():
+            name = code_data.get("name", "")
+            parsed_slot, friendly_name = _parse_tag(name)
+            if parsed_slot == slot_num:
+                pin = code_data.get("code", "")
+                return CodeSlot(
+                    slot_num=slot_num,
+                    code=pin or None,
+                    in_use=bool(pin),
+                    name=friendly_name,
+                )
+        return None
+
+    async def async_set_usercode(self, slot_num: int, code: str, name: str | None = None) -> bool:
+        """Set user code on a virtual slot.
+
+        If a code already exists for the given slot it is replaced.
+        """
+        codes = await self._async_get_codes()
+
+        # Look for an existing code on this slot so we can preserve its
+        # friendly name when the caller doesn't supply one.
+        existing_full_name: str | None = None
+        existing_friendly_name: str | None = None
+        for code_data in codes.values():
+            code_name = code_data.get("name", "")
+            parsed_slot, friendly = _parse_tag(code_name)
+            if parsed_slot == slot_num:
+                existing_full_name = code_name
+                existing_friendly_name = friendly
+                break
+
+        effective_name = name or existing_friendly_name
+        tagged_name = _make_tagged_name(slot_num, effective_name)
+
+        try:
+            if existing_full_name:
+                await self._async_delete_code(existing_full_name)
+            await self._async_add_code(tagged_name, code)
+        except HomeAssistantError as e:
+            _LOGGER.error(
+                "[SchlageProvider] Failed to set usercode on slot %s: %s: %s",
+                slot_num,
+                e.__class__.__qualname__,
+                e,
+            )
+            return False
+
+        _LOGGER.debug("[SchlageProvider] Set usercode on slot %s", slot_num)
+        return True
+
+    async def async_clear_usercode(self, slot_num: int) -> bool:
+        """Clear user code from a virtual slot."""
+        codes = await self._async_get_codes()
+        target_name: str | None = None
+        for code_data in codes.values():
+            parsed_slot, _ = _parse_tag(code_data.get("name", ""))
+            if parsed_slot == slot_num:
+                target_name = code_data.get("name", "")
+                break
+
+        if not target_name:
+            _LOGGER.debug(
+                "[SchlageProvider] No code found for slot %s, already clear",
+                slot_num,
+            )
+            return True
+
+        try:
+            await self._async_delete_code(target_name)
+        except HomeAssistantError as e:
+            _LOGGER.error(
+                "[SchlageProvider] Failed to clear usercode from slot %s: %s: %s",
+                slot_num,
+                e.__class__.__qualname__,
+                e,
+            )
+            return False
+
+        _LOGGER.debug("[SchlageProvider] Cleared usercode from slot %s", slot_num)
+        return True
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
+    def get_platform_data(self) -> dict[str, Any]:
+        """Get Schlage-specific diagnostic data."""
+        data = super().get_platform_data()
+        data.update(
+            {
+                "schlage_device_id": self._schlage_device_id,
+                "lock_config_entry_id": self.lock_config_entry_id,
+            }
+        )
+        return data

--- a/custom_components/keymaster/providers/schlage.py
+++ b/custom_components/keymaster/providers/schlage.py
@@ -50,6 +50,14 @@ def _parse_tag(name: str) -> tuple[int | None, str]:
     return None, name
 
 
+def _is_masked_pin(pin: str) -> bool:
+    """Return True if a PIN looks masked or placeholder (e.g. '****', empty)."""
+    if not pin:
+        return True
+    # Only treat '*' repeated as masked; allow real all-zero PINs like '0000'.
+    return len(set(pin)) == 1 and pin[0] == "*"
+
+
 @dataclass
 class SchlageLockProvider(BaseLockProvider):
     """Schlage WiFi lock provider implementation.
@@ -137,10 +145,18 @@ class SchlageLockProvider(BaseLockProvider):
             )
             return False
 
-        if schlage_device_id not in coordinator.data.locks:
+        try:
+            if schlage_device_id not in coordinator.data.locks:
+                _LOGGER.error(
+                    "[SchlageProvider] Lock %s not found in Schlage coordinator data",
+                    schlage_device_id,
+                )
+                return False
+        except (AttributeError, TypeError) as e:
             _LOGGER.error(
-                "[SchlageProvider] Lock %s not found in Schlage coordinator data",
-                schlage_device_id,
+                "[SchlageProvider] Can't access Schlage coordinator data: %s: %s",
+                e.__class__.__qualname__,
+                e,
             )
             return False
 
@@ -276,7 +292,10 @@ class SchlageLockProvider(BaseLockProvider):
                 untagged.append((code_id, pin, name))
 
         # Emit already-tagged codes that fall within the managed range.
-        for _code_id, pin, slot_num, friendly_name in tagged:
+        # Sort by code_id for deterministic dedup, then keep the first per slot.
+        tagged.sort(key=lambda t: t[0])
+        seen_slots: set[int] = set()
+        for code_id, pin, slot_num, friendly_name in tagged:
             if slot_num not in managed_range:
                 _LOGGER.debug(
                     "[SchlageProvider] Ignoring tagged code slot %d: outside managed range %d-%d",
@@ -285,6 +304,16 @@ class SchlageLockProvider(BaseLockProvider):
                     slot_start + slot_count - 1,
                 )
                 continue
+            if slot_num in seen_slots:
+                _LOGGER.warning(
+                    "[SchlageProvider] Duplicate tag for slot %d (code_id=%s, name='%s'); "
+                    "skipping in favor of earlier entry",
+                    slot_num,
+                    code_id,
+                    friendly_name,
+                )
+                continue
+            seen_slots.add(slot_num)
             result.append(
                 CodeSlot(
                     slot_num=slot_num,
@@ -295,9 +324,16 @@ class SchlageLockProvider(BaseLockProvider):
             )
 
         # Assign virtual slots to untagged codes and tag them on the lock.
-        # Only assign to slots within the managed range.
+        # Only codes that are successfully tagged get a managed slot; masked
+        # PINs and tagging failures are skipped to avoid slot drift.
         next_slot = slot_start
         for _code_id, pin, original_name in untagged:
+            if not original_name or not original_name.strip():
+                _LOGGER.debug(
+                    "[SchlageProvider] Skipping code with empty/whitespace name",
+                )
+                continue
+
             while next_slot in assigned_slots and next_slot in managed_range:
                 next_slot += 1
             if next_slot not in managed_range:
@@ -307,35 +343,66 @@ class SchlageLockProvider(BaseLockProvider):
                     original_name,
                 )
                 continue
-            slot_num = next_slot
-            assigned_slots.add(slot_num)
-            next_slot += 1
 
-            tagged_name = _make_tagged_name(slot_num, original_name)
-            try:
-                await self._async_delete_code(original_name)
-                await self._async_add_code(tagged_name, pin)
-                _LOGGER.info(
-                    "[SchlageProvider] Tagged code '%s' as slot %d: '%s'",
+            prospective_slot = next_slot
+            tagged_name = _make_tagged_name(prospective_slot, original_name)
+
+            if _is_masked_pin(pin):
+                _LOGGER.debug(
+                    "[SchlageProvider] Skipping untaggable code '%s' (slot %d): "
+                    "PIN appears masked or empty",
                     original_name,
-                    slot_num,
-                    tagged_name,
+                    prospective_slot,
                 )
+                continue
+
+            try:
+                await self._async_add_code(tagged_name, pin)
             except HomeAssistantError as e:
                 _LOGGER.error(
                     "[SchlageProvider] Failed to tag code '%s' for slot %d: %s: %s",
                     original_name,
-                    slot_num,
+                    prospective_slot,
                     e.__class__.__qualname__,
                     e,
                 )
+                continue
 
-            # Include the code regardless of whether tagging succeeded.
+            try:
+                await self._async_delete_code(original_name)
+            except HomeAssistantError as e:
+                _LOGGER.warning(
+                    "[SchlageProvider] Tagged code added but failed to delete "
+                    "original '%s' for slot %d: %s. Attempting rollback.",
+                    original_name,
+                    prospective_slot,
+                    e,
+                )
+                try:
+                    await self._async_delete_code(tagged_name)
+                except HomeAssistantError:
+                    _LOGGER.error(
+                        "[SchlageProvider] Rollback failed for tagged code '%s'. "
+                        "Lock may have duplicate entries.",
+                        tagged_name,
+                    )
+                continue
+
+            slot_num = prospective_slot
+            assigned_slots.add(slot_num)
+            next_slot += 1
+            _LOGGER.debug(
+                "[SchlageProvider] Tagged code '%s' as slot %d: '%s'",
+                original_name,
+                slot_num,
+                tagged_name,
+            )
             result.append(
                 CodeSlot(
                     slot_num=slot_num,
                     code=pin or None,
-                    in_use=bool(pin),
+                    # This code was just successfully added to the lock, so it is in use.
+                    in_use=True,
                     name=original_name,
                 )
             )
@@ -350,10 +417,12 @@ class SchlageLockProvider(BaseLockProvider):
             parsed_slot, friendly_name = _parse_tag(name)
             if parsed_slot == slot_num:
                 pin = code_data.get("code", "")
+                status = code_data.get("status")
+                in_use = bool(status) if status is not None else bool(pin)
                 return CodeSlot(
                     slot_num=slot_num,
                     code=pin or None,
-                    in_use=bool(pin),
+                    in_use=in_use,
                     name=friendly_name,
                 )
         return None
@@ -381,8 +450,7 @@ class SchlageLockProvider(BaseLockProvider):
         tagged_name = _make_tagged_name(slot_num, effective_name)
 
         try:
-            if existing_full_name:
-                await self._async_delete_code(existing_full_name)
+            # Add the new code first to avoid data loss if the add fails.
             await self._async_add_code(tagged_name, code)
         except HomeAssistantError as e:
             _LOGGER.error(
@@ -392,6 +460,17 @@ class SchlageLockProvider(BaseLockProvider):
                 e,
             )
             return False
+
+        if existing_full_name and existing_full_name != tagged_name:
+            try:
+                await self._async_delete_code(existing_full_name)
+            except HomeAssistantError as e:
+                _LOGGER.warning(
+                    "[SchlageProvider] Code set on slot %s but failed to remove old entry '%s': %s",
+                    slot_num,
+                    existing_full_name,
+                    e,
+                )
 
         _LOGGER.debug("[SchlageProvider] Set usercode on slot %s", slot_num)
         return True

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
   "name": "keymaster",
   "zip_release": true,
   "filename": "keymaster.zip",
-  "homeassistant": "2025.8.0",
+  "homeassistant": "2026.4.0",
   "persistent_directory": "json_kmlocks"
 }

--- a/tests/providers/test_schlage.py
+++ b/tests/providers/test_schlage.py
@@ -1,0 +1,670 @@
+"""Tests for the Schlage WiFi lock provider."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.keymaster.providers.schlage import (
+    SchlageLockProvider,
+    _make_tagged_name,
+    _parse_tag,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    return hass
+
+
+@pytest.fixture
+def mock_entity_registry():
+    """Create a mock entity registry."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_device_registry():
+    """Create a mock device registry."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_config_entry():
+    """Create a mock keymaster config entry."""
+    entry = MagicMock()
+    entry.entry_id = "keymaster_test_entry"
+    entry.data = {"start_from": 1, "slots": 6}
+    return entry
+
+
+@pytest.fixture
+def schlage_provider(mock_hass, mock_entity_registry, mock_device_registry, mock_config_entry):
+    """Create a SchlageLockProvider instance."""
+    return SchlageLockProvider(
+        hass=mock_hass,
+        lock_entity_id="lock.schlage_front_door",
+        keymaster_config_entry=mock_config_entry,
+        device_registry=mock_device_registry,
+        entity_registry=mock_entity_registry,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestHelperFunctions:
+    """Tests for module-level helpers."""
+
+    def test_make_tagged_name_with_name(self):
+        """Test tagged name with friendly name."""
+        assert _make_tagged_name(1, "Guest") == "[KM:1] Guest"
+
+    def test_make_tagged_name_without_name(self):
+        """Test tagged name defaults to 'Code Slot N'."""
+        assert _make_tagged_name(5) == "[KM:5] Code Slot 5"
+
+    def test_make_tagged_name_none_name(self):
+        """Test tagged name with explicit None."""
+        assert _make_tagged_name(3, None) == "[KM:3] Code Slot 3"
+
+    def test_parse_tag_valid(self):
+        """Test parsing a valid tag."""
+        assert _parse_tag("[KM:1] Guest") == (1, "Guest")
+
+    def test_parse_tag_large_slot(self):
+        """Test parsing a large slot number."""
+        assert _parse_tag("[KM:99] Family") == (99, "Family")
+
+    def test_parse_tag_no_tag(self):
+        """Test parsing name without a tag."""
+        assert _parse_tag("Guest Code") == (None, "Guest Code")
+
+    def test_parse_tag_empty_string(self):
+        """Test parsing an empty string."""
+        assert _parse_tag("") == (None, "")
+
+    def test_parse_tag_partial_tag(self):
+        """Test parsing a partial/malformed tag."""
+        assert _parse_tag("[KM:] Guest") == (None, "[KM:] Guest")
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+class TestProperties:
+    """Tests for provider properties."""
+
+    def test_domain(self, schlage_provider):
+        """Test domain property."""
+        assert schlage_provider.domain == "schlage"
+
+    def test_supports_push_updates(self, schlage_provider):
+        """Test push updates not supported (cloud polling)."""
+        assert schlage_provider.supports_push_updates is False
+
+    def test_supports_connection_status(self, schlage_provider):
+        """Test connection status is supported."""
+        assert schlage_provider.supports_connection_status is True
+
+
+# ---------------------------------------------------------------------------
+# Connection
+# ---------------------------------------------------------------------------
+
+
+class TestConnect:
+    """Tests for async_connect."""
+
+    async def test_connect_success(self, schlage_provider):
+        """Test successful connection."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_config_entry"
+        lock_entry.device_id = "ha_device_id"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        coordinator = MagicMock()
+        coordinator.data.locks = {"schlage_device_123": MagicMock()}
+        schlage_entry.runtime_data = coordinator
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {("schlage", "schlage_device_123")}
+        schlage_provider.device_registry.async_get.return_value = device_entry
+
+        result = await schlage_provider.async_connect()
+        assert result is True
+        assert schlage_provider._connected is True
+        assert schlage_provider._schlage_device_id == "schlage_device_123"
+        assert schlage_provider.lock_config_entry_id == "schlage_config_entry"
+
+    async def test_connect_entity_not_found(self, schlage_provider):
+        """Test connection fails when entity not in registry."""
+        schlage_provider.entity_registry.async_get.return_value = None
+        assert await schlage_provider.async_connect() is False
+        assert schlage_provider._connected is False
+
+    async def test_connect_no_config_entry(self, schlage_provider):
+        """Test connection fails when entity has no config entry."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = None
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+        assert await schlage_provider.async_connect() is False
+
+    async def test_connect_schlage_entry_not_found(self, schlage_provider):
+        """Test connection fails when schlage config entry missing."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "missing_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+        schlage_provider.hass.config_entries.async_get_entry.return_value = None
+        assert await schlage_provider.async_connect() is False
+
+    async def test_connect_coordinator_not_available(self, schlage_provider):
+        """Test connection fails when coordinator unavailable."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        del schlage_entry.runtime_data  # AttributeError
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+        assert await schlage_provider.async_connect() is False
+
+    async def test_connect_no_device_entry(self, schlage_provider):
+        """Test connection fails when device not in registry."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        lock_entry.device_id = "ha_device"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        schlage_entry.runtime_data = MagicMock()
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+        schlage_provider.device_registry.async_get.return_value = None
+        assert await schlage_provider.async_connect() is False
+
+    async def test_connect_no_schlage_identifier(self, schlage_provider):
+        """Test connection fails when device has no schlage identifier."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        lock_entry.device_id = "ha_device"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        schlage_entry.runtime_data = MagicMock()
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {("other_domain", "some_id")}
+        schlage_provider.device_registry.async_get.return_value = device_entry
+        assert await schlage_provider.async_connect() is False
+
+    async def test_connect_lock_not_in_coordinator(self, schlage_provider):
+        """Test connection fails when lock not in coordinator data."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        lock_entry.device_id = "ha_device"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        coordinator = MagicMock()
+        coordinator.data.locks = {}  # Empty
+        schlage_entry.runtime_data = coordinator
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {("schlage", "schlage_device_123")}
+        schlage_provider.device_registry.async_get.return_value = device_entry
+        assert await schlage_provider.async_connect() is False
+
+
+# ---------------------------------------------------------------------------
+# Connection status
+# ---------------------------------------------------------------------------
+
+
+class TestIsConnected:
+    """Tests for async_is_connected."""
+
+    async def test_not_connected_no_device_id(self, schlage_provider):
+        """Test returns False when no device_id set."""
+        schlage_provider._schlage_device_id = None
+        assert await schlage_provider.async_is_connected() is False
+
+    async def test_connected_lock_in_coordinator(self, schlage_provider):
+        """Test returns True when lock exists in coordinator."""
+        schlage_provider._schlage_device_id = "dev123"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        coordinator = MagicMock()
+        coordinator.data.locks = {"dev123": MagicMock()}
+        schlage_entry.runtime_data = coordinator
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        assert await schlage_provider.async_is_connected() is True
+
+    async def test_not_connected_lock_removed(self, schlage_provider):
+        """Test returns False when lock removed from coordinator."""
+        schlage_provider._schlage_device_id = "dev123"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        coordinator = MagicMock()
+        coordinator.data.locks = {}
+        schlage_entry.runtime_data = coordinator
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        assert await schlage_provider.async_is_connected() is False
+
+
+# ---------------------------------------------------------------------------
+# Get usercodes
+# ---------------------------------------------------------------------------
+
+
+class TestGetUsercodes:
+    """Tests for async_get_usercodes."""
+
+    async def test_get_usercodes_all_tagged(self, schlage_provider):
+        """Test retrieving codes that are already tagged."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "[KM:1] Guest", "code": "1234"},
+                    "id2": {"name": "[KM:2] Family", "code": "5678"},
+                }
+            }
+        )
+
+        codes = await schlage_provider.async_get_usercodes()
+        assert len(codes) == 2
+        assert codes[0].slot_num == 1
+        assert codes[0].code == "1234"
+        assert codes[0].name == "Guest"
+        assert codes[0].in_use is True
+        assert codes[1].slot_num == 2
+        assert codes[1].code == "5678"
+        assert codes[1].name == "Family"
+
+    async def test_get_usercodes_untagged_assigned_slots(self, schlage_provider):
+        """Test untagged codes are assigned slots and tagged."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "Guest", "code": "1234"},
+                    "id2": {"name": "Family", "code": "5678"},
+                }
+            }
+        )
+
+        codes = await schlage_provider.async_get_usercodes()
+        assert len(codes) == 2
+        assert codes[0].slot_num == 1
+        assert codes[0].code == "1234"
+        assert codes[0].name == "Guest"
+        assert codes[1].slot_num == 2
+        assert codes[1].code == "5678"
+        assert codes[1].name == "Family"
+
+        # Verify delete + add calls for tagging (get_codes + 2 * (delete + add))
+        calls = schlage_provider.hass.services.async_call.call_args_list
+        assert len(calls) == 5  # 1 get_codes + 2 delete + 2 add
+        # First untagged code: delete "Guest", add "[KM:1] Guest"
+        assert calls[1].kwargs["service_data"] == {"name": "Guest"}
+        assert calls[2].kwargs["service_data"] == {
+            "name": "[KM:1] Guest",
+            "code": "1234",
+        }
+        # Second untagged code: delete "Family", add "[KM:2] Family"
+        assert calls[3].kwargs["service_data"] == {"name": "Family"}
+        assert calls[4].kwargs["service_data"] == {
+            "name": "[KM:2] Family",
+            "code": "5678",
+        }
+
+    async def test_get_usercodes_mixed_tagged_and_untagged(self, schlage_provider):
+        """Test mix of tagged and untagged codes."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "[KM:1] Guest", "code": "1234"},
+                    "id2": {"name": "New Code", "code": "9999"},
+                }
+            }
+        )
+
+        codes = await schlage_provider.async_get_usercodes()
+        assert len(codes) == 2
+        # Tagged code keeps slot 1
+        assert codes[0].slot_num == 1
+        assert codes[0].name == "Guest"
+        # Untagged gets slot 2 (skips occupied slot 1)
+        assert codes[1].slot_num == 2
+        assert codes[1].name == "New Code"
+
+    async def test_get_usercodes_empty(self, schlage_provider):
+        """Test empty code list."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={"lock.schlage_front_door": {}}
+        )
+        codes = await schlage_provider.async_get_usercodes()
+        assert codes == []
+
+    async def test_get_usercodes_service_error(self, schlage_provider):
+        """Test returns empty list on service error."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("API error")
+        )
+        codes = await schlage_provider.async_get_usercodes()
+        assert codes == []
+
+    async def test_get_usercodes_tagging_failure_still_returns_code(self, schlage_provider):
+        """Test that codes are still returned even if tagging fails."""
+        call_count = 0
+
+        async def mock_service_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # get_codes succeeds
+                return {
+                    "lock.schlage_front_door": {
+                        "id1": {"name": "Guest", "code": "1234"},
+                    }
+                }
+            # delete/add for tagging fails
+            raise HomeAssistantError("Tag failed")
+
+        schlage_provider.hass.services.async_call = AsyncMock(side_effect=mock_service_call)
+        codes = await schlage_provider.async_get_usercodes()
+        assert len(codes) == 1
+        assert codes[0].slot_num == 1
+        assert codes[0].code == "1234"
+        assert codes[0].name == "Guest"
+
+    async def test_get_usercodes_slot_gap_filled(self, schlage_provider):
+        """Test untagged codes fill gaps in slot numbering."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "[KM:1] First", "code": "1111"},
+                    "id2": {"name": "[KM:3] Third", "code": "3333"},
+                    "id3": {"name": "New Code", "code": "2222"},
+                }
+            }
+        )
+
+        codes = await schlage_provider.async_get_usercodes()
+        assert len(codes) == 3
+        slot_nums = {c.slot_num for c in codes}
+        # Untagged gets slot 2 (gap between 1 and 3)
+        assert slot_nums == {1, 2, 3}
+
+    async def test_get_usercodes_tagged_outside_range_ignored(self, schlage_provider):
+        """Test tagged codes outside managed range are ignored."""
+        schlage_provider.keymaster_config_entry.data = {"start_from": 1, "slots": 3}
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "[KM:1] Guest", "code": "1234"},
+                    "id2": {"name": "[KM:10] Outside", "code": "9999"},
+                }
+            }
+        )
+
+        codes = await schlage_provider.async_get_usercodes()
+        assert len(codes) == 1
+        assert codes[0].slot_num == 1
+        assert codes[0].name == "Guest"
+
+    async def test_get_usercodes_untagged_overflow_left_alone(self, schlage_provider):
+        """Test untagged codes left alone when no managed slots available."""
+        schlage_provider.keymaster_config_entry.data = {"start_from": 1, "slots": 2}
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "[KM:1] First", "code": "1111"},
+                    "id2": {"name": "[KM:2] Second", "code": "2222"},
+                    "id3": {"name": "Extra Code", "code": "3333"},
+                }
+            }
+        )
+
+        codes = await schlage_provider.async_get_usercodes()
+        assert len(codes) == 2
+        slot_nums = {c.slot_num for c in codes}
+        assert slot_nums == {1, 2}
+        # Only get_codes was called; no delete/add for the extra code
+        assert schlage_provider.hass.services.async_call.call_count == 1
+
+    async def test_get_usercodes_nondefault_start(self, schlage_provider):
+        """Test slot assignment respects non-default start_from."""
+        schlage_provider.keymaster_config_entry.data = {"start_from": 5, "slots": 3}
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "Guest", "code": "1234"},
+                    "id2": {"name": "Family", "code": "5678"},
+                }
+            }
+        )
+
+        codes = await schlage_provider.async_get_usercodes()
+        assert len(codes) == 2
+        slot_nums = {c.slot_num for c in codes}
+        assert slot_nums == {5, 6}
+
+
+# ---------------------------------------------------------------------------
+# Get single usercode
+# ---------------------------------------------------------------------------
+
+
+class TestGetUsercode:
+    """Tests for async_get_usercode."""
+
+    async def test_get_usercode_found(self, schlage_provider):
+        """Test getting a specific code by slot."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "[KM:3] Guest", "code": "1234"},
+                }
+            }
+        )
+
+        code = await schlage_provider.async_get_usercode(3)
+        assert code is not None
+        assert code.slot_num == 3
+        assert code.code == "1234"
+        assert code.name == "Guest"
+
+    async def test_get_usercode_not_found(self, schlage_provider):
+        """Test returns None when slot not found."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={"lock.schlage_front_door": {}}
+        )
+        assert await schlage_provider.async_get_usercode(99) is None
+
+
+# ---------------------------------------------------------------------------
+# Set usercode
+# ---------------------------------------------------------------------------
+
+
+class TestSetUsercode:
+    """Tests for async_set_usercode."""
+
+    async def test_set_new_code(self, schlage_provider):
+        """Test setting a code on an empty slot."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={"lock.schlage_front_door": {}}
+        )
+
+        result = await schlage_provider.async_set_usercode(1, "1234", "Guest")
+        assert result is True
+
+        calls = schlage_provider.hass.services.async_call.call_args_list
+        # get_codes + add_code
+        assert len(calls) == 2
+        add_call = calls[1]
+        assert add_call.args == ("schlage", "add_code")
+        assert add_call.kwargs["service_data"] == {
+            "name": "[KM:1] Guest",
+            "code": "1234",
+        }
+
+    async def test_set_replace_existing_code(self, schlage_provider):
+        """Test replacing an existing code on a slot."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "[KM:1] Guest", "code": "1234"},
+                }
+            }
+        )
+
+        result = await schlage_provider.async_set_usercode(1, "5678")
+        assert result is True
+
+        calls = schlage_provider.hass.services.async_call.call_args_list
+        # get_codes + delete_code + add_code
+        assert len(calls) == 3
+        # Delete old
+        assert calls[1].kwargs["service_data"] == {"name": "[KM:1] Guest"}
+        # Add new — preserves friendly name since none provided
+        assert calls[2].kwargs["service_data"] == {
+            "name": "[KM:1] Guest",
+            "code": "5678",
+        }
+
+    async def test_set_preserves_friendly_name(self, schlage_provider):
+        """Test that the friendly name is preserved when no name is given."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "[KM:5] VIP", "code": "0000"},
+                }
+            }
+        )
+
+        result = await schlage_provider.async_set_usercode(5, "9999")
+        assert result is True
+
+        add_call = schlage_provider.hass.services.async_call.call_args_list[2]
+        assert add_call.kwargs["service_data"]["name"] == "[KM:5] VIP"
+
+    async def test_set_service_error(self, schlage_provider):
+        """Test returns False on service error."""
+        call_count = 0
+
+        async def mock_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"lock.schlage_front_door": {}}
+            raise HomeAssistantError("Schlage API error")
+
+        schlage_provider.hass.services.async_call = AsyncMock(side_effect=mock_call)
+        result = await schlage_provider.async_set_usercode(1, "1234")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Clear usercode
+# ---------------------------------------------------------------------------
+
+
+class TestClearUsercode:
+    """Tests for async_clear_usercode."""
+
+    async def test_clear_existing_code(self, schlage_provider):
+        """Test clearing an existing code."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "[KM:1] Guest", "code": "1234"},
+                }
+            }
+        )
+
+        result = await schlage_provider.async_clear_usercode(1)
+        assert result is True
+
+        calls = schlage_provider.hass.services.async_call.call_args_list
+        assert len(calls) == 2  # get_codes + delete_code
+        assert calls[1].kwargs["service_data"] == {"name": "[KM:1] Guest"}
+
+    async def test_clear_already_empty(self, schlage_provider):
+        """Test clearing a slot that's already empty."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={"lock.schlage_front_door": {}}
+        )
+
+        result = await schlage_provider.async_clear_usercode(99)
+        assert result is True
+        # Only get_codes was called, no delete
+        assert schlage_provider.hass.services.async_call.call_count == 1
+
+    async def test_clear_service_error(self, schlage_provider):
+        """Test returns False on service error during delete."""
+        call_count = 0
+
+        async def mock_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {
+                    "lock.schlage_front_door": {
+                        "id1": {"name": "[KM:1] Guest", "code": "1234"},
+                    }
+                }
+            raise HomeAssistantError("Delete failed")
+
+        schlage_provider.hass.services.async_call = AsyncMock(side_effect=mock_call)
+        result = await schlage_provider.async_clear_usercode(1)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnostics:
+    """Tests for diagnostic data."""
+
+    def test_get_platform_data(self, schlage_provider):
+        """Test platform diagnostic data."""
+        schlage_provider._schlage_device_id = "dev_123"
+        schlage_provider.lock_config_entry_id = "config_456"
+
+        data = schlage_provider.get_platform_data()
+        assert data["domain"] == "schlage"
+        assert data["schlage_device_id"] == "dev_123"
+        assert data["lock_config_entry_id"] == "config_456"
+        assert data["lock_entity_id"] == "lock.schlage_front_door"

--- a/tests/providers/test_schlage.py
+++ b/tests/providers/test_schlage.py
@@ -182,8 +182,7 @@ class TestConnect:
         lock_entry.config_entry_id = "schlage_entry"
         schlage_provider.entity_registry.async_get.return_value = lock_entry
 
-        schlage_entry = MagicMock()
-        del schlage_entry.runtime_data  # AttributeError
+        schlage_entry = MagicMock(spec_set=[])
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
         assert await schlage_provider.async_connect() is False
 
@@ -226,6 +225,23 @@ class TestConnect:
         schlage_entry = MagicMock()
         coordinator = MagicMock()
         coordinator.data.locks = {}  # Empty
+        schlage_entry.runtime_data = coordinator
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {("schlage", "schlage_device_123")}
+        schlage_provider.device_registry.async_get.return_value = device_entry
+        assert await schlage_provider.async_connect() is False
+
+    async def test_connect_coordinator_data_missing(self, schlage_provider):
+        """Test connection fails when coordinator.data.locks is inaccessible."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        lock_entry.device_id = "ha_device"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        coordinator = type("Coordinator", (), {})()
         schlage_entry.runtime_data = coordinator
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
 
@@ -280,6 +296,52 @@ class TestIsConnected:
 
         assert await schlage_provider.async_is_connected() is False
 
+    async def test_not_connected_lock_entry_missing(self, schlage_provider):
+        """Test returns False when entity registry entry is missing."""
+        schlage_provider._schlage_device_id = "dev123"
+        schlage_provider.entity_registry.async_get.return_value = None
+
+        assert await schlage_provider.async_is_connected() is False
+        assert schlage_provider._connected is False
+
+    async def test_not_connected_no_config_entry_id(self, schlage_provider):
+        """Test returns False when lock_entry has no config_entry_id."""
+        schlage_provider._schlage_device_id = "dev123"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = None
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        assert await schlage_provider.async_is_connected() is False
+        assert schlage_provider._connected is False
+
+    async def test_not_connected_schlage_entry_missing(self, schlage_provider):
+        """Test returns False when Schlage config entry is gone."""
+        schlage_provider._schlage_device_id = "dev123"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+        schlage_provider.hass.config_entries.async_get_entry.return_value = None
+
+        assert await schlage_provider.async_is_connected() is False
+        assert schlage_provider._connected is False
+
+    async def test_not_connected_coordinator_error(self, schlage_provider):
+        """Test returns False when coordinator access raises an exception."""
+        schlage_provider._schlage_device_id = "dev123"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        schlage_entry.runtime_data = None  # causes AttributeError on .data.locks
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        assert await schlage_provider.async_is_connected() is False
+        assert schlage_provider._connected is False
+
 
 # ---------------------------------------------------------------------------
 # Get usercodes
@@ -330,21 +392,21 @@ class TestGetUsercodes:
         assert codes[1].code == "5678"
         assert codes[1].name == "Family"
 
-        # Verify delete + add calls for tagging (get_codes + 2 * (delete + add))
+        # Verify add + delete calls for tagging (get_codes + 2 * (add + delete))
         calls = schlage_provider.hass.services.async_call.call_args_list
-        assert len(calls) == 5  # 1 get_codes + 2 delete + 2 add
-        # First untagged code: delete "Guest", add "[KM:1] Guest"
-        assert calls[1].kwargs["service_data"] == {"name": "Guest"}
-        assert calls[2].kwargs["service_data"] == {
+        assert len(calls) == 5  # 1 get_codes + 2 add + 2 delete
+        # First untagged code: add "[KM:1] Guest", delete "Guest"
+        assert calls[1].kwargs["service_data"] == {
             "name": "[KM:1] Guest",
             "code": "1234",
         }
-        # Second untagged code: delete "Family", add "[KM:2] Family"
-        assert calls[3].kwargs["service_data"] == {"name": "Family"}
-        assert calls[4].kwargs["service_data"] == {
+        assert calls[2].kwargs["service_data"] == {"name": "Guest"}
+        # Second untagged code: add "[KM:2] Family", delete "Family"
+        assert calls[3].kwargs["service_data"] == {
             "name": "[KM:2] Family",
             "code": "5678",
         }
+        assert calls[4].kwargs["service_data"] == {"name": "Family"}
 
     async def test_get_usercodes_mixed_tagged_and_untagged(self, schlage_provider):
         """Test mix of tagged and untagged codes."""
@@ -382,8 +444,22 @@ class TestGetUsercodes:
         codes = await schlage_provider.async_get_usercodes()
         assert codes == []
 
-    async def test_get_usercodes_tagging_failure_still_returns_code(self, schlage_provider):
-        """Test that codes are still returned even if tagging fails."""
+    async def test_get_usercodes_non_dict_response(self, schlage_provider):
+        """Test returns empty list when service returns a non-dict response."""
+        schlage_provider.hass.services.async_call = AsyncMock(return_value=None)
+        codes = await schlage_provider.async_get_usercodes()
+        assert codes == []
+
+    async def test_get_usercodes_non_dict_entity_response(self, schlage_provider):
+        """Test returns empty list when entity response wrapper is not a dict."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={"lock.schlage_front_door": "unexpected_string"}
+        )
+        codes = await schlage_provider.async_get_usercodes()
+        assert codes == []
+
+    async def test_get_usercodes_tagging_failure_skips_code(self, schlage_provider):
+        """Test that codes are not returned if tagging fails."""
         call_count = 0
 
         async def mock_service_call(*args, **kwargs):
@@ -401,10 +477,107 @@ class TestGetUsercodes:
 
         schlage_provider.hass.services.async_call = AsyncMock(side_effect=mock_service_call)
         codes = await schlage_provider.async_get_usercodes()
-        assert len(codes) == 1
-        assert codes[0].slot_num == 1
-        assert codes[0].code == "1234"
-        assert codes[0].name == "Guest"
+        # Code is not returned because tagging failed — avoids slot drift
+        assert len(codes) == 0
+
+    async def test_get_usercodes_partial_tagging_delete_failure(self, schlage_provider):
+        """Test add_code success followed by delete_code failure triggers rollback."""
+        call_count = 0
+
+        async def mock_service_call(*args, **kwargs):
+            nonlocal call_count
+            idx = call_count
+            call_count += 1
+            if idx == 0:
+                # get_codes returns untagged code
+                return {
+                    "lock.schlage_front_door": {
+                        "id1": {"name": "Guest", "code": "1234"},
+                    }
+                }
+            if idx == 1:
+                # add_code succeeds
+                return None
+            if idx == 2:
+                # delete_code (original) fails
+                raise HomeAssistantError("Delete failed after add")
+            if idx == 3:
+                # rollback: delete_code (tagged) succeeds
+                return None
+            pytest.fail(f"Unexpected service call #{idx}")
+
+        schlage_provider.hass.services.async_call = AsyncMock(side_effect=mock_service_call)
+        codes = await schlage_provider.async_get_usercodes()
+        # Code is not returned because tagging was rolled back
+        assert len(codes) == 0
+        # get_codes + add_code + delete(original fail) + delete(rollback)
+        assert call_count == 4
+
+    async def test_get_usercodes_partial_tagging_rollback_then_retag_on_next_poll(
+        self, schlage_provider
+    ):
+        """Test that a rollback on first poll allows re-tagging to succeed on the next poll."""
+        call_count = 0
+
+        async def mock_service_call(*args, **kwargs):
+            nonlocal call_count
+            idx = call_count
+            call_count += 1
+            if idx == 0:
+                # First poll: untagged code
+                return {
+                    "lock.schlage_front_door": {
+                        "id1": {"name": "Guest", "code": "1234"},
+                    }
+                }
+            if idx == 1:
+                # add_code succeeds
+                return None
+            if idx == 2:
+                # delete_code (original) fails
+                raise HomeAssistantError("Delete failed")
+            if idx == 3:
+                # rollback: delete_code (tagged) succeeds
+                return None
+            if idx == 4:
+                # Second poll: code is still untagged (rollback worked)
+                return {
+                    "lock.schlage_front_door": {
+                        "id1": {"name": "Guest", "code": "1234"},
+                    }
+                }
+            if idx == 5:
+                # Second poll: re-tagging succeeds
+                return None
+            if idx == 6:
+                # Second poll: delete original succeeds
+                return None
+            pytest.fail(f"Unexpected service call #{idx}")
+
+        schlage_provider.hass.services.async_call = AsyncMock(side_effect=mock_service_call)
+
+        # First poll: partial failure triggers rollback
+        codes_first = await schlage_provider.async_get_usercodes()
+        assert len(codes_first) == 0
+
+        # Second poll: retry tagging succeeds
+        codes_second = await schlage_provider.async_get_usercodes()
+        assert len(codes_second) == 1
+        assert codes_second[0].slot_num == 1
+        assert call_count == 7
+
+    async def test_get_usercodes_empty_name_skipped(self, schlage_provider):
+        """Test that codes with empty names are skipped during tagging."""
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "", "code": "1234"},
+                    "id2": {"name": "   ", "code": "5678"},
+                }
+            }
+        )
+        codes = await schlage_provider.async_get_usercodes()
+        assert len(codes) == 0
 
     async def test_get_usercodes_slot_gap_filled(self, schlage_provider):
         """Test untagged codes fill gaps in slot numbering."""
@@ -477,6 +650,43 @@ class TestGetUsercodes:
         assert len(codes) == 2
         slot_nums = {c.slot_num for c in codes}
         assert slot_nums == {5, 6}
+
+    async def test_get_usercodes_duplicate_tag_deduplication(self, schlage_provider):
+        """Test that duplicate tagged slots keep only the first occurrence."""
+        schlage_provider.keymaster_config_entry.data = {"start_from": 1, "slots": 6}
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "[KM:1] First", "code": "1111"},
+                    "id2": {"name": "[KM:1] Duplicate", "code": "2222"},
+                    "id3": {"name": "[KM:2] Valid", "code": "3333"},
+                }
+            }
+        )
+
+        codes = await schlage_provider.async_get_usercodes()
+        assert len(codes) == 2
+        slot_nums = [c.slot_num for c in codes]
+        assert slot_nums == [1, 2]
+        assert codes[0].name == "First"
+
+    async def test_get_usercodes_masked_pin_skips_code(self, schlage_provider):
+        """Test that codes with masked PINs are not assigned managed slots."""
+        schlage_provider.keymaster_config_entry.data = {"start_from": 1, "slots": 6}
+        schlage_provider.hass.services.async_call = AsyncMock(
+            return_value={
+                "lock.schlage_front_door": {
+                    "id1": {"name": "Masked Code", "code": "****"},
+                    "id2": {"name": "Empty Code", "code": ""},
+                }
+            }
+        )
+
+        codes = await schlage_provider.async_get_usercodes()
+        # Masked/empty PINs are skipped entirely to avoid slot drift
+        assert len(codes) == 0
+        # Service should only be called once (get_codes), no delete+add
+        assert schlage_provider.hass.services.async_call.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -552,12 +762,10 @@ class TestSetUsercode:
         assert result is True
 
         calls = schlage_provider.hass.services.async_call.call_args_list
-        # get_codes + delete_code + add_code
-        assert len(calls) == 3
-        # Delete old
-        assert calls[1].kwargs["service_data"] == {"name": "[KM:1] Guest"}
+        # get_codes + add_code only (no delete — name is unchanged)
+        assert len(calls) == 2
         # Add new — preserves friendly name since none provided
-        assert calls[2].kwargs["service_data"] == {
+        assert calls[1].kwargs["service_data"] == {
             "name": "[KM:1] Guest",
             "code": "5678",
         }
@@ -575,7 +783,7 @@ class TestSetUsercode:
         result = await schlage_provider.async_set_usercode(5, "9999")
         assert result is True
 
-        add_call = schlage_provider.hass.services.async_call.call_args_list[2]
+        add_call = schlage_provider.hass.services.async_call.call_args_list[1]
         assert add_call.kwargs["service_data"]["name"] == "[KM:5] VIP"
 
     async def test_set_service_error(self, schlage_provider):
@@ -592,6 +800,36 @@ class TestSetUsercode:
         schlage_provider.hass.services.async_call = AsyncMock(side_effect=mock_call)
         result = await schlage_provider.async_set_usercode(1, "1234")
         assert result is False
+
+    async def test_rename_delete_failure_non_fatal(self, schlage_provider):
+        """Test that a delete failure during rename is non-fatal after add succeeds."""
+        call_count = 0
+
+        async def mock_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # get_codes with tagged entry in slot 1
+                return {
+                    "lock.schlage_front_door": {
+                        "id1": {"name": "[KM:1] Guest", "code": "1234"},
+                    }
+                }
+            if call_count == 2:
+                # add_code succeeds
+                return None
+            # delete_code fails
+            raise HomeAssistantError("Schlage delete_code error")
+
+        schlage_provider.hass.services.async_call = AsyncMock(side_effect=mock_call)
+        result = await schlage_provider.async_set_usercode(1, "5678", "New Guest")
+        # Add succeeded so delete failure is non-fatal
+        assert result is True
+
+        calls = schlage_provider.hass.services.async_call.call_args_list
+        assert len(calls) == 3
+        delete_call = calls[2]
+        assert delete_call.args[:2] == ("schlage", "delete_code")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a new lock provider for Schlage WiFi smart locks, enabling Keymaster to manage code slots on Schlage locks via the `schlage` Home Assistant integration.

## Changes

- **`providers/schlage.py`**: New `SchlageProvider` implementing code slot management (get/set/clear) via Schlage actions
- **`providers/__init__.py`**: Register the Schlage provider in the provider registry
- **`manifest.json`**: Add `schlage` to `after_dependencies`, add `@tykeal` as codeowner
- **`hacs.json`**: Bump minimum HA version to `2026.4.0`
- **`tests/providers/test_schlage.py`**: Comprehensive test suite for the Schlage provider

## Notes

- Requires HA 2026.4.0+ which includes the necessary Schlage integration actions for code slot management
- Uses polling-based code slot sync (no push updates); Schlage integration does not currently expose lock events suitable for real-time subscriptions
- Follows the same provider pattern as existing Akuvox and Z-Wave JS providers