### PR TITLE
fix: trust fresh entity state over stale event label

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -495,11 +495,22 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if temp_new_state := self.hass.states.get(kmlock.lock_entity_id):
             new_state = temp_new_state.state
 
-        # Determine the intended action from event semantics first, since
-        # provider events may arrive before the entity state has updated.
-        # Fall back to entity state only when the event label is ambiguous.
+        # Disambiguate between the event label and the entity state:
+        # - If the entity state differs from our last-tracked state, the state
+        #   has genuinely changed and is authoritative. This handles providers
+        #   that derive event_label from a sensor which may be stale (e.g.
+        #   Z-Wave JS alarm_type/access_control fallback in handle_lock_state_change).
+        # - Otherwise, trust the label's semantics. Some providers (e.g. Akuvox
+        #   webhooks) fire events before the entity state updates, so falling
+        #   back to `new_state` in that case would drop the event.
+        # - If the label is ambiguous, fall back to new_state.
         label_lower = event_label.lower() if event_label else ""
-        if "unlock" in label_lower:
+        state_changed = (
+            new_state in (LockState.LOCKED, LockState.UNLOCKED) and new_state != kmlock.lock_state
+        )
+        if state_changed:
+            inferred_action = new_state
+        elif "unlock" in label_lower:
             inferred_action = LockState.UNLOCKED
         elif "lock" in label_lower and "jam" not in label_lower:
             inferred_action = LockState.LOCKED

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -119,7 +119,9 @@ async def test_handle_provider_lock_event_label_overrides_stale_state(
     updates. An "Unlocked via Keypad" event should trigger _lock_unlocked
     even if the entity still shows "locked".
     """
-    # Entity state is stale (still locked), but event says unlock happened
+    # Akuvox scenario: keymaster and entity both track LOCKED; webhook fires
+    # the "unlocked" event before the entity state updates.
+    mock_lock.lock_state = LockState.LOCKED
     hass.states.async_set(mock_lock.lock_entity_id, LockState.LOCKED)
 
     await mock_coordinator._handle_provider_lock_event(
@@ -139,6 +141,7 @@ async def test_handle_provider_lock_event_lock_label_overrides_stale_state(
 ):
     """Test that a lock label is trusted over stale unlocked entity state."""
     # Entity state is stale (still unlocked), but event says lock happened
+    mock_lock.lock_state = LockState.UNLOCKED
     hass.states.async_set(mock_lock.lock_entity_id, LockState.UNLOCKED)
 
     await mock_coordinator._handle_provider_lock_event(
@@ -146,6 +149,56 @@ async def test_handle_provider_lock_event_lock_label_overrides_stale_state(
         code_slot_num=0,
         event_label="Locked",
         action_code=4,
+    )
+
+    mock_coordinator._lock_locked.assert_called_once()
+    mock_coordinator._lock_unlocked.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_provider_lock_event_fresh_state_overrides_stale_label(
+    hass, mock_coordinator, mock_lock
+):
+    """Test that a fresh entity state is trusted over a stale event label.
+
+    Regression test for #594. The Z-Wave JS fallback path
+    (handle_lock_state_change) reads alarm_type/access_control sensors to
+    derive an event label. Some locks (e.g. Schlage BE469ZP) don't reliably
+    update those sensors for manual actions, so the label can be stale
+    (e.g. "RF Lock" left over from a previous auto-lock) while the lock's
+    entity state has genuinely just transitioned to UNLOCKED. The entity
+    state change must win, otherwise _lock_locked would run and cancel the
+    autolock timer instead of starting it.
+    """
+    # Schlage scenario: keymaster last saw LOCKED, entity just transitioned
+    # to UNLOCKED, but the derived label is a stale "RF Lock".
+    mock_lock.lock_state = LockState.LOCKED
+    hass.states.async_set(mock_lock.lock_entity_id, LockState.UNLOCKED)
+
+    await mock_coordinator._handle_provider_lock_event(
+        kmlock=mock_lock,
+        code_slot_num=0,
+        event_label="RF Lock",
+        action_code=24,
+    )
+
+    mock_coordinator._lock_unlocked.assert_called_once()
+    mock_coordinator._lock_locked.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_provider_lock_event_fresh_state_overrides_unlock_label(
+    hass, mock_coordinator, mock_lock
+):
+    """Mirror of the Schlage regression for the unlock-label-but-now-locked case."""
+    mock_lock.lock_state = LockState.UNLOCKED
+    hass.states.async_set(mock_lock.lock_entity_id, LockState.LOCKED)
+
+    await mock_coordinator._handle_provider_lock_event(
+        kmlock=mock_lock,
+        code_slot_num=0,
+        event_label="RF Unlock",
+        action_code=25,
     )
 
     mock_coordinator._lock_locked.assert_called_once()


### PR DESCRIPTION
## Summary

- Fixes an autolock regression on Z-Wave locks (e.g. Schlage BE469ZP) reported in #594 and triggered by the Akuvox provider PR (commit `c190b46`).
- Disambiguates event-label vs. entity-state using keymaster's last-committed `kmlock.lock_state`: if the entity has changed since then, treat it as authoritative; otherwise keep trusting the label (the Akuvox webhook-arrives-before-state case).
- Tightens the two existing stale-state regression tests so they actually model the Akuvox ordering, and adds two new tests for the Schlage regression in both directions.

## Why

After `c190b46` in the Akuvox PR, `_handle_provider_lock_event` started trusting the event label over the entity state. That's correct for Akuvox (webhook fires before the lock's state changes in HA) but wrong for Z-Wave locks that rely on the `handle_lock_state_change` fallback in `providers/zwave_js.py`:

- Locks like the BE469ZP don't reliably fire `ZWAVE_JS_NOTIFICATION_EVENT`, so keymaster falls back to reading the `alarm_type` / `access_control` sensors.
- Those sensors can stick at the previous event's code (e.g. `alarm_type == 24` = "RF Lock" from an earlier auto-lock) even after a manual unlock.
- The staleness guard in the provider requires `alarm_level == 0`, which some locks never satisfy, so the stale label makes it through.
- The coordinator then sees `new_state=unlocked` but `event_label="RF Lock"` → infers LOCKED → calls `_lock_locked` → cancels the autolock timer.

Reporter symptom from #594: autolock timer never appears after unlock, and a spurious "locked" event fires when the real state is unlocked.

## Fix

```python
state_changed = (
    new_state in (LockState.LOCKED, LockState.UNLOCKED)
    and new_state != kmlock.lock_state
)
if state_changed:
    inferred_action = new_state
elif "unlock" in label_lower:
    ...
```

- `state_changed` means the entity is now in a lock state that differs from what keymaster last committed — the state change is fresh and the label may be stale (Schlage case) → trust state.
- Otherwise, the entity hasn't moved yet — the label is the fresher signal (Akuvox case) → keep the label-first behavior.

## Test plan

- [x] `pytest --no-cov -q` — 648 passed
- [x] New test covers the Schlage case: `kmlock.lock_state=LOCKED`, `new_state=UNLOCKED`, `event_label="RF Lock"` → `_lock_unlocked` wins.
- [x] Mirror test covers the inverse: `kmlock.lock_state=UNLOCKED`, `new_state=LOCKED`, `event_label="RF Unlock"` → `_lock_locked` wins.
- [x] Updated Akuvox regression tests to set `kmlock.lock_state` so the "entity is stale" claim actually matches what keymaster last saw.
- [ ] Reporter in #594 to verify on their BE469ZP after next release.

Fixes #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)