### PR TITLE
fix: respect hide_pins on child lock parent-view dashboard

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -210,6 +210,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         advanced_date_range=config_entry.data[CONF_ADVANCED_DATE_RANGE],
         advanced_day_of_week=config_entry.data[CONF_ADVANCED_DAY_OF_WEEK],
         door_sensor=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
+        hide_pins=config_entry.data.get(CONF_HIDE_PINS, False),
     )
 
     return True

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -211,6 +211,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         advanced_date_range=config_entry.data[CONF_ADVANCED_DATE_RANGE],
         advanced_day_of_week=config_entry.data[CONF_ADVANCED_DAY_OF_WEEK],
         door_sensor=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
+        hide_pins=config_entry.data.get(CONF_HIDE_PINS, False),
     )
 
     return True

--- a/custom_components/keymaster/lovelace.py
+++ b/custom_components/keymaster/lovelace.py
@@ -713,60 +713,97 @@ def _generate_parent_view_card_ll_config(
     When parent_pin_entity_id is provided, the PIN row is replaced with a
     read-only markdown card that indicates whether the slot is occupied.
     """
-    pin_row: MutableMapping[str, Any]
-    if parent_pin_entity_id:
-        pin_row = {
-            "type": "markdown",
-            "content": (
-                f"{{% set pin = states('{parent_pin_entity_id}') %}}"
-                "**PIN:** "
-                "{% if pin not in ['unknown', 'unavailable', 'None', ''] %}"
-                "Slot occupied"
-                "{% else %}"
-                "Empty"
-                "{% endif %}"
-            ),
-        }
-    else:
-        pin_row = _generate_entity_card_ll_config(
-            code_slot_num, "text", "pin", "PIN", parent=True, type_="simple-entity"
-        )
-
     entities: list[MutableMapping[str, Any]] = [
         _generate_entity_card_ll_config(
             code_slot_num, "text", "name", "Name", parent=True, type_="simple-entity"
         ),
-        pin_row,
-        _generate_entity_card_ll_config(
-            code_slot_num, "switch", "enabled", "Enabled", parent=True, type_="simple-entity"
-        ),
-        _generate_entity_card_ll_config(code_slot_num, "binary_sensor", "active", "Active"),
-        _generate_entity_card_ll_config(code_slot_num, "event", "last_used", "Last Used"),
-        _generate_entity_card_ll_config(code_slot_num, "sensor", "synced", "Sync Status"),
-        _generate_entity_card_ll_config(
-            code_slot_num, "switch", "override_parent", "Override Parent"
-        ),
-        _generate_entity_card_ll_config(code_slot_num, "switch", "notifications", "Notifications"),
-        _generate_entity_card_ll_config(
-            code_slot_num,
-            "switch",
-            "accesslimit_count_enabled",
-            "Limit by Number of Uses",
-            parent=True,
-            type_="simple-entity",
-        ),
-        _generate_conditional_card_ll_config(
-            code_slot_num,
-            "number",
-            "accesslimit_count",
-            "Uses Remaining",
-            [_generate_state_condition(code_slot_num, "accesslimit_count_enabled", parent=True)],
-            parent=True,
-            type_="simple-entity",
-        ),
-        *(_generate_date_range_entities(code_slot_num, parent=True) if advanced_date_range else ()),
-        *(_generate_dow_entities(code_slot_num, parent=True) if advanced_day_of_week else ()),
     ]
+
+    # Only include PIN as an entity row when not hiding; when hiding, a
+    # separate markdown card is added via vertical-stack below.
+    if not parent_pin_entity_id:
+        entities.append(
+            _generate_entity_card_ll_config(
+                code_slot_num, "text", "pin", "PIN", parent=True, type_="simple-entity"
+            )
+        )
+
+    entities.extend(
+        [
+            _generate_entity_card_ll_config(
+                code_slot_num, "switch", "enabled", "Enabled", parent=True, type_="simple-entity"
+            ),
+            _generate_entity_card_ll_config(code_slot_num, "binary_sensor", "active", "Active"),
+            _generate_entity_card_ll_config(code_slot_num, "event", "last_used", "Last Used"),
+            _generate_entity_card_ll_config(code_slot_num, "sensor", "synced", "Sync Status"),
+            _generate_entity_card_ll_config(
+                code_slot_num, "switch", "override_parent", "Override Parent"
+            ),
+            _generate_entity_card_ll_config(
+                code_slot_num, "switch", "notifications", "Notifications"
+            ),
+            _generate_entity_card_ll_config(
+                code_slot_num,
+                "switch",
+                "accesslimit_count_enabled",
+                "Limit by Number of Uses",
+                parent=True,
+                type_="simple-entity",
+            ),
+            _generate_conditional_card_ll_config(
+                code_slot_num,
+                "number",
+                "accesslimit_count",
+                "Uses Remaining",
+                [
+                    _generate_state_condition(
+                        code_slot_num, "accesslimit_count_enabled", parent=True
+                    )
+                ],
+                parent=True,
+                type_="simple-entity",
+            ),
+            *(
+                _generate_date_range_entities(code_slot_num, parent=True)
+                if advanced_date_range
+                else ()
+            ),
+            *(_generate_dow_entities(code_slot_num, parent=True) if advanced_day_of_week else ()),
+        ]
+    )
+
+    entities_card: MutableMapping[str, Any] = {
+        "type": "entities",
+        "show_header_toggle": False,
+        "state_color": True,
+        "entities": entities,
+    }
+
+    # When hiding PINs, wrap in a vertical-stack: the entities card (without
+    # the PIN row) plus a markdown card showing slot occupancy. Markdown is a
+    # card type and cannot be used as an entities-row, so vertical-stack is
+    # needed to combine them.
+    if parent_pin_entity_id:
+        inner_card: MutableMapping[str, Any] = {
+            "type": "vertical-stack",
+            "cards": [
+                entities_card,
+                {
+                    "type": "markdown",
+                    "content": (
+                        f"{{% set pin = states('{parent_pin_entity_id}') %}}"
+                        "**PIN:** "
+                        "{% if pin not in ['unknown', 'unavailable', 'None', ''] %}"
+                        "Slot occupied"
+                        "{% else %}"
+                        "Empty"
+                        "{% endif %}"
+                    ),
+                },
+            ],
+        }
+    else:
+        inner_card = entities_card
 
     return {
         "type": "conditional",
@@ -775,12 +812,7 @@ def _generate_parent_view_card_ll_config(
                 code_slot_num, "override_parent", state="off", needs_type=True
             )
         ],
-        "card": {
-            "type": "entities",
-            "show_header_toggle": False,
-            "state_color": True,
-            "entities": entities,
-        },
+        "card": inner_card,
     }
 
 

--- a/custom_components/keymaster/lovelace.py
+++ b/custom_components/keymaster/lovelace.py
@@ -84,19 +84,36 @@ def generate_section_config(
     advanced_date_range: bool,
     advanced_day_of_week: bool,
     parent_config_entry_id: str | None = None,
+    hide_pins: bool = False,
 ) -> MutableMapping[str, Any]:
     """Generate the Lovelace section configuration for a single code slot.
 
     Returns the section configuration as a dict (for WebSocket/strategy use).
     """
-    generate_dict_func = (
-        _generate_child_code_slot_dict if parent_config_entry_id else _generate_code_slot_dict
-    )
-    code_slot_dict: MutableMapping[str, Any] = generate_dict_func(
-        code_slot_num=slot_num,
-        advanced_date_range=advanced_date_range,
-        advanced_day_of_week=advanced_day_of_week,
-    )
+    # For child locks with hide_pins, resolve the parent PIN entity ID so the
+    # parent-view card can render a masked markdown card instead of simple-entity.
+    parent_pin_entity_id: str | None = None
+    if parent_config_entry_id and hide_pins:
+        parent_pin_entity_id = resolve_entity_id(
+            hass,
+            keymaster_config_entry_id,
+            parent_config_entry_id,
+            f"parent.text.code_slots:{slot_num}.pin",
+        )
+
+    if parent_config_entry_id:
+        code_slot_dict: MutableMapping[str, Any] = _generate_child_code_slot_dict(
+            code_slot_num=slot_num,
+            advanced_date_range=advanced_date_range,
+            advanced_day_of_week=advanced_day_of_week,
+            parent_pin_entity_id=parent_pin_entity_id,
+        )
+    else:
+        code_slot_dict = _generate_code_slot_dict(
+            code_slot_num=slot_num,
+            advanced_date_range=advanced_date_range,
+            advanced_day_of_week=advanced_day_of_week,
+        )
 
     mapped_section: MutableMapping[str, Any] | list[MutableMapping[str, Any]] = (
         _map_property_to_entity_id(
@@ -126,6 +143,7 @@ def generate_view_config(
     advanced_day_of_week: bool,
     door_sensor: str | None = None,
     parent_config_entry_id: str | None = None,
+    hide_pins: bool = False,
 ) -> MutableMapping[str, Any]:
     """Generate the complete Lovelace view configuration for a keymaster lock.
 
@@ -147,6 +165,7 @@ def generate_view_config(
             advanced_date_range=advanced_date_range,
             advanced_day_of_week=advanced_day_of_week,
             parent_config_entry_id=parent_config_entry_id,
+            hide_pins=hide_pins,
         )
         for slot_num in range(code_slot_start, code_slot_start + code_slots)
     ]
@@ -172,6 +191,7 @@ async def async_generate_lovelace(
     advanced_day_of_week: bool,
     door_sensor: str | None = None,
     parent_config_entry_id: str | None = None,
+    hide_pins: bool = False,
 ) -> None:
     """Create the lovelace file for the keymaster lock."""
     folder: str = hass.config.path("custom_components", DOMAIN, "lovelace")
@@ -188,6 +208,7 @@ async def async_generate_lovelace(
         advanced_day_of_week=advanced_day_of_week,
         door_sensor=door_sensor,
         parent_config_entry_id=parent_config_entry_id,
+        hide_pins=hide_pins,
     )
     lovelace: list[MutableMapping[str, Any]] = [view_config]
 
@@ -259,6 +280,17 @@ def _write_lovelace_yaml(folder: str, filename: str, lovelace: Any) -> None:
     return
 
 
+def resolve_entity_id(
+    hass: HomeAssistant,
+    keymaster_config_entry_id: str,
+    parent_config_entry_id: str | None,
+    prop: str,
+) -> str | None:
+    """Resolve a keymaster property path to a real HA entity ID."""
+    entity_registry: er.EntityRegistry = er.async_get(hass)
+    return _get_entity_id(entity_registry, keymaster_config_entry_id, parent_config_entry_id, prop)
+
+
 def _map_property_to_entity_id(
     hass: HomeAssistant,
     lovelace_entities: list[MutableMapping[str, Any]] | MutableMapping[str, Any],
@@ -266,10 +298,6 @@ def _map_property_to_entity_id(
     parent_config_entry_id: str | None = None,
 ) -> MutableMapping[str, Any] | list[MutableMapping[str, Any]]:
     """Update all the entities with the entity_id for the keymaster lock."""
-    # _LOGGER.debug(
-    #     f"[map_property_to_entity_id] keymaster_config_entry_id: {keymaster_config_entry_id}, "
-    #     f"parent_config_entry_id: {parent_config_entry_id}"
-    # )
     entity_registry: er.EntityRegistry = er.async_get(hass)
     lovelace_list: list[MutableMapping[str, Any]] | MutableMapping[str, Any] = _process_entities(
         lovelace_entities,
@@ -674,19 +702,41 @@ def _generate_date_range_entities(
 
 
 def _generate_parent_view_card_ll_config(
-    code_slot_num: int, advanced_date_range: bool, advanced_day_of_week: bool
+    code_slot_num: int,
+    advanced_date_range: bool,
+    advanced_day_of_week: bool,
+    parent_pin_entity_id: str | None = None,
 ) -> MutableMapping[str, Any]:
     """Build the parent-view conditional card for a child lock code slot.
 
     Shows parent's settings alongside child's status when override_parent is off.
+    When parent_pin_entity_id is provided, the PIN row is replaced with a
+    read-only markdown card that indicates whether the slot is occupied.
     """
+    pin_row: MutableMapping[str, Any]
+    if parent_pin_entity_id:
+        pin_row = {
+            "type": "markdown",
+            "content": (
+                f"{{% set pin = states('{parent_pin_entity_id}') %}}"
+                "**PIN:** "
+                "{% if pin not in ['unknown', 'unavailable', 'None', ''] %}"
+                "Slot occupied"
+                "{% else %}"
+                "Empty"
+                "{% endif %}"
+            ),
+        }
+    else:
+        pin_row = _generate_entity_card_ll_config(
+            code_slot_num, "text", "pin", "PIN", parent=True, type_="simple-entity"
+        )
+
     entities: list[MutableMapping[str, Any]] = [
         _generate_entity_card_ll_config(
             code_slot_num, "text", "name", "Name", parent=True, type_="simple-entity"
         ),
-        _generate_entity_card_ll_config(
-            code_slot_num, "text", "pin", "PIN", parent=True, type_="simple-entity"
-        ),
+        pin_row,
         _generate_entity_card_ll_config(
             code_slot_num, "switch", "enabled", "Enabled", parent=True, type_="simple-entity"
         ),
@@ -735,7 +785,10 @@ def _generate_parent_view_card_ll_config(
 
 
 def _generate_child_code_slot_dict(
-    code_slot_num: int, advanced_date_range: bool, advanced_day_of_week: bool
+    code_slot_num: int,
+    advanced_date_range: bool,
+    advanced_day_of_week: bool,
+    parent_pin_entity_id: str | None = None,
 ) -> MutableMapping[str, Any]:
     """Build the dict for the code slot of a child keymaster lock."""
     return {
@@ -743,7 +796,10 @@ def _generate_child_code_slot_dict(
         "cards": [
             _generate_header_ll_config(code_slot_num),
             _generate_parent_view_card_ll_config(
-                code_slot_num, advanced_date_range, advanced_day_of_week
+                code_slot_num,
+                advanced_date_range,
+                advanced_day_of_week,
+                parent_pin_entity_id=parent_pin_entity_id,
             ),
             {
                 "type": "conditional",

--- a/custom_components/keymaster/services.py
+++ b/custom_components/keymaster/services.py
@@ -10,6 +10,7 @@ from .const import (
     CONF_ADVANCED_DATE_RANGE,
     CONF_ADVANCED_DAY_OF_WEEK,
     CONF_DOOR_SENSOR_ENTITY_ID,
+    CONF_HIDE_PINS,
     CONF_LOCK_ENTITY_ID,
     CONF_LOCK_NAME,
     CONF_PARENT_ENTRY_ID,
@@ -83,6 +84,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 advanced_date_range=config_entry.data[CONF_ADVANCED_DATE_RANGE],
                 advanced_day_of_week=config_entry.data[CONF_ADVANCED_DAY_OF_WEEK],
                 door_sensor=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
+                hide_pins=config_entry.data.get(CONF_HIDE_PINS, False),
             )
 
     # hass.services.async_register(

--- a/custom_components/keymaster/websocket.py
+++ b/custom_components/keymaster/websocket.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_ADVANCED_DATE_RANGE,
     CONF_ADVANCED_DAY_OF_WEEK,
     CONF_DOOR_SENSOR_ENTITY_ID,
+    CONF_HIDE_PINS,
     CONF_LOCK_ENTITY_ID,
     CONF_LOCK_NAME,
     CONF_PARENT_ENTRY_ID,
@@ -205,6 +206,7 @@ async def ws_get_section_config(
         advanced_date_range=config_entry.data.get(CONF_ADVANCED_DATE_RANGE, True),
         advanced_day_of_week=config_entry.data.get(CONF_ADVANCED_DAY_OF_WEEK, True),
         parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
+        hide_pins=config_entry.data.get(CONF_HIDE_PINS, False),
     )
 
     connection.send_result(msg["id"], section_config)

--- a/tests/test_lovelace.py
+++ b/tests/test_lovelace.py
@@ -727,21 +727,26 @@ async def test_generate_view_config_child_lock_hide_pins(hass: HomeAssistant):
             hide_pins=True,
         )
 
-    # Get parent view card (second card in the grid, after the heading)
+    # Get parent view conditional card (second card in the grid, after heading)
     parent_card = view["sections"][0]["cards"][1]
-    parent_entities = parent_card["card"]["entities"]
 
-    # PIN should NOT be a simple-entity anymore
+    # When hide_pins=True, the conditional wraps a vertical-stack
+    inner = parent_card["card"]
+    assert inner["type"] == "vertical-stack"
+
+    # First card in the stack is the entities card (without PIN row)
+    entities_card = inner["cards"][0]
+    assert entities_card["type"] == "entities"
     simple_entity_names = [
-        e.get("name") for e in parent_entities if e.get("type") == "simple-entity"
+        e.get("name") for e in entities_card["entities"] if e.get("type") == "simple-entity"
     ]
     assert "PIN" not in simple_entity_names
 
-    # Instead, there should be a markdown card in the entities list
-    markdown_cards = [e for e in parent_entities if e.get("type") == "markdown"]
-    assert len(markdown_cards) == 1
-    assert "Slot occupied" in markdown_cards[0]["content"]
-    assert "Empty" in markdown_cards[0]["content"]
+    # Second card in the stack is the markdown card
+    markdown_card = inner["cards"][1]
+    assert markdown_card["type"] == "markdown"
+    assert "Slot occupied" in markdown_card["content"]
+    assert "Empty" in markdown_card["content"]
 
 
 async def test_generate_view_config_child_lock_no_hide_pins(hass: HomeAssistant):

--- a/tests/test_lovelace.py
+++ b/tests/test_lovelace.py
@@ -706,6 +706,80 @@ async def test_generate_view_config_child_lock_parent_entities(hass: HomeAssista
     assert "Enabled" in names
 
 
+async def test_generate_view_config_child_lock_hide_pins(hass: HomeAssistant):
+    """Test child lock parent-view replaces PIN with markdown card when hide_pins is True."""
+    mock_registry = _create_mock_registry()
+
+    with patch(
+        "custom_components.keymaster.lovelace.er.async_get",
+        return_value=mock_registry,
+    ):
+        view = generate_view_config(
+            hass=hass,
+            kmlock_name="backdoor",
+            keymaster_config_entry_id="child_entry_id",
+            code_slot_start=1,
+            code_slots=1,
+            lock_entity="lock.backdoor",
+            advanced_date_range=False,
+            advanced_day_of_week=False,
+            parent_config_entry_id="parent_entry_id",
+            hide_pins=True,
+        )
+
+    # Get parent view card (second card in the grid, after the heading)
+    parent_card = view["sections"][0]["cards"][1]
+    parent_entities = parent_card["card"]["entities"]
+
+    # PIN should NOT be a simple-entity anymore
+    simple_entity_names = [
+        e.get("name") for e in parent_entities if e.get("type") == "simple-entity"
+    ]
+    assert "PIN" not in simple_entity_names
+
+    # Instead, there should be a markdown card in the entities list
+    markdown_cards = [e for e in parent_entities if e.get("type") == "markdown"]
+    assert len(markdown_cards) == 1
+    assert "Slot occupied" in markdown_cards[0]["content"]
+    assert "Empty" in markdown_cards[0]["content"]
+
+
+async def test_generate_view_config_child_lock_no_hide_pins(hass: HomeAssistant):
+    """Test child lock parent-view keeps simple-entity PIN when hide_pins is False."""
+    mock_registry = _create_mock_registry()
+
+    with patch(
+        "custom_components.keymaster.lovelace.er.async_get",
+        return_value=mock_registry,
+    ):
+        view = generate_view_config(
+            hass=hass,
+            kmlock_name="backdoor",
+            keymaster_config_entry_id="child_entry_id",
+            code_slot_start=1,
+            code_slots=1,
+            lock_entity="lock.backdoor",
+            advanced_date_range=False,
+            advanced_day_of_week=False,
+            parent_config_entry_id="parent_entry_id",
+            hide_pins=False,
+        )
+
+    # Get parent view card
+    parent_card = view["sections"][0]["cards"][1]
+    parent_entities = parent_card["card"]["entities"]
+
+    # PIN should still be a simple-entity
+    simple_entity_names = [
+        e.get("name") for e in parent_entities if e.get("type") == "simple-entity"
+    ]
+    assert "PIN" in simple_entity_names
+
+    # No markdown cards
+    markdown_cards = [e for e in parent_entities if e.get("type") == "markdown"]
+    assert len(markdown_cards) == 0
+
+
 async def test_generate_view_config_child_lock_override_parent(hass: HomeAssistant):
     """Test child lock has override parent switch somewhere in the view."""
     mock_registry = _create_mock_registry()
@@ -889,6 +963,7 @@ async def test_async_generate_lovelace_delegates_to_view_config(hass: HomeAssist
             advanced_day_of_week=True,
             door_sensor="binary_sensor.door",
             parent_config_entry_id="parent_id",
+            hide_pins=False,
         )
 
         # Verify written data contains the view config


### PR DESCRIPTION
## Summary

- Fixes #597: child lock dashboard showed parent's PINs in plaintext even when `hide_pins` was enabled on both locks.
- When `hide_pins` is true, removes the `simple-entity` PIN row from the parent-view entities card and adds a read-only Jinja2 markdown card (via `vertical-stack`) showing "Slot occupied" / "Empty" instead.
- Extracts `resolve_entity_id()` from the `_map_property_to_entity_id` pipeline so callers can resolve individual property paths to real HA entity IDs without the full recursive mapping.

## Why

The child lock's parent-view card (shown when `override_parent` is off) used `type: simple-entity` for all parent entities including the PIN. The `simple-entity` card type renders the raw entity state, bypassing `TextMode.PASSWORD` masking — so PINs were visible on the child dashboard even when `hide_pins` was enabled.

The default text entity row can't be used either because it has inline editing that `tap_action: none` doesn't block. A `markdown` card is read-only by nature, uses no custom card dependencies, and uses Jinja2 to show occupancy status without revealing the PIN value. Since `markdown` is a card type (not a valid entities-row type), it's placed alongside the entities card in a `vertical-stack`.

## Test plan

- [x] `pytest --no-cov -q` — 648 passed
- [x] `test_generate_view_config_child_lock_hide_pins` — verifies `vertical-stack` structure: entities card (no PIN row) + markdown card with "Slot occupied"/"Empty" template
- [x] `test_generate_view_config_child_lock_no_hide_pins` — verifies entities card keeps `simple-entity` PIN row, no vertical-stack
- [ ] Manual verification on a child lock dashboard with `hide_pins` enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)