### PR TITLE
fix: parent/child lock sync resolution

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -128,10 +128,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if updated_config != config_entry.data:
         hass.config_entries.async_update_entry(config_entry, data=updated_config)
 
-    # Use normalized values for the rest of setup so runtime objects are created
-    # with resolved parent relationships in the same setup pass.
-    setup_data = updated_config
-
     # _LOGGER.debug(f"[init async_setup_entry] updated config_entry.data: {config_entry.data}")
 
     await async_setup_services(hass)
@@ -149,7 +145,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     device_registry = dr.async_get(hass)
 
     via_device: tuple[str, str] | None = None
-    if parent_entry_id := setup_data.get(CONF_PARENT_ENTRY_ID):
+    if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
         via_device = (DOMAIN, parent_entry_id)
 
     # _LOGGER.debug(
@@ -162,7 +158,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, config_entry.entry_id)},
-        name=setup_data.get(CONF_LOCK_NAME),
+        name=config_entry.data.get(CONF_LOCK_NAME),
         configuration_url="https://github.com/FutureTense/keymaster",
         via_device=via_device,
     )
@@ -171,8 +167,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     code_slots: MutableMapping[int, KeymasterCodeSlot] = {}
     for x in range(
-        setup_data[CONF_START],
-        setup_data[CONF_START] + setup_data[CONF_SLOTS],
+        config_entry.data[CONF_START],
+        config_entry.data[CONF_START] + config_entry.data[CONF_SLOTS],
     ):
         dow_slots: MutableMapping[int, KeymasterCodeSlotDayOfWeek] = {}
         for i, dow in enumerate(DAY_NAMES):
@@ -180,40 +176,43 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         code_slots[x] = KeymasterCodeSlot(number=x, accesslimit_day_of_week=dow_slots)
 
     kmlock = KeymasterLock(
-        lock_name=setup_data[CONF_LOCK_NAME],
-        lock_entity_id=setup_data[CONF_LOCK_ENTITY_ID],
+        lock_name=config_entry.data[CONF_LOCK_NAME],
+        lock_entity_id=config_entry.data[CONF_LOCK_ENTITY_ID],
         keymaster_config_entry_id=config_entry.entry_id,
-        alarm_level_or_user_code_entity_id=setup_data.get(CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID),
-        alarm_type_or_access_control_entity_id=setup_data.get(
+        alarm_level_or_user_code_entity_id=config_entry.data.get(
+            CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID
+        ),
+        alarm_type_or_access_control_entity_id=config_entry.data.get(
             CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID
         ),
-        door_sensor_entity_id=setup_data.get(CONF_DOOR_SENSOR_ENTITY_ID),
-        number_of_code_slots=setup_data[CONF_SLOTS],
-        starting_code_slot=setup_data[CONF_START],
+        door_sensor_entity_id=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
+        number_of_code_slots=config_entry.data[CONF_SLOTS],
+        starting_code_slot=config_entry.data[CONF_START],
         code_slots=code_slots,
-        parent_name=setup_data.get(CONF_PARENT),
-        parent_config_entry_id=setup_data.get(CONF_PARENT_ENTRY_ID),
-        notify_script_name=setup_data.get(CONF_NOTIFY_SCRIPT_NAME),
+        parent_name=config_entry.data.get(CONF_PARENT),
+        parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
+        notify_script_name=config_entry.data.get(CONF_NOTIFY_SCRIPT_NAME),
     )
 
+    needs_update = config_entry.entry_id in coordinator.kmlocks
     try:
-        await coordinator.add_lock(kmlock=kmlock, update=True)
+        await coordinator.add_lock(kmlock=kmlock, update=needs_update)
     except asyncio.exceptions.CancelledError as e:
         _LOGGER.error("Timeout on add_lock. %s: %s", e.__class__.__qualname__, e)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     await async_generate_lovelace(
         hass=hass,
-        kmlock_name=setup_data[CONF_LOCK_NAME],
+        kmlock_name=config_entry.data[CONF_LOCK_NAME],
         keymaster_config_entry_id=config_entry.entry_id,
-        parent_config_entry_id=setup_data.get(CONF_PARENT_ENTRY_ID),
-        code_slot_start=setup_data[CONF_START],
-        code_slots=setup_data[CONF_SLOTS],
-        lock_entity=setup_data[CONF_LOCK_ENTITY_ID],
-        advanced_date_range=setup_data[CONF_ADVANCED_DATE_RANGE],
-        advanced_day_of_week=setup_data[CONF_ADVANCED_DAY_OF_WEEK],
-        door_sensor=setup_data.get(CONF_DOOR_SENSOR_ENTITY_ID),
-        hide_pins=setup_data.get(CONF_HIDE_PINS, False),
+        parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
+        code_slot_start=config_entry.data[CONF_START],
+        code_slots=config_entry.data[CONF_SLOTS],
+        lock_entity=config_entry.data[CONF_LOCK_ENTITY_ID],
+        advanced_date_range=config_entry.data[CONF_ADVANCED_DATE_RANGE],
+        advanced_day_of_week=config_entry.data[CONF_ADVANCED_DAY_OF_WEEK],
+        door_sensor=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
+        hide_pins=config_entry.data.get(CONF_HIDE_PINS, False),
     )
 
     return True

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -183,9 +183,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         lock_name=setup_data[CONF_LOCK_NAME],
         lock_entity_id=setup_data[CONF_LOCK_ENTITY_ID],
         keymaster_config_entry_id=config_entry.entry_id,
-        alarm_level_or_user_code_entity_id=setup_data.get(
-            CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID
-        ),
+        alarm_level_or_user_code_entity_id=setup_data.get(CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID),
         alarm_type_or_access_control_entity_id=setup_data.get(
             CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID
         ),

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -110,7 +110,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         updated_config[CONF_PARENT_ENTRY_ID] = None
     elif updated_config.get(CONF_PARENT_ENTRY_ID) is None:
         for entry in hass.config_entries.async_entries(DOMAIN):
-            if updated_config.get(CONF_PARENT) == entry.data.get(CONF_LOCK_NAME):
+            if updated_config.get(CONF_PARENT) in (entry.title, entry.data.get(CONF_LOCK_NAME)):
                 updated_config[CONF_PARENT_ENTRY_ID] = entry.entry_id
                 break
 
@@ -127,6 +127,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     if updated_config != config_entry.data:
         hass.config_entries.async_update_entry(config_entry, data=updated_config)
+
+    # Use normalized values for the rest of setup so runtime objects are created
+    # with resolved parent relationships in the same setup pass.
+    setup_data = updated_config
 
     # _LOGGER.debug(f"[init async_setup_entry] updated config_entry.data: {config_entry.data}")
 
@@ -145,7 +149,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     device_registry = dr.async_get(hass)
 
     via_device: tuple[str, str] | None = None
-    if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
+    if parent_entry_id := setup_data.get(CONF_PARENT_ENTRY_ID):
         via_device = (DOMAIN, parent_entry_id)
 
     # _LOGGER.debug(
@@ -158,7 +162,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, config_entry.entry_id)},
-        name=config_entry.data.get(CONF_LOCK_NAME),
+        name=setup_data.get(CONF_LOCK_NAME),
         configuration_url="https://github.com/FutureTense/keymaster",
         via_device=via_device,
     )
@@ -167,8 +171,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     code_slots: MutableMapping[int, KeymasterCodeSlot] = {}
     for x in range(
-        config_entry.data[CONF_START],
-        config_entry.data[CONF_START] + config_entry.data[CONF_SLOTS],
+        setup_data[CONF_START],
+        setup_data[CONF_START] + setup_data[CONF_SLOTS],
     ):
         dow_slots: MutableMapping[int, KeymasterCodeSlotDayOfWeek] = {}
         for i, dow in enumerate(DAY_NAMES):
@@ -176,42 +180,42 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         code_slots[x] = KeymasterCodeSlot(number=x, accesslimit_day_of_week=dow_slots)
 
     kmlock = KeymasterLock(
-        lock_name=config_entry.data[CONF_LOCK_NAME],
-        lock_entity_id=config_entry.data[CONF_LOCK_ENTITY_ID],
+        lock_name=setup_data[CONF_LOCK_NAME],
+        lock_entity_id=setup_data[CONF_LOCK_ENTITY_ID],
         keymaster_config_entry_id=config_entry.entry_id,
-        alarm_level_or_user_code_entity_id=config_entry.data.get(
+        alarm_level_or_user_code_entity_id=setup_data.get(
             CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID
         ),
-        alarm_type_or_access_control_entity_id=config_entry.data.get(
+        alarm_type_or_access_control_entity_id=setup_data.get(
             CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID
         ),
-        door_sensor_entity_id=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
-        number_of_code_slots=config_entry.data[CONF_SLOTS],
-        starting_code_slot=config_entry.data[CONF_START],
+        door_sensor_entity_id=setup_data.get(CONF_DOOR_SENSOR_ENTITY_ID),
+        number_of_code_slots=setup_data[CONF_SLOTS],
+        starting_code_slot=setup_data[CONF_START],
         code_slots=code_slots,
-        parent_name=config_entry.data.get(CONF_PARENT),
-        parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
-        notify_script_name=config_entry.data.get(CONF_NOTIFY_SCRIPT_NAME),
+        parent_name=setup_data.get(CONF_PARENT),
+        parent_config_entry_id=setup_data.get(CONF_PARENT_ENTRY_ID),
+        notify_script_name=setup_data.get(CONF_NOTIFY_SCRIPT_NAME),
     )
 
     try:
-        await coordinator.add_lock(kmlock=kmlock)
+        await coordinator.add_lock(kmlock=kmlock, update=True)
     except asyncio.exceptions.CancelledError as e:
         _LOGGER.error("Timeout on add_lock. %s: %s", e.__class__.__qualname__, e)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     await async_generate_lovelace(
         hass=hass,
-        kmlock_name=config_entry.data[CONF_LOCK_NAME],
+        kmlock_name=setup_data[CONF_LOCK_NAME],
         keymaster_config_entry_id=config_entry.entry_id,
-        parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
-        code_slot_start=config_entry.data[CONF_START],
-        code_slots=config_entry.data[CONF_SLOTS],
-        lock_entity=config_entry.data[CONF_LOCK_ENTITY_ID],
-        advanced_date_range=config_entry.data[CONF_ADVANCED_DATE_RANGE],
-        advanced_day_of_week=config_entry.data[CONF_ADVANCED_DAY_OF_WEEK],
-        door_sensor=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
-        hide_pins=config_entry.data.get(CONF_HIDE_PINS, False),
+        parent_config_entry_id=setup_data.get(CONF_PARENT_ENTRY_ID),
+        code_slot_start=setup_data[CONF_START],
+        code_slots=setup_data[CONF_SLOTS],
+        lock_entity=setup_data[CONF_LOCK_ENTITY_ID],
+        advanced_date_range=setup_data[CONF_ADVANCED_DATE_RANGE],
+        advanced_day_of_week=setup_data[CONF_ADVANCED_DAY_OF_WEEK],
+        door_sensor=setup_data.get(CONF_DOOR_SENSOR_ENTITY_ID),
+        hide_pins=setup_data.get(CONF_HIDE_PINS, False),
     )
 
     return True

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -481,18 +481,15 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
     async def _rebuild_lock_relationships(self) -> None:
         for keymaster_config_entry_id, kmlock in self.kmlocks.items():
-            if (
-                kmlock.parent_config_entry_id is not None
-                and kmlock.parent_config_entry_id in self.kmlocks
-            ):
-                parent_lock = self.kmlocks[kmlock.parent_config_entry_id]
+            parent_config_entry_id = kmlock.parent_config_entry_id
+            if parent_config_entry_id is not None and parent_config_entry_id in self.kmlocks:
+                parent_lock = self.kmlocks[parent_config_entry_id]
                 if keymaster_config_entry_id not in parent_lock.child_config_entry_ids:
                     parent_lock.child_config_entry_ids.append(keymaster_config_entry_id)
             elif kmlock.parent_name is not None:
                 for parent_config_entry_id, parent_lock in self.kmlocks.items():
                     if kmlock.parent_name == parent_lock.lock_name:
-                        if kmlock.parent_config_entry_id is None:
-                            kmlock.parent_config_entry_id = parent_config_entry_id
+                        kmlock.parent_config_entry_id = parent_config_entry_id
                         if keymaster_config_entry_id not in parent_lock.child_config_entry_ids:
                             parent_lock.child_config_entry_ids.append(keymaster_config_entry_id)
                         break

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -481,7 +481,14 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
     async def _rebuild_lock_relationships(self) -> None:
         for keymaster_config_entry_id, kmlock in self.kmlocks.items():
-            if kmlock.parent_name is not None:
+            if (
+                kmlock.parent_config_entry_id is not None
+                and kmlock.parent_config_entry_id in self.kmlocks
+            ):
+                parent_lock = self.kmlocks[kmlock.parent_config_entry_id]
+                if keymaster_config_entry_id not in parent_lock.child_config_entry_ids:
+                    parent_lock.child_config_entry_ids.append(keymaster_config_entry_id)
+            elif kmlock.parent_name is not None:
                 for parent_config_entry_id, parent_lock in self.kmlocks.items():
                     if kmlock.parent_name == parent_lock.lock_name:
                         if kmlock.parent_config_entry_id is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,7 +250,7 @@ def mock_client_fixture(
         client.connect = AsyncMock(side_effect=connect)
         client.listen = AsyncMock(side_effect=listen)
         client.disconnect = AsyncMock(side_effect=disconnect)
-        client.disable_server_logging = MagicMock()
+        client.disable_server_logging = AsyncMock(return_value=None)
         client.driver = Driver(
             client, copy.deepcopy(controller_state), copy.deepcopy(log_config_state)
         )
@@ -381,9 +381,12 @@ def mock_async_call_later():
     with patch("homeassistant.helpers.event.async_call_later") as mock:
 
         def immediate_call(hass, delay, callback):
-            # Immediately call the callback with a mock `hass` object
-            del hass, delay  # Parameters not used in immediate callback
-            return callback(None)
+            del hass, delay, callback  # Parameters not used in the no-op mock
+
+            def _unsubscribe() -> None:
+                return None
+
+            return _unsubscribe
 
         mock.side_effect = immediate_call
         yield mock

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -513,6 +513,41 @@ class TestRebuildLockRelationships:
         assert "child_id" in parent_lock.child_config_entry_ids
         assert child_lock.parent_config_entry_id == "parent_id"
 
+    async def test_rebuild_prefers_explicit_parent_id_over_parent_name(self, mock_coordinator):
+        """Test that explicit parent_config_entry_id wins over stale parent_name."""
+        parent_a = Mock(spec=KeymasterLock)
+        parent_a.keymaster_config_entry_id = "parent_a"
+        parent_a.lock_name = "Front Door"
+        parent_a.child_config_entry_ids = []
+        parent_a.parent_config_entry_id = None
+        parent_a.parent_name = None
+
+        parent_b = Mock(spec=KeymasterLock)
+        parent_b.keymaster_config_entry_id = "parent_b"
+        parent_b.lock_name = "Back Door"
+        parent_b.child_config_entry_ids = []
+        parent_b.parent_config_entry_id = None
+        parent_b.parent_name = None
+
+        child = Mock(spec=KeymasterLock)
+        child.keymaster_config_entry_id = "child"
+        child.lock_name = "Child"
+        child.child_config_entry_ids = []
+        child.parent_config_entry_id = "parent_b"
+        child.parent_name = "Front Door"
+
+        mock_coordinator.kmlocks = {
+            "parent_a": parent_a,
+            "parent_b": parent_b,
+            "child": child,
+        }
+
+        await mock_coordinator._rebuild_lock_relationships()
+
+        assert child.parent_config_entry_id == "parent_b"
+        assert "child" not in parent_a.child_config_entry_ids
+        assert "child" in parent_b.child_config_entry_ids
+
     async def test_rebuild_with_mismatched_parent(self, mock_coordinator):
         """Test that child with mismatched parent is removed from old parent."""
         # Arrange: Parent claims child, but child points to different parent

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -548,6 +548,29 @@ class TestRebuildLockRelationships:
         assert "child" not in parent_a.child_config_entry_ids
         assert "child" in parent_b.child_config_entry_ids
 
+    async def test_rebuild_falls_back_to_name_when_parent_entry_stale(self, mock_coordinator):
+        """Test stale parent_config_entry_id falls back to parent_name matching."""
+        parent = Mock(spec=KeymasterLock)
+        parent.keymaster_config_entry_id = "parent_id"
+        parent.lock_name = "Front Door"
+        parent.child_config_entry_ids = []
+        parent.parent_config_entry_id = None
+        parent.parent_name = None
+
+        child = Mock(spec=KeymasterLock)
+        child.keymaster_config_entry_id = "child_id"
+        child.lock_name = "Child Lock"
+        child.child_config_entry_ids = []
+        child.parent_config_entry_id = "deleted_parent_id"
+        child.parent_name = "Front Door"
+
+        mock_coordinator.kmlocks = {"parent_id": parent, "child_id": child}
+
+        await mock_coordinator._rebuild_lock_relationships()
+
+        assert child.parent_config_entry_id == "parent_id"
+        assert "child_id" in parent.child_config_entry_ids
+
     async def test_rebuild_with_mismatched_parent(self, mock_coordinator):
         """Test that child with mismatched parent is removed from old parent."""
         # Arrange: Parent claims child, but child points to different parent

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,13 +1,15 @@
 """Test keymaster init."""
 
 import logging
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.keymaster import async_setup_entry
 from custom_components.keymaster.const import (
+    CONF_ADVANCED_DATE_RANGE,
+    CONF_ADVANCED_DAY_OF_WEEK,
     CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
     CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
     CONF_DOOR_SENSOR_ENTITY_ID,
@@ -15,8 +17,12 @@ from custom_components.keymaster.const import (
     CONF_LOCK_ENTITY_ID,
     CONF_LOCK_NAME,
     CONF_NOTIFY_SCRIPT_NAME,
+    CONF_PARENT,
+    CONF_PARENT_ENTRY_ID,
     CONF_SLOTS,
     CONF_START,
+    DEFAULT_ADVANCED_DATE_RANGE,
+    DEFAULT_ADVANCED_DAY_OF_WEEK,
     DOMAIN,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -33,6 +39,23 @@ _LOGGER = logging.getLogger(__name__)
 # CONFIG_DATA has 6 slots → 2 + 6 = 8 keymaster sensors
 # (last_used moved from sensor to event platform)
 KEYMASTER_SENSOR_COUNT = 8
+
+
+def _build_entry_data(lock_name: str, lock_entity_id: str) -> dict:
+    """Build minimal config entry data for async_setup_entry tests."""
+    return {
+        CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID: None,
+        CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID: None,
+        CONF_LOCK_ENTITY_ID: lock_entity_id,
+        CONF_LOCK_NAME: lock_name,
+        CONF_DOOR_SENSOR_ENTITY_ID: None,
+        CONF_SLOTS: 1,
+        CONF_START: 1,
+        CONF_NOTIFY_SCRIPT_NAME: None,
+        CONF_HIDE_PINS: False,
+        CONF_ADVANCED_DATE_RANGE: DEFAULT_ADVANCED_DATE_RANGE,
+        CONF_ADVANCED_DAY_OF_WEEK: DEFAULT_ADVANCED_DAY_OF_WEEK,
+    }
 
 
 async def test_setup_entry(
@@ -154,3 +177,93 @@ async def test_notify_script_name_slugified(hass):
             await async_setup_entry(hass, entry)
 
     assert entry.data[CONF_NOTIFY_SCRIPT_NAME] == "keymaster_akuvox_relay_a_manual_notify"
+
+
+async def test_parent_title_resolves_to_parent_entry_id_and_setup_data_flow(hass):
+    """Test parent title resolution and normalized setup_data propagation."""
+    parent_data = _build_entry_data("front_door", "lock.front_door")
+    parent_entry = MockConfigEntry(domain=DOMAIN, title="Front Door", data=parent_data, version=4)
+    parent_entry.add_to_hass(hass)
+
+    child_data = _build_entry_data("garage_door", "lock.garage_door")
+    child_data[CONF_PARENT] = "Front Door"
+    child_data[CONF_PARENT_ENTRY_ID] = None
+    child_entry = MockConfigEntry(domain=DOMAIN, title="Garage Door", data=child_data, version=4)
+    child_entry.add_to_hass(hass)
+
+    hass.data.setdefault(DOMAIN, {})
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch("custom_components.keymaster.KeymasterCoordinator") as mock_coordinator_class,
+        patch("custom_components.keymaster.dr.async_get") as mock_device_registry_get,
+        patch(
+            "custom_components.keymaster.async_generate_lovelace",
+            new_callable=AsyncMock,
+        ) as mock_generate_lovelace,
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+        ),
+    ):
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.initial_setup = AsyncMock()
+        mock_coordinator.async_refresh = AsyncMock()
+        mock_coordinator.last_update_success = True
+        mock_coordinator.kmlocks = {}
+        mock_coordinator.add_lock = AsyncMock()
+
+        mock_device_registry = Mock()
+        mock_device_registry.async_get_or_create = Mock()
+        mock_device_registry_get.return_value = mock_device_registry
+
+        assert await async_setup_entry(hass, child_entry)
+
+    assert child_entry.data[CONF_PARENT_ENTRY_ID] == parent_entry.entry_id
+
+    add_lock_call = mock_coordinator.add_lock.await_args.kwargs
+    assert add_lock_call["update"] is True
+    assert add_lock_call["kmlock"].parent_name == "Front Door"
+    assert add_lock_call["kmlock"].parent_config_entry_id == parent_entry.entry_id
+
+    device_registry_call = mock_device_registry.async_get_or_create.call_args.kwargs
+    assert device_registry_call["via_device"] == (DOMAIN, parent_entry.entry_id)
+
+    lovelace_call = mock_generate_lovelace.await_args.kwargs
+    assert lovelace_call["parent_config_entry_id"] == parent_entry.entry_id
+
+
+async def test_setup_entry_calls_add_lock_with_update_true(hass):
+    """Test that setup always calls add_lock with update=True."""
+    entry_data = _build_entry_data("front_door", "lock.front_door")
+    entry = MockConfigEntry(domain=DOMAIN, title="Front Door", data=entry_data, version=4)
+    entry.add_to_hass(hass)
+
+    hass.data.setdefault(DOMAIN, {})
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch("custom_components.keymaster.KeymasterCoordinator") as mock_coordinator_class,
+        patch("custom_components.keymaster.dr.async_get") as mock_device_registry_get,
+        patch("custom_components.keymaster.async_generate_lovelace", new_callable=AsyncMock),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+        ),
+    ):
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.initial_setup = AsyncMock()
+        mock_coordinator.async_refresh = AsyncMock()
+        mock_coordinator.last_update_success = True
+        mock_coordinator.add_lock = AsyncMock()
+        mock_coordinator.kmlocks = {entry.entry_id: Mock()}
+
+        mock_device_registry = Mock()
+        mock_device_registry.async_get_or_create = Mock()
+        mock_device_registry_get.return_value = mock_device_registry
+
+        assert await async_setup_entry(hass, entry)
+
+    assert mock_coordinator.add_lock.await_args.kwargs["update"] is True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -179,8 +179,8 @@ async def test_notify_script_name_slugified(hass):
     assert entry.data[CONF_NOTIFY_SCRIPT_NAME] == "keymaster_akuvox_relay_a_manual_notify"
 
 
-async def test_parent_title_resolves_to_parent_entry_id_and_setup_data_flow(hass):
-    """Test parent title resolution and normalized setup_data propagation."""
+async def test_parent_title_resolves_to_parent_entry_id_during_setup(hass):
+    """Test parent title resolution is used during setup."""
     parent_data = _build_entry_data("front_door", "lock.front_door")
     parent_entry = MockConfigEntry(domain=DOMAIN, title="Front Door", data=parent_data, version=4)
     parent_entry.add_to_hass(hass)
@@ -222,20 +222,24 @@ async def test_parent_title_resolves_to_parent_entry_id_and_setup_data_flow(hass
 
     assert child_entry.data[CONF_PARENT_ENTRY_ID] == parent_entry.entry_id
 
-    add_lock_call = mock_coordinator.add_lock.await_args.kwargs
-    assert add_lock_call["update"] is True
+    add_lock_await_args = mock_coordinator.add_lock.await_args
+    assert add_lock_await_args is not None
+    add_lock_call = add_lock_await_args.kwargs
+    assert add_lock_call["update"] is False
     assert add_lock_call["kmlock"].parent_name == "Front Door"
     assert add_lock_call["kmlock"].parent_config_entry_id == parent_entry.entry_id
 
     device_registry_call = mock_device_registry.async_get_or_create.call_args.kwargs
     assert device_registry_call["via_device"] == (DOMAIN, parent_entry.entry_id)
 
-    lovelace_call = mock_generate_lovelace.await_args.kwargs
+    lovelace_await_args = mock_generate_lovelace.await_args
+    assert lovelace_await_args is not None
+    lovelace_call = lovelace_await_args.kwargs
     assert lovelace_call["parent_config_entry_id"] == parent_entry.entry_id
 
 
-async def test_setup_entry_calls_add_lock_with_update_true(hass):
-    """Test that setup always calls add_lock with update=True."""
+async def test_setup_entry_calls_add_lock_with_update_true_for_existing_lock(hass):
+    """Test setup calls add_lock with update=True for an existing lock."""
     entry_data = _build_entry_data("front_door", "lock.front_door")
     entry = MockConfigEntry(domain=DOMAIN, title="Front Door", data=entry_data, version=4)
     entry.add_to_hass(hass)
@@ -268,4 +272,5 @@ async def test_setup_entry_calls_add_lock_with_update_true(hass):
 
     add_lock_await_args = mock_coordinator.add_lock.await_args
     assert add_lock_await_args is not None
-    assert add_lock_await_args.kwargs["update"] is True
+    add_lock_kwargs = add_lock_await_args.kwargs
+    assert add_lock_kwargs["update"] is True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -266,4 +266,6 @@ async def test_setup_entry_calls_add_lock_with_update_true(hass):
 
         assert await async_setup_entry(hass, entry)
 
-    assert mock_coordinator.add_lock.await_args.kwargs["update"] is True
+    add_lock_await_args = mock_coordinator.add_lock.await_args
+    assert add_lock_await_args is not None
+    assert add_lock_await_args.kwargs["update"] is True


### PR DESCRIPTION
## Summary
Fixes child-lock sync not propagating from the parent lock due to parent relationship resolution/runtime linkage issues.

## Root Cause
- CONF_PARENT is stored as the config entry title (e.g. Front Door), but setup logic compared it only with CONF_LOCK_NAME (e.g. front_door), so parent_entry_id could remain unresolved.
- During setup, normalized config data was updated, but runtime lock objects could still be created from stale entry data in the same pass.
- Existing lock objects loaded from storage were not force-refreshed with updated relationship data during setup.
- Relationship rebuild favored name matching and could miss valid links when parent_config_entry_id was already known.

## Changes
- Resolve parent by matching CONF_PARENT against entry.title with fallback to CONF_LOCK_NAME.
- Use normalized setup data consistently during runtime lock setup.
- Force coordinator lock refresh with add_lock(..., update=True) so existing locks are updated on startup/reload.
- In relationship rebuild, prioritize explicit parent_config_entry_id before fallback name matching.

## Validation
- Reproduced with node8 parent and node9/14/15 children.
- After restart and slot updates, child locks began syncing correctly from parent.