### PR TITLE
CI: Skip pre-commit no-commit-to-branch in CI

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: 🔍 Run prek
         uses: j178/prek-action@6ad80277337ad479fe43bd70701c3f7f8aa74db3 # v2.0.3
         with:
-          extra-args: --all-files
+          extra-args: --all-files --skip no-commit-to-branch
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: 🔍 Run prek
         uses: j178/prek-action@6ad80277337ad479fe43bd70701c3f7f8aa74db3 # v2.0.3
         with:
-          extra-args: --all-files
+          extra-args: --all-files --skip no-commit-to-branch
 
   test:
     needs: prek


### PR DESCRIPTION
When running in a CI environment (especially on merge) the
no-commit-to-branch check is not relevant and can cause false positives.
Skip it in CI.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
