### PR TITLE
fix(coordinator): allow slot>0 events to supersede slot=0 unlocks

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -112,6 +112,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._prev_kmlocks_dict: MutableMapping[str, Any] = {}
         self._initial_setup_done_event = asyncio.Event()
         self._throttle = Throttle()
+        self._last_unlock_code_slot: dict[str, int | None] = {}
         self._sync_status_counter: int = 0
         self._quick_refresh: bool = False
         self._cancel_quick_refresh: Callable | None = None
@@ -669,6 +670,30 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 functools.partial(self._create_listeners, kmlock),
             )
 
+    def _fire_unlock_state_changed(
+        self,
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+        source: str | None,
+        event_label: str | None,
+        action_code: int | None,
+    ) -> None:
+        """Fire the keymaster_lock_state_changed bus event for an unlock."""
+        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
+        self.hass.bus.fire(
+            EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+            event_data={
+                ATTR_NOTIFICATION_SOURCE: source,
+                ATTR_NAME: kmlock.lock_name,
+                ATTR_ENTITY_ID: kmlock.lock_entity_id,
+                ATTR_STATE: LockState.UNLOCKED,
+                ATTR_ACTION_CODE: action_code,
+                ATTR_ACTION_TEXT: event_label,
+                ATTR_CODE_SLOT: code_slot_num,
+                ATTR_CODE_SLOT_NAME: slot.name if slot and code_slot_num != 0 else "",
+            },
+        )
+
     async def _lock_unlocked(
         self,
         kmlock: KeymasterLock,
@@ -677,15 +702,34 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         event_label: str | None = None,
         action_code: int | None = None,
     ) -> None:
+        # Check for supersede condition before throttle: when the lock is already
+        # unlocked with slot=0 and a more informative slot>0 event arrives, we
+        # must let it through regardless of throttle state.
+        if kmlock.lock_state == LockState.UNLOCKED:
+            prior_slot = self._last_unlock_code_slot.get(kmlock.keymaster_config_entry_id)
+            if isinstance(code_slot_num, int) and code_slot_num > 0 and prior_slot == 0:
+                # A more informative event arrived after an initial slot=0 unlock.
+                # Re-fire the bus event with the correct slot info so downstream
+                # consumers get it, but skip side effects (autolock, notifications,
+                # access limits) that already ran from the first event.
+                _LOGGER.debug(
+                    "[lock_unlocked] %s: Superseding prior slot=0 unlock with slot=%s. source: %s",
+                    kmlock.lock_name,
+                    code_slot_num,
+                    source,
+                )
+                self._last_unlock_code_slot[kmlock.keymaster_config_entry_id] = code_slot_num
+                self._fire_unlock_state_changed(
+                    kmlock, code_slot_num, source, event_label, action_code
+                )
+            return
+
         if not self._throttle.is_allowed(
             "lock_unlocked",
             kmlock.keymaster_config_entry_id,
             THROTTLE_SECONDS,
         ):
             _LOGGER.debug("[lock_unlocked] %s: Throttled. source: %s", kmlock.lock_name, source)
-            return
-
-        if kmlock.lock_state == LockState.UNLOCKED:
             return
 
         kmlock.lock_state = LockState.UNLOCKED
@@ -701,6 +745,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         if not isinstance(code_slot_num, int):
             code_slot_num = 0
+
+        self._last_unlock_code_slot[kmlock.keymaster_config_entry_id] = code_slot_num
 
         if kmlock.autolock_enabled and kmlock.autolock_timer:
             await kmlock.autolock_timer.start(duration=self.autolock_duration_seconds(kmlock))
@@ -782,23 +828,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 )
 
         # Fire state change event
-        self.hass.bus.fire(
-            EVENT_KEYMASTER_LOCK_STATE_CHANGED,
-            event_data={
-                ATTR_NOTIFICATION_SOURCE: source,
-                ATTR_NAME: kmlock.lock_name,
-                ATTR_ENTITY_ID: kmlock.lock_entity_id,
-                ATTR_STATE: LockState.UNLOCKED,
-                ATTR_ACTION_CODE: action_code,
-                ATTR_ACTION_TEXT: event_label,
-                ATTR_CODE_SLOT: code_slot_num,
-                ATTR_CODE_SLOT_NAME: (
-                    kmlock.code_slots[code_slot_num].name
-                    if kmlock.code_slots and code_slot_num != 0
-                    else ""
-                ),
-            },
-        )
+        self._fire_unlock_state_changed(kmlock, code_slot_num, source, event_label, action_code)
 
     async def _lock_locked(
         self,
@@ -821,6 +851,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         kmlock.lock_state = LockState.LOCKED
         kmlock.pending_retry_lock = False
         self._throttle.reset("lock_unlocked", kmlock.keymaster_config_entry_id)
+        self._last_unlock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
         _LOGGER.debug(
             "[lock_locked] %s: Running. source: %s, event_label: %s, action_code: %s",
             kmlock.lock_name,
@@ -1213,6 +1244,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self.kmlocks[kmlock.keymaster_config_entry_id],
         )
         self.kmlocks.pop(kmlock.keymaster_config_entry_id, None)
+        self._last_unlock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
         await self._rebuild_lock_relationships()
         await self._async_save_data()
         await self.async_refresh()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -107,6 +107,7 @@ def mock_coordinator(mock_hass) -> Any:
         # Set up the necessary attributes manually
         coordinator.hass = mock_hass
         coordinator.kmlocks = {}
+        coordinator._last_unlock_code_slot = {}
         # Use setattr to safely add the mock method
         setattr(coordinator, "delete_lock_by_config_entry_id", AsyncMock())
         setattr(coordinator, "async_set_updated_data", Mock())

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -4,9 +4,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.keymaster.const import (
+    ATTR_CODE_SLOT,
+    ATTR_CODE_SLOT_NAME,
+    ATTR_NOTIFICATION_SOURCE,
+    EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+)
 from custom_components.keymaster.coordinator import KeymasterCoordinator
+from custom_components.keymaster.helpers import Throttle
 from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
 from homeassistant.components.lock.const import LockState
+from homeassistant.const import ATTR_STATE
 
 
 @pytest.fixture
@@ -402,3 +410,320 @@ async def test_lock_unlocked_does_not_decrement_when_count_zero(hass, coordinato
 
         # Count should remain at 0 (not go negative)
         assert kmlock.code_slots[1].accesslimit_count == 0
+
+
+async def test_lock_unlocked_supersedes_slot_zero_with_slot_info(hass, coordinator_for_unlock_test):
+    """Test that a slot>0 event supersedes a prior slot=0 unlock.
+
+    When relay_a_triggered (slot=0) arrives first and then valid_code_entered
+    (slot=N) arrives, two keymaster_lock_state_changed events should fire:
+    the first with code_slot=0, the second with code_slot=N.
+    """
+    coordinator = coordinator_for_unlock_test
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.code_slots = {
+        3: KeymasterCodeSlot(
+            number=3,
+            name="Alice",
+            enabled=True,
+        )
+    }
+    coordinator.kmlocks["test_entry"] = kmlock
+
+    fired_events: list[dict] = []
+
+    def _capture_event(event):
+        fired_events.append(event.data)
+
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, _capture_event)
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+    ):
+        # First event: relay_a_triggered with slot=0
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        # Second event: valid_code_entered with slot=3
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=3,
+            source="valid_code_entered",
+            event_label="Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+
+    assert len(fired_events) == 2
+    assert fired_events[0][ATTR_CODE_SLOT] == 0
+    assert fired_events[0][ATTR_CODE_SLOT_NAME] == ""
+    assert fired_events[1][ATTR_CODE_SLOT] == 3
+    assert fired_events[1][ATTR_CODE_SLOT_NAME] == "Alice"
+    assert fired_events[1][ATTR_NOTIFICATION_SOURCE] == "valid_code_entered"
+    assert fired_events[1][ATTR_STATE] == LockState.UNLOCKED
+
+
+async def test_lock_unlocked_does_not_supersede_when_already_has_slot(
+    hass, coordinator_for_unlock_test
+):
+    """Test that a second slot>0 event is dropped when first had slot>0.
+
+    If the first unlock event already had slot=5, a second event with slot=3
+    should be short-circuited (no superseding).
+    """
+    coordinator = coordinator_for_unlock_test
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.code_slots = {
+        3: KeymasterCodeSlot(number=3, name="Alice", enabled=True),
+        5: KeymasterCodeSlot(number=5, name="Bob", enabled=True),
+    }
+    coordinator.kmlocks["test_entry"] = kmlock
+
+    fired_events: list[dict] = []
+
+    def _capture_event(event):
+        fired_events.append(event.data)
+
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, _capture_event)
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+    ):
+        # First event: slot=5
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=5,
+            source="valid_code_entered",
+            event_label="Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        # Second event: slot=3 — should be dropped (already unlocked with slot>0)
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=3,
+            source="valid_code_entered",
+            event_label="Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+
+    # Only the first event should fire
+    assert len(fired_events) == 1
+    assert fired_events[0][ATTR_CODE_SLOT] == 5
+    assert fired_events[0][ATTR_CODE_SLOT_NAME] == "Bob"
+
+
+async def test_lock_unlocked_side_effects_not_duplicated(hass, coordinator_for_unlock_test):
+    """Test that superseding slot>0 event does not re-run side effects.
+
+    When a slot>0 event supersedes a prior slot=0 unlock, autolock timer
+    should NOT be restarted, access limits should NOT be decremented, and
+    notifications should NOT be re-sent.
+    """
+    coordinator = coordinator_for_unlock_test
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.autolock_enabled = True
+    kmlock.autolock_timer = MagicMock()
+    kmlock.autolock_timer.start = AsyncMock()
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "script.notify_test"
+    kmlock.code_slots = {
+        2: KeymasterCodeSlot(
+            number=2,
+            name="Charlie",
+            enabled=True,
+            accesslimit_count_enabled=True,
+            accesslimit_count=5,
+            notifications=True,
+        )
+    }
+    coordinator.kmlocks["test_entry"] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        # First event: slot=0 — triggers autolock and notification
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        autolock_call_count = kmlock.autolock_timer.start.call_count
+        notify_call_count = mock_notify.call_count
+        access_count_after_first = kmlock.code_slots[2].accesslimit_count
+
+        # Second event: slot=2 — supersedes, but should NOT re-run side effects
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=2,
+            source="valid_code_entered",
+            event_label="Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+
+    # Autolock timer should not be started again
+    assert kmlock.autolock_timer.start.call_count == autolock_call_count
+    # Notification should not be sent again
+    assert mock_notify.call_count == notify_call_count
+    # Access limit should not be decremented
+    assert kmlock.code_slots[2].accesslimit_count == access_count_after_first == 5
+
+
+async def test_lock_unlocked_drops_second_slot_zero(hass, coordinator_for_unlock_test):
+    """Test that a second slot=0 event is dropped normally.
+
+    Two consecutive slot=0 events — the second should be short-circuited
+    without firing an additional bus event.
+    """
+    coordinator = coordinator_for_unlock_test
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    coordinator.kmlocks["test_entry"] = kmlock
+
+    fired_events: list[dict] = []
+
+    def _capture_event(event):
+        fired_events.append(event.data)
+
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, _capture_event)
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+    ):
+        # First slot=0 event
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        # Second slot=0 event — should be dropped
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+    # Only one event should fire
+    assert len(fired_events) == 1
+    assert fired_events[0][ATTR_CODE_SLOT] == 0
+
+
+async def test_lock_unlocked_supersede_bypasses_throttle(hass, coordinator_for_unlock_test):
+    """Test that the supersede path works even when the throttle would block.
+
+    In real usage, the slot=0 event sets the throttle cooldown. The slot>0
+    event arrives within THROTTLE_SECONDS but must still supersede because the
+    supersede check runs before the throttle gate.
+    """
+    coordinator = coordinator_for_unlock_test
+    # Use a real Throttle instead of a mock
+    coordinator._throttle = Throttle()
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.code_slots = {
+        3: KeymasterCodeSlot(
+            number=3,
+            name="Alice",
+            enabled=True,
+        )
+    }
+    coordinator.kmlocks["test_entry"] = kmlock
+
+    fired_events: list[dict] = []
+
+    def _capture_event(event):
+        fired_events.append(event.data)
+
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, _capture_event)
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+    ):
+        # First event: relay_a_triggered with slot=0 (sets throttle cooldown)
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        # Second event: valid_code_entered with slot=3 — arrives within
+        # THROTTLE_SECONDS but should still supersede
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=3,
+            source="valid_code_entered",
+            event_label="Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+
+    # Both events should fire despite throttle
+    assert len(fired_events) == 2
+    assert fired_events[0][ATTR_CODE_SLOT] == 0
+    assert fired_events[1][ATTR_CODE_SLOT] == 3
+    assert fired_events[1][ATTR_CODE_SLOT_NAME] == "Alice"


### PR DESCRIPTION
## Summary

When the Akuvox provider fires both `relay_a_triggered` (slot=0) and `valid_code_entered` (slot=N), the relay event can arrive first and set `lock_state=UNLOCKED` with `code_slot_num=0`. The subsequent `valid_code_entered` was being dropped by the short-circuit check in `_lock_unlocked`, causing downstream consumers (e.g., rental-control) to lose the slot information.

## Fix

Modified `_lock_unlocked` so that when `lock_state == UNLOCKED` and the prior unlock used slot=0, a new event with `code_slot_num > 0` re-fires the `keymaster_lock_state_changed` bus event with the corrected slot info. Side effects (autolock timer restart, access limit decrement, notifications) are **not** duplicated—only the bus event is re-fired.

A `_last_unlock_code_slot` dict tracks which slot caused each lock's last unlock transition. It's cleared when the lock transitions back to LOCKED.

## Edge Cases Handled

- `code_slot_num` is `None` or 0 → normal short-circuit (no supersede)
- First unlock had slot > 0, second has different slot > 0 → dropped (no supersede)
- Two slot=0 events → second dropped normally
- Access limits not decremented again (superseding path only fires bus event)

## Tests Added

- `test_lock_unlocked_supersedes_slot_zero_with_slot_info`
- `test_lock_unlocked_does_not_supersede_when_already_has_slot`
- `test_lock_unlocked_side_effects_not_duplicated`
- `test_lock_unlocked_drops_second_slot_zero`

Closes #608