### PR TITLE
fix(coordinator): retry child sync on OUT_OF_SYNC state

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1856,6 +1856,43 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         for usercode_slot in usercodes:
             await self._sync_usercode(kmlock=kmlock, usercode_slot=usercode_slot)
 
+        # Retry OUT_OF_SYNC slots not covered by provider usercodes.
+        # Name-based providers (Akuvox, Schlage) only return slots with
+        # tagged users on the device. If the initial set_pin_on_lock()
+        # failed, no tagged user exists and _sync_pin() is never called.
+        provider_slots = {uc.slot_num for uc in usercodes}
+        if kmlock.code_slots:
+            for code_slot_num, kmslot in kmlock.code_slots.items():
+                if code_slot_num in provider_slots:
+                    continue  # Already handled by _sync_usercode
+                if kmslot.synced != Synced.OUT_OF_SYNC:
+                    continue
+                if kmslot.enabled and kmslot.active and kmslot.pin:
+                    _LOGGER.debug(
+                        "[_update_code_slots] %s Slot %s: Retrying set_pin "
+                        "(OUT_OF_SYNC, not returned by provider)",
+                        kmlock.lock_name,
+                        code_slot_num,
+                    )
+                    await self.set_pin_on_lock(
+                        config_entry_id=kmlock.keymaster_config_entry_id,
+                        code_slot_num=code_slot_num,
+                        pin=str(kmslot.pin),
+                        override=True,
+                    )
+                elif not kmslot.pin and kmslot.enabled:
+                    _LOGGER.debug(
+                        "[_update_code_slots] %s Slot %s: Retrying clear_pin "
+                        "(OUT_OF_SYNC, not returned by provider)",
+                        kmlock.lock_name,
+                        code_slot_num,
+                    )
+                    await self.clear_pin_from_lock(
+                        config_entry_id=kmlock.keymaster_config_entry_id,
+                        code_slot_num=code_slot_num,
+                        override=True,
+                    )
+
     async def _update_slot(
         self,
         kmlock: KeymasterLock,
@@ -2202,10 +2239,26 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 pin_mismatch,
             )
 
+            child_slot = child_kmlock.code_slots[code_slot_num]
+            child_needs_retry = (
+                child_slot.synced == Synced.OUT_OF_SYNC
+                and kmslot.enabled
+                and kmslot.active
+                and kmslot.pin
+            )
+
+            if child_needs_retry:
+                _LOGGER.debug(
+                    "[_sync_child_locks] %s Slot %s: Retrying sync (child is OUT_OF_SYNC)",
+                    child_kmlock.lock_name,
+                    code_slot_num,
+                )
+
             if (
                 pin_mismatch
-                or prev_enabled != child_kmlock.code_slots[code_slot_num].enabled
-                or prev_active != child_kmlock.code_slots[code_slot_num].active
+                or prev_enabled != child_slot.enabled
+                or prev_active != child_slot.active
+                or child_needs_retry
             ):
                 self._quick_refresh = True
                 if not kmslot.enabled or not kmslot.active or not kmslot.pin:

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1892,6 +1892,18 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         code_slot_num=code_slot_num,
                         override=True,
                     )
+                elif not kmslot.enabled or not kmslot.active:
+                    _LOGGER.debug(
+                        "[_update_code_slots] %s Slot %s: Retrying clear_pin "
+                        "(OUT_OF_SYNC, disabled/inactive, not returned by provider)",
+                        kmlock.lock_name,
+                        code_slot_num,
+                    )
+                    await self.clear_pin_from_lock(
+                        config_entry_id=kmlock.keymaster_config_entry_id,
+                        code_slot_num=code_slot_num,
+                        override=True,
+                    )
 
     async def _update_slot(
         self,
@@ -2240,12 +2252,16 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
 
             child_slot = child_kmlock.code_slots[code_slot_num]
-            child_needs_retry = (
+            child_needs_set_retry = (
                 child_slot.synced == Synced.OUT_OF_SYNC
                 and kmslot.enabled
                 and kmslot.active
                 and kmslot.pin
             )
+            child_needs_clear_retry = child_slot.synced == Synced.OUT_OF_SYNC and (
+                not kmslot.enabled or not kmslot.active or not kmslot.pin
+            )
+            child_needs_retry = child_needs_set_retry or child_needs_clear_retry
 
             if child_needs_retry:
                 _LOGGER.debug(

--- a/tests/test_coordinator_sync.py
+++ b/tests/test_coordinator_sync.py
@@ -1249,6 +1249,38 @@ class TestChildSyncRetryOnOutOfSync:
         )
         assert child_slot.pin is None
 
+    async def test_child_sync_out_of_sync_clear_retry_matching_state(
+        self, mock_coordinator, parent_lock, child_lock
+    ):
+        """OUT_OF_SYNC child with disabled parent retries clear even when states match."""
+        parent_slot = Mock(spec=KeymasterCodeSlot)
+        parent_slot.code_slot_num = 1
+        parent_slot.enabled = False  # Parent disabled
+        parent_slot.active = True
+        parent_slot.pin = "1234"
+        parent_slot.name = "Test Slot"
+
+        # Child already has matching disabled state (prev_enabled == child_slot.enabled)
+        child_slot = Mock(spec=KeymasterCodeSlot)
+        child_slot.code_slot_num = 1
+        child_slot.enabled = False  # Already disabled — no enabled change
+        child_slot.active = True  # Same active
+        child_slot.pin = None  # PIN already cleared locally
+        child_slot.override_parent = False
+        child_slot.synced = Synced.OUT_OF_SYNC
+
+        parent_lock.code_slots = {1: parent_slot}
+        child_lock.code_slots = {1: child_slot}
+
+        await mock_coordinator._update_child_code_slots(parent_lock, child_lock)
+
+        # OUT_OF_SYNC clear retry should fire even though states match
+        mock_coordinator.clear_pin_from_lock.assert_called_once_with(
+            config_entry_id="child_id",
+            code_slot_num=1,
+            override=True,
+        )
+
 
 class TestUpdateCodeSlotsRetryUncovered:
     """Tests that _update_code_slots retries OUT_OF_SYNC slots not returned by provider."""
@@ -1327,6 +1359,31 @@ class TestUpdateCodeSlotsRetryUncovered:
         )
         lock.code_slots = {
             1: KeymasterCodeSlot(number=1, pin=None, name="Guest", active=True, enabled=True),
+        }
+        lock.code_slots[1].synced = Synced.OUT_OF_SYNC
+
+        usercodes: list[CodeSlot] = []
+
+        await coordinator_for_update._update_code_slots(kmlock=lock, usercodes=usercodes)
+
+        coordinator_for_update.clear_pin_from_lock.assert_called_once_with(
+            config_entry_id="test_entry",
+            code_slot_num=1,
+            override=True,
+        )
+        coordinator_for_update.set_pin_on_lock.assert_not_called()
+
+    async def test_update_code_slots_retries_clear_for_disabled_out_of_sync(
+        self, coordinator_for_update
+    ):
+        """OUT_OF_SYNC slot that is disabled retries clear_pin even with PIN in memory."""
+        lock = KeymasterLock(
+            lock_name="Test Lock",
+            lock_entity_id="lock.test",
+            keymaster_config_entry_id="test_entry",
+        )
+        lock.code_slots = {
+            1: KeymasterCodeSlot(number=1, pin="1234", name="Guest", active=True, enabled=False),
         }
         lock.code_slots[1].synced = Synced.OUT_OF_SYNC
 

--- a/tests/test_coordinator_sync.py
+++ b/tests/test_coordinator_sync.py
@@ -8,7 +8,7 @@ import pytest
 from custom_components.keymaster.const import PIN_SET_GRACE_SECONDS, Synced
 from custom_components.keymaster.coordinator import KeymasterCoordinator
 from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
-from custom_components.keymaster.providers._base import BaseLockProvider
+from custom_components.keymaster.providers._base import BaseLockProvider, CodeSlot
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
@@ -1154,3 +1154,232 @@ class TestSyncPinStuckStateRecovery:
         # Should NOT recover — operation is genuinely in flight
         assert slot.synced == Synced.ADDING
         real_coordinator.set_pin_on_lock.assert_not_called()
+
+
+class TestChildSyncRetryOnOutOfSync:
+    """Tests that _update_child_code_slots retries when child slot is OUT_OF_SYNC."""
+
+    async def test_child_sync_retries_on_out_of_sync(
+        self, mock_coordinator, parent_lock, child_lock
+    ):
+        """Child slot stuck in OUT_OF_SYNC retries even when PINs match in memory."""
+        parent_slot = Mock(spec=KeymasterCodeSlot)
+        parent_slot.code_slot_num = 1
+        parent_slot.enabled = True
+        parent_slot.active = True
+        parent_slot.pin = "1234"
+        parent_slot.name = "Test Slot"
+
+        child_slot = Mock(spec=KeymasterCodeSlot)
+        child_slot.code_slot_num = 1
+        child_slot.enabled = True
+        child_slot.active = True
+        child_slot.pin = "1234"  # Same PIN — pin_mismatch is False
+        child_slot.override_parent = False
+        child_slot.synced = Synced.OUT_OF_SYNC
+
+        parent_lock.code_slots = {1: parent_slot}
+        child_lock.code_slots = {1: child_slot}
+
+        await mock_coordinator._update_child_code_slots(parent_lock, child_lock)
+
+        # OUT_OF_SYNC should trigger a retry even though PINs match
+        mock_coordinator.set_pin_on_lock.assert_called_once_with(
+            config_entry_id="child_id",
+            code_slot_num=1,
+            pin="1234",
+            override=True,
+        )
+
+    async def test_child_sync_no_retry_when_synced(self, mock_coordinator, parent_lock, child_lock):
+        """Child slot that is SYNCED with matching PIN should NOT trigger a retry."""
+        parent_slot = Mock(spec=KeymasterCodeSlot)
+        parent_slot.code_slot_num = 1
+        parent_slot.enabled = True
+        parent_slot.active = True
+        parent_slot.pin = "1234"
+        parent_slot.name = "Test Slot"
+
+        child_slot = Mock(spec=KeymasterCodeSlot)
+        child_slot.code_slot_num = 1
+        child_slot.enabled = True
+        child_slot.active = True
+        child_slot.pin = "1234"  # Same PIN — pin_mismatch is False
+        child_slot.override_parent = False
+        child_slot.synced = Synced.SYNCED
+
+        parent_lock.code_slots = {1: parent_slot}
+        child_lock.code_slots = {1: child_slot}
+
+        await mock_coordinator._update_child_code_slots(parent_lock, child_lock)
+
+        # No retry needed — slot is already SYNCED
+        mock_coordinator.set_pin_on_lock.assert_not_called()
+        mock_coordinator.clear_pin_from_lock.assert_not_called()
+
+    async def test_child_sync_out_of_sync_disabled_slot(
+        self, mock_coordinator, parent_lock, child_lock
+    ):
+        """OUT_OF_SYNC child with disabled parent should clear the child PIN."""
+        parent_slot = Mock(spec=KeymasterCodeSlot)
+        parent_slot.code_slot_num = 1
+        parent_slot.enabled = False  # Parent disabled
+        parent_slot.active = True
+        parent_slot.pin = "1234"
+        parent_slot.name = "Test Slot"
+
+        child_slot = Mock(spec=KeymasterCodeSlot)
+        child_slot.code_slot_num = 1
+        child_slot.enabled = True  # Was enabled before attr copy
+        child_slot.active = True
+        child_slot.pin = "1234"
+        child_slot.override_parent = False
+        child_slot.synced = Synced.OUT_OF_SYNC
+
+        parent_lock.code_slots = {1: parent_slot}
+        child_lock.code_slots = {1: child_slot}
+
+        await mock_coordinator._update_child_code_slots(parent_lock, child_lock)
+
+        # Parent is disabled → child should be cleared (enabled changed)
+        mock_coordinator.clear_pin_from_lock.assert_called_once_with(
+            config_entry_id="child_id",
+            code_slot_num=1,
+            override=True,
+        )
+        assert child_slot.pin is None
+
+
+class TestUpdateCodeSlotsRetryUncovered:
+    """Tests that _update_code_slots retries OUT_OF_SYNC slots not returned by provider."""
+
+    @pytest.fixture
+    def coordinator_for_update(self, mock_hass):
+        """Coordinator with real _update_code_slots (mocked set/clear/update_slot/sync)."""
+        with patch.object(KeymasterCoordinator, "__init__", return_value=None):
+            coordinator = KeymasterCoordinator(mock_hass)
+            coordinator.hass = mock_hass
+            coordinator.kmlocks = {}
+            coordinator._quick_refresh = False
+            coordinator.set_pin_on_lock = AsyncMock(return_value=True)
+            coordinator.clear_pin_from_lock = AsyncMock(return_value=True)
+            coordinator._update_slot = AsyncMock()
+            coordinator._sync_usercode = AsyncMock()
+            return coordinator
+
+    async def test_update_code_slots_retries_uncovered_out_of_sync(self, coordinator_for_update):
+        """OUT_OF_SYNC slot not returned by provider gets a retry set_pin call."""
+
+        lock = KeymasterLock(
+            lock_name="Test Lock",
+            lock_entity_id="lock.test",
+            keymaster_config_entry_id="test_entry",
+        )
+        lock.code_slots = {
+            1: KeymasterCodeSlot(number=1, pin="1234", name="Guest", active=True, enabled=True),
+        }
+        lock.code_slots[1].synced = Synced.OUT_OF_SYNC
+
+        # Provider returns NO usercodes for slot 1 (name-based provider)
+        usercodes: list[CodeSlot] = []
+
+        await coordinator_for_update._update_code_slots(kmlock=lock, usercodes=usercodes)
+
+        coordinator_for_update.set_pin_on_lock.assert_called_once_with(
+            config_entry_id="test_entry",
+            code_slot_num=1,
+            pin="1234",
+            override=True,
+        )
+
+    async def test_update_code_slots_no_retry_when_provider_covers_slot(
+        self, coordinator_for_update
+    ):
+        """OUT_OF_SYNC slot covered by provider should NOT be retried in the third pass."""
+
+        lock = KeymasterLock(
+            lock_name="Test Lock",
+            lock_entity_id="lock.test",
+            keymaster_config_entry_id="test_entry",
+        )
+        lock.code_slots = {
+            1: KeymasterCodeSlot(number=1, pin="1234", name="Guest", active=True, enabled=True),
+        }
+        lock.code_slots[1].synced = Synced.OUT_OF_SYNC
+
+        # Provider DOES return usercode for slot 1
+        usercodes = [CodeSlot(slot_num=1, code="1234", in_use=True)]
+
+        await coordinator_for_update._update_code_slots(kmlock=lock, usercodes=usercodes)
+
+        # The retry pass should NOT call set_pin_on_lock (slot covered by provider)
+        coordinator_for_update.set_pin_on_lock.assert_not_called()
+
+    async def test_update_code_slots_retries_clear_for_uncovered_out_of_sync(
+        self, coordinator_for_update
+    ):
+        """OUT_OF_SYNC slot with no PIN and enabled should retry clear_pin."""
+
+        lock = KeymasterLock(
+            lock_name="Test Lock",
+            lock_entity_id="lock.test",
+            keymaster_config_entry_id="test_entry",
+        )
+        lock.code_slots = {
+            1: KeymasterCodeSlot(number=1, pin=None, name="Guest", active=True, enabled=True),
+        }
+        lock.code_slots[1].synced = Synced.OUT_OF_SYNC
+
+        usercodes: list[CodeSlot] = []
+
+        await coordinator_for_update._update_code_slots(kmlock=lock, usercodes=usercodes)
+
+        coordinator_for_update.clear_pin_from_lock.assert_called_once_with(
+            config_entry_id="test_entry",
+            code_slot_num=1,
+            override=True,
+        )
+        coordinator_for_update.set_pin_on_lock.assert_not_called()
+
+
+class TestChildSyncOutOfSyncFullCycle:
+    """Integration test: full cycle retry for child lock OUT_OF_SYNC recovery."""
+
+    async def test_child_sync_out_of_sync_recovery_full_cycle(
+        self, mock_coordinator, parent_lock, child_lock
+    ):
+        """Full cycle: parent has PIN, child is OUT_OF_SYNC with matching in-memory PIN."""
+        parent_slot = Mock(spec=KeymasterCodeSlot)
+        parent_slot.code_slot_num = 1
+        parent_slot.enabled = True
+        parent_slot.active = True
+        parent_slot.pin = "5678"
+        parent_slot.name = "Full Cycle Test"
+
+        child_slot = Mock(spec=KeymasterCodeSlot)
+        child_slot.code_slot_num = 1
+        child_slot.enabled = True
+        child_slot.active = True
+        child_slot.pin = "5678"  # Same PIN in memory (copied on prior failed attempt)
+        child_slot.override_parent = False
+        child_slot.synced = Synced.OUT_OF_SYNC
+
+        parent_lock.code_slots = {1: parent_slot}
+        child_lock.code_slots = {1: child_slot}
+
+        mock_coordinator.kmlocks = {
+            "parent_id": parent_lock,
+            "child_id": child_lock,
+        }
+
+        # Simulate what _async_update_data does for child sync
+        await mock_coordinator._update_child_code_slots(parent_lock, child_lock)
+
+        # Assert: set_pin_on_lock was called for the child slot
+        mock_coordinator.set_pin_on_lock.assert_called_once_with(
+            config_entry_id="child_id",
+            code_slot_num=1,
+            pin="5678",
+            override=True,
+        )
+        assert mock_coordinator._quick_refresh is True

--- a/tests/test_coordinator_sync.py
+++ b/tests/test_coordinator_sync.py
@@ -1309,14 +1309,17 @@ class TestUpdateCodeSlotsRetryUncovered:
         )
         lock.code_slots = {
             1: KeymasterCodeSlot(number=1, pin="1234", name="Guest", active=True, enabled=True),
+            2: KeymasterCodeSlot(number=2, pin="5678", name="Other", active=True, enabled=True),
         }
         lock.code_slots[1].synced = Synced.OUT_OF_SYNC
+        # Slot 2 stays SYNCED (default) — should be skipped by retry pass
 
-        # Provider returns NO usercodes for slot 1 (name-based provider)
+        # Provider returns NO usercodes for either slot (name-based provider)
         usercodes: list[CodeSlot] = []
 
         await coordinator_for_update._update_code_slots(kmlock=lock, usercodes=usercodes)
 
+        # Only slot 1 (OUT_OF_SYNC) should be retried; slot 2 (SYNCED) is skipped
         coordinator_for_update.set_pin_on_lock.assert_called_once_with(
             config_entry_id="test_entry",
             code_slot_num=1,


### PR DESCRIPTION
## Summary

Fix child lock slots getting stuck in `OUT_OF_SYNC` after a failed initial sync.

### Problem

In `_update_child_code_slots()`, when `set_pin_on_lock()` fails for a child lock:
1. The child slot correctly transitions to `OUT_OF_SYNC`
2. But the parent PIN is copied to the child's in-memory `slot.pin`
3. On subsequent cycles, the retry condition checks only `pin_mismatch`, `prev_enabled != current`, and `prev_active != current`
4. Since PINs now match in memory and enabled/active haven't changed, **no retry ever happens**

Secondary issue: In `_update_code_slots()`, `_sync_usercode()` is only called for slots the provider returns. Name-based providers (Akuvox, Schlage) don't return slots where the tagged user was never created (because the initial set failed), so `_sync_pin()` is never called as a backup.

### Fix 1: `_update_child_code_slots()`

Add `synced == OUT_OF_SYNC` as an additional trigger condition. The child retries sync when it's out of sync AND the parent has an active, enabled slot with a PIN.

### Fix 2: `_update_code_slots()`

Add a third pass after the existing update_slot + sync_usercode loops to retry `OUT_OF_SYNC` slots that the provider didn't return usercodes for.

### Tests

Added 7 new test cases in `tests/test_coordinator_sync.py`:
- `test_child_sync_retries_on_out_of_sync` — verifies retry fires for OUT_OF_SYNC child
- `test_child_sync_no_retry_when_synced` — verifies no unnecessary retry
- `test_child_sync_out_of_sync_disabled_slot` — verifies clear on disabled parent
- `test_update_code_slots_retries_uncovered_out_of_sync` — verifies retry for uncovered slots
- `test_update_code_slots_no_retry_when_provider_covers_slot` — verifies no double-retry
- `test_update_code_slots_retries_clear_for_uncovered_out_of_sync` — verifies clear retry
- `test_child_sync_out_of_sync_recovery_full_cycle` — integration test for full cycle

Closes #613