### PR TITLE
fix(akuvox): widen _is_local_user to handle E18C "local" source_type

### DIFF
--- a/custom_components/keymaster/providers/akuvox.py
+++ b/custom_components/keymaster/providers/akuvox.py
@@ -46,17 +46,25 @@ _DEFAULT_SCHEDULE_IDS = "1001"  # "Always" schedule on Akuvox devices
 _DEFAULT_LIFT_FLOOR_NUM = "1"
 
 # Akuvox firmware varies in how it marks local vs cloud users:
-#   A08S / E18C: source_type "1" = local, "2" = cloud, user_type "0" for both
+#   A08S / E18C: source_type "1" or "local" = local, "2" or "cloud" = cloud
 #   X916:        source_type None for all, user_type "-1" = local, "0" = cloud
-_LOCAL_SOURCE_TYPE = "1"
+# Strategy: tagged [KM:XX] users always pass; for untagged users, exclude
+# known cloud source_types (case-insensitive) when present, else fall back
+# to user_type.
+_CLOUD_SOURCE_TYPES = {"2", "cloud"}
 _LOCAL_USER_TYPE = "-1"
 
 
 def _is_local_user(user: dict[str, Any]) -> bool:
-    """Return True if *user* was created locally on the device."""
+    """Return True if *user* appears manageable via the local API."""
+    # Tagged users are always managed by Keymaster regardless of source/type.
+    name = str(user.get("name") or "")
+    if _parse_tag(name)[0] is not None:
+        return True
+    # If source_type is present, exclude known cloud values (case-insensitive).
     source_type = user.get("source_type")
     if source_type is not None:
-        return str(source_type) == _LOCAL_SOURCE_TYPE
+        return str(source_type).lower() not in _CLOUD_SOURCE_TYPES
     # source_type absent — fall back to user_type (X916 pattern)
     return str(user.get("user_type", "")) == _LOCAL_USER_TYPE
 

--- a/tests/providers/test_akuvox.py
+++ b/tests/providers/test_akuvox.py
@@ -128,13 +128,37 @@ class TestHelperFunctions:
 
     # -- _is_local_user -------------------------------------------------------
 
+    def test_is_local_user_tagged_always_passes(self):
+        """Tagged [KM:XX] users are always considered local."""
+        assert _is_local_user({"name": "[KM:1] Test", "source_type": "2", "user_type": "0"}) is True
+
+    def test_is_local_user_tagged_no_source_type(self):
+        """Tagged user with no source_type still passes."""
+        assert _is_local_user({"name": "[KM:5] Foo", "user_type": "0"}) is True
+
     def test_is_local_user_source_type_1(self):
         """A08S/E18C pattern: source_type '1' is local."""
         assert _is_local_user({"source_type": "1", "user_type": "0"}) is True
 
+    def test_is_local_user_source_type_local(self):
+        """E18C alternate firmware: source_type 'local' is local."""
+        assert _is_local_user({"source_type": "local", "user_type": "0"}) is True
+
     def test_is_local_user_source_type_2(self):
-        """A08S/E18C pattern: source_type '2' is cloud."""
+        """A08S/E18C pattern: source_type '2' is cloud (numeric variant)."""
         assert _is_local_user({"source_type": "2", "user_type": "0"}) is False
+
+    def test_is_local_user_source_type_cloud_lowercase(self):
+        """E18C pattern: source_type 'cloud' is cloud."""
+        assert _is_local_user({"source_type": "cloud", "user_type": "0"}) is False
+
+    def test_is_local_user_source_type_cloud_capitalized(self):
+        """E18C pattern: source_type 'Cloud' is cloud (case-insensitive)."""
+        assert _is_local_user({"source_type": "Cloud", "user_type": "0"}) is False
+
+    def test_is_local_user_source_type_local_capitalized(self):
+        """E18C pattern: source_type 'Local' is local (case-insensitive)."""
+        assert _is_local_user({"source_type": "Local", "user_type": "0"}) is True
 
     def test_is_local_user_none_source_local_user_type(self):
         """X916 pattern: source_type None, user_type '-1' is local."""
@@ -483,7 +507,7 @@ class TestAsyncGetUsercodes:
             "lock.akuvox_relay_a": {
                 "users": [
                     _make_user("10", "[KM:1] Local", "1234", source_type="1"),
-                    _make_user("20", "[KM:2] Cloud", "5678", source_type="2"),
+                    _make_user("20", "Cloud User", "5678", source_type="2"),
                 ]
             }
         }
@@ -634,7 +658,7 @@ class TestAsyncGetUsercode:
         provider.hass.services.async_call.return_value = {
             "lock.akuvox_relay_a": {
                 "users": [
-                    _make_user("10", "[KM:1] Cloud", "1234", source_type="2"),
+                    _make_user("10", "Cloud User", "1234", source_type="2"),
                 ]
             }
         }
@@ -647,7 +671,7 @@ class TestAsyncGetUsercode:
         provider.hass.services.async_call.return_value = {
             "lock.akuvox_relay_a": {
                 "users": [
-                    _make_user("10", "[KM:1] Cloud", "1234", source_type=None, user_type="0"),
+                    _make_user("10", "Cloud User", "1234", source_type=None, user_type="0"),
                 ]
             }
         }
@@ -759,7 +783,7 @@ class TestAsyncSetUsercode:
             {
                 "lock.akuvox_relay_a": {
                     "users": [
-                        _make_user("10", "[KM:1] Cloud", "1234", source_type="2"),
+                        _make_user("10", "Cloud User", "1234", source_type="2"),
                     ]
                 }
             },
@@ -781,7 +805,7 @@ class TestAsyncSetUsercode:
                     "users": [
                         _make_user(
                             "10",
-                            "[KM:1] Cloud",
+                            "Cloud User",
                             "1234",
                             source_type=None,
                             user_type="0",
@@ -847,7 +871,7 @@ class TestAsyncClearUsercode:
         provider.hass.services.async_call.return_value = {
             "lock.akuvox_relay_a": {
                 "users": [
-                    _make_user("10", "[KM:1] Cloud", "1234", source_type="2"),
+                    _make_user("10", "Cloud User", "1234", source_type="2"),
                 ]
             }
         }
@@ -864,7 +888,7 @@ class TestAsyncClearUsercode:
                 "users": [
                     _make_user(
                         "10",
-                        "[KM:1] Cloud",
+                        "Cloud User",
                         "1234",
                         source_type=None,
                         user_type="0",


### PR DESCRIPTION
Akuvox E18C firmware may return `source_type="local"` instead of `"1"` for
locally-created users. The previous strict equality check against `"1"` silently
skipped all local users on affected devices.

## Changes

- **Tagged `[KM:XX]` users always pass** `_is_local_user()` — if Keymaster
  created it, Keymaster manages it regardless of `source_type`/`user_type`.
- **Invert source_type logic**: instead of matching known-local (`"1"`), we now
  exclude known-cloud (`"2"`). Any other value (including `"local"`, `"1"`, or
  future firmware strings) is treated as local.
- Update tests to cover the new tag-bypass path and `source_type="local"`.
- Existing "cloud user skipped" tests now use untagged names to properly
  exercise the `source_type`/`user_type` filtering path.

Closes FutureTense/keymaster#615