### PR TITLE
fix(zwave): support User Credential CC for HA 2026.6+

### DIFF
--- a/custom_components/keymaster/providers/zwave_js.py
+++ b/custom_components/keymaster/providers/zwave_js.py
@@ -41,6 +41,31 @@ from homeassistant.util import dt as dt_util
 from ._base import BaseLockProvider, CodeSlot, LockEventCallback
 from .const import ACCESS_CONTROL, ALARM_TYPE, UNKNOWN
 
+SetCredentialResult: Any
+SetUserOptions: Any
+SetUserResult: Any
+UserCredentialType: Any
+
+try:
+    from zwave_js_server.const.command_class.access_control import (
+        SetCredentialResult as _SetCredentialResult,
+        SetUserResult as _SetUserResult,
+        UserCredentialType as _UserCredentialType,
+    )
+    from zwave_js_server.model.access_control import SetUserOptions as _SetUserOptions
+except ImportError:
+    _HAS_CREDENTIAL_CC = False
+    SetCredentialResult = None
+    SetUserOptions = None
+    SetUserResult = None
+    UserCredentialType = None
+else:
+    _HAS_CREDENTIAL_CC = True
+    SetCredentialResult = _SetCredentialResult
+    SetUserOptions = _SetUserOptions
+    SetUserResult = _SetUserResult
+    UserCredentialType = _UserCredentialType
+
 if TYPE_CHECKING:
     from custom_components.keymaster.lock import KeymasterLock
 
@@ -298,6 +323,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
     _node: ZwaveJSNode | None = field(default=None, init=False, repr=False)
     _device: DeviceEntry | None = field(default=None, init=False, repr=False)
     _client: ZwaveJSClient | None = field(default=None, init=False, repr=False)
+    _uses_credential_cc: bool = field(default=False, init=False, repr=False)
 
     def _is_node_alive(self) -> bool:
         """Check if the Z-Wave node is alive (not dead).
@@ -447,6 +473,18 @@ class ZWaveJSLockProvider(BaseLockProvider):
                 node_id,
             )
 
+        self._uses_credential_cc = False
+        if _HAS_CREDENTIAL_CC and hasattr(self._node, "access_control"):
+            try:
+                self._uses_credential_cc = await self._node.access_control.is_supported()
+            except Exception:  # noqa: BLE001
+                self._uses_credential_cc = False
+            _LOGGER.debug(
+                "[ZWaveJSProvider] Node %s uses %s CC for PIN",
+                node_id,
+                "User Credential" if self._uses_credential_cc else "User Code",
+            )
+
         self._connected = True
         _LOGGER.debug(
             "[ZWaveJSProvider] Connected to lock %s (node %s)",
@@ -471,11 +509,54 @@ class ZWaveJSLockProvider(BaseLockProvider):
         self._connected = connected
         return connected
 
+    def _credential_to_code_slot(
+        self, user: Any | None, credentials: list[Any], slot_num: int
+    ) -> CodeSlot:
+        """Convert User Credential CC data to a provider code slot."""
+        pin = next(
+            (
+                credential
+                for credential in credentials
+                if credential.type == UserCredentialType.PIN_CODE
+            ),
+            None,
+        )
+        return CodeSlot(
+            slot_num=slot_num,
+            code=pin.data if pin else None,
+            in_use=bool(user and user.active and pin),
+        )
+
     async def async_get_usercodes(self) -> list[CodeSlot]:
         """Get all user codes from the Z-Wave JS lock."""
         if not self._node:
             _LOGGER.error("[ZWaveJSProvider] No node available for get_usercodes")
             return []
+
+        if self._uses_credential_cc:
+            try:
+                users = await self._node.access_control.get_users_cached()
+                credentials = await self._node.access_control.get_all_credentials_cached()
+            except BaseZwaveJSServerError as e:
+                _LOGGER.error(
+                    "[ZWaveJSProvider] Failed to get credentials: %s: %s",
+                    e.__class__.__qualname__,
+                    e,
+                )
+                return []
+
+            credentials_by_user: dict[int, list[Any]] = {}
+            for credential in credentials:
+                if credential.type == UserCredentialType.PIN_CODE:
+                    credentials_by_user.setdefault(credential.user_id, []).append(credential)
+            return [
+                self._credential_to_code_slot(
+                    user,
+                    credentials_by_user.get(user.user_id, []),
+                    user.user_id,
+                )
+                for user in users
+            ]
 
         try:
             zwave_codes = get_usercodes(self._node)
@@ -509,6 +590,22 @@ class ZWaveJSLockProvider(BaseLockProvider):
         if not self._node:
             return None
 
+        if self._uses_credential_cc:
+            try:
+                user = await self._node.access_control.get_user_cached(slot_num)
+                if user is None:
+                    return CodeSlot(slot_num=slot_num, code=None, in_use=False)
+                credentials = await self._node.access_control.get_credentials_cached(slot_num)
+            except BaseZwaveJSServerError as e:
+                _LOGGER.error(
+                    "[ZWaveJSProvider] Failed to get credential for slot %s: %s: %s",
+                    slot_num,
+                    e.__class__.__qualname__,
+                    e,
+                )
+                return None
+            return self._credential_to_code_slot(user, credentials, slot_num)
+
         try:
             zw_slot: ZwaveJSCodeSlot = get_usercode(self._node, slot_num)
             return CodeSlot(
@@ -532,6 +629,22 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
         if not self._is_node_alive():
             return None
+
+        if self._uses_credential_cc:
+            try:
+                user = await self._node.access_control.get_user(slot_num)
+                if user is None:
+                    return CodeSlot(slot_num=slot_num, code=None, in_use=False)
+                credentials = await self._node.access_control.get_credentials(slot_num)
+            except BaseZwaveJSServerError as e:
+                _LOGGER.error(
+                    "[ZWaveJSProvider] Failed to refresh credential for slot %s: %s: %s",
+                    slot_num,
+                    e.__class__.__qualname__,
+                    e,
+                )
+                return None
+            return self._credential_to_code_slot(user, credentials, slot_num)
 
         try:
             zw_slot: ZwaveJSCodeSlot = await get_usercode_from_node(self._node, slot_num)
@@ -558,6 +671,48 @@ class ZWaveJSLockProvider(BaseLockProvider):
         if not self._is_node_alive():
             return False
 
+        if self._uses_credential_cc:
+            try:
+                user_result = await self._node.access_control.set_user(
+                    slot_num,
+                    SetUserOptions(active=True, user_name=name),
+                )
+                if user_result != SetUserResult.OK:
+                    _LOGGER.error(
+                        "[ZWaveJSProvider] Failed to set user on slot %s: %s",
+                        slot_num,
+                        user_result,
+                    )
+                    return False
+
+                credential_result = await self._node.access_control.set_credential(
+                    slot_num,
+                    UserCredentialType.PIN_CODE,
+                    1,
+                    code,
+                )
+                if credential_result != SetCredentialResult.OK:
+                    _LOGGER.error(
+                        "[ZWaveJSProvider] Failed to set credential on slot %s: %s",
+                        slot_num,
+                        credential_result,
+                    )
+                    return False
+            except BaseZwaveJSServerError as e:
+                _LOGGER.error(
+                    "[ZWaveJSProvider] Failed to set credential on slot %s: %s: %s",
+                    slot_num,
+                    e.__class__.__qualname__,
+                    e,
+                )
+                return False
+            else:
+                _LOGGER.debug(
+                    "[ZWaveJSProvider] Set credential on slot %s",
+                    slot_num,
+                )
+                return True
+
         try:
             await set_usercode(self._node, slot_num, code)
         except BaseZwaveJSServerError as e:
@@ -583,6 +738,49 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
         if not self._is_node_alive():
             return False
+
+        if self._uses_credential_cc:
+            try:
+                credential_result = await self._node.access_control.delete_credential(
+                    slot_num,
+                    UserCredentialType.PIN_CODE,
+                    1,
+                )
+                ok_credential_results = (
+                    SetCredentialResult.OK,
+                    SetCredentialResult.ERROR_MODIFY_REJECTED_LOCATION_EMPTY,
+                )
+                if credential_result not in ok_credential_results:
+                    _LOGGER.error(
+                        "[ZWaveJSProvider] Failed to delete credential on slot %s: %s",
+                        slot_num,
+                        credential_result,
+                    )
+                    return False
+
+                user_result = await self._node.access_control.delete_user(slot_num)
+                ok_user_results = (
+                    SetUserResult.OK,
+                    SetUserResult.ERROR_MODIFY_REJECTED_LOCATION_EMPTY,
+                )
+                if user_result not in ok_user_results:
+                    _LOGGER.error(
+                        "[ZWaveJSProvider] Failed to delete user on slot %s: %s",
+                        slot_num,
+                        user_result,
+                    )
+                    return False
+            except BaseZwaveJSServerError as e:
+                _LOGGER.error(
+                    "[ZWaveJSProvider] Failed to clear credential on slot %s: %s: %s",
+                    slot_num,
+                    e.__class__.__qualname__,
+                    e,
+                )
+                return False
+            else:
+                # User Credential CC delete result codes are authoritative.
+                return True
 
         try:
             await clear_usercode(self._node, slot_num)

--- a/custom_components/keymaster/providers/zwave_js.py
+++ b/custom_components/keymaster/providers/zwave_js.py
@@ -527,6 +527,27 @@ class ZWaveJSLockProvider(BaseLockProvider):
             in_use=bool(user and user.active and pin),
         )
 
+    async def _verify_credential_state(self, slot_num: int, expect_present: bool) -> bool:
+        """Re-read a credential slot after a transient write result."""
+        if not self._node:
+            return False
+
+        try:
+            user = await self._node.access_control.get_user(slot_num)
+            credentials = await self._node.access_control.get_credentials(slot_num)
+        except BaseZwaveJSServerError as e:
+            _LOGGER.debug(
+                "[ZWaveJSProvider] Verify failed for slot %s: %s",
+                slot_num,
+                e,
+            )
+            return False
+
+        has_pin = any(credential.type == UserCredentialType.PIN_CODE for credential in credentials)
+        if not expect_present:
+            return user is None and not has_pin
+        return user is not None and has_pin
+
     async def async_get_usercodes(self) -> list[CodeSlot]:
         """Get all user codes from the Z-Wave JS lock."""
         if not self._node:
@@ -673,31 +694,12 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
         if self._uses_credential_cc:
             try:
-                user_result = await self._node.access_control.set_user(
-                    slot_num,
-                    SetUserOptions(active=True, user_name=name),
-                )
-                if user_result != SetUserResult.OK:
-                    _LOGGER.error(
-                        "[ZWaveJSProvider] Failed to set user on slot %s: %s",
-                        slot_num,
-                        user_result,
-                    )
-                    return False
-
                 credential_result = await self._node.access_control.set_credential(
                     slot_num,
                     UserCredentialType.PIN_CODE,
-                    1,
+                    slot_num,
                     code,
                 )
-                if credential_result != SetCredentialResult.OK:
-                    _LOGGER.error(
-                        "[ZWaveJSProvider] Failed to set credential on slot %s: %s",
-                        slot_num,
-                        credential_result,
-                    )
-                    return False
             except BaseZwaveJSServerError as e:
                 _LOGGER.error(
                     "[ZWaveJSProvider] Failed to set credential on slot %s: %s: %s",
@@ -706,12 +708,50 @@ class ZWaveJSLockProvider(BaseLockProvider):
                     e,
                 )
                 return False
-            else:
+
+            if credential_result == SetCredentialResult.ERROR_UNKNOWN:
+                if not await self._verify_credential_state(slot_num, expect_present=True):
+                    _LOGGER.error(
+                        "[ZWaveJSProvider] Failed to verify credential set on slot %s",
+                        slot_num,
+                    )
+                    return False
                 _LOGGER.debug(
-                    "[ZWaveJSProvider] Set credential on slot %s",
-                    slot_num,
+                    "[ZWaveJSProvider] Credential set verified post-op despite ERROR_UNKNOWN",
                 )
-                return True
+            elif credential_result != SetCredentialResult.OK:
+                _LOGGER.error(
+                    "[ZWaveJSProvider] Failed to set credential on slot %s: %s",
+                    slot_num,
+                    credential_result,
+                )
+                return False
+
+            if name:
+                try:
+                    user_result = await self._node.access_control.set_user(
+                        slot_num,
+                        SetUserOptions(user_name=name),
+                    )
+                except BaseZwaveJSServerError as e:
+                    _LOGGER.debug(
+                        "[ZWaveJSProvider] Could not set user_name on slot %s: %s",
+                        slot_num,
+                        e,
+                    )
+                else:
+                    if user_result != SetUserResult.OK:
+                        _LOGGER.debug(
+                            "[ZWaveJSProvider] Could not set user_name on slot %s: %s",
+                            slot_num,
+                            user_result,
+                        )
+
+            _LOGGER.debug(
+                "[ZWaveJSProvider] Set credential on slot %s",
+                slot_num,
+            )
+            return True
 
         try:
             await set_usercode(self._node, slot_num, code)
@@ -744,11 +784,14 @@ class ZWaveJSLockProvider(BaseLockProvider):
                 credential_result = await self._node.access_control.delete_credential(
                     slot_num,
                     UserCredentialType.PIN_CODE,
-                    1,
+                    slot_num,
                 )
+                # LOCATION_EMPTY means the slot was already empty, which is the
+                # desired post-condition for a clear operation.
                 ok_credential_results = (
                     SetCredentialResult.OK,
                     SetCredentialResult.ERROR_MODIFY_REJECTED_LOCATION_EMPTY,
+                    SetCredentialResult.ERROR_UNKNOWN,
                 )
                 if credential_result not in ok_credential_results:
                     _LOGGER.error(
@@ -759,9 +802,12 @@ class ZWaveJSLockProvider(BaseLockProvider):
                     return False
 
                 user_result = await self._node.access_control.delete_user(slot_num)
+                # LOCATION_EMPTY means the user was already absent, which is the
+                # desired post-condition for a clear operation.
                 ok_user_results = (
                     SetUserResult.OK,
                     SetUserResult.ERROR_MODIFY_REJECTED_LOCATION_EMPTY,
+                    SetUserResult.ERROR_UNKNOWN,
                 )
                 if user_result not in ok_user_results:
                     _LOGGER.error(
@@ -778,9 +824,22 @@ class ZWaveJSLockProvider(BaseLockProvider):
                     e,
                 )
                 return False
-            else:
-                # User Credential CC delete result codes are authoritative.
+
+            if await self._verify_credential_state(slot_num, expect_present=False):
+                if (
+                    credential_result == SetCredentialResult.ERROR_UNKNOWN
+                    or user_result == SetUserResult.ERROR_UNKNOWN
+                ):
+                    _LOGGER.debug(
+                        "[ZWaveJSProvider] Credential clear verified post-op despite ERROR_UNKNOWN",
+                    )
                 return True
+
+            _LOGGER.warning(
+                "[ZWaveJSProvider] Failed to verify credential clear on slot %s",
+                slot_num,
+            )
+            return False
 
         try:
             await clear_usercode(self._node, slot_num)

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -1,5 +1,8 @@
 """Tests for the Z-Wave JS lock provider."""
 
+from dataclasses import dataclass
+from enum import Enum
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,13 +12,86 @@ from zwave_js_server.event import Event
 from zwave_js_server.exceptions import BaseZwaveJSServerError, FailedZWaveCommand
 
 from custom_components.keymaster.const import DOMAIN
-from custom_components.keymaster.providers import create_provider, get_provider_class_for_lock
+from custom_components.keymaster.providers import (
+    create_provider,
+    get_provider_class_for_lock,
+    zwave_js as zwave_js_provider,
+)
 from custom_components.keymaster.providers.zwave_js import ZWaveJSLockProvider
 from homeassistant.components.lock.const import LockState
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from tests.common import async_capture_events
 from tests.const import CONFIG_DATA_910
+
+
+class FakeSetCredentialResult(Enum):
+    """Fake User Credential CC credential result values."""
+
+    OK = "ok"
+    ERROR_MODIFY_REJECTED_LOCATION_EMPTY = "empty"
+    ERROR_INVALID = "invalid"
+
+
+class FakeSetUserResult(Enum):
+    """Fake User Credential CC user result values."""
+
+    OK = "ok"
+    ERROR_MODIFY_REJECTED_LOCATION_EMPTY = "empty"
+    ERROR_INVALID = "invalid"
+
+
+class FakeUserCredentialType(Enum):
+    """Fake User Credential CC credential types."""
+
+    PIN_CODE = "pin_code"
+    RFID = "rfid"
+
+
+@dataclass
+class FakeSetUserOptions:
+    """Fake SetUserOptions value."""
+
+    active: bool
+    user_name: str | None = None
+
+
+class OldLibraryNode:
+    """Node without the access_control API."""
+
+    node_id = 14
+    status = NodeStatus.ALIVE
+
+
+def enable_fake_credential_cc(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch zwave_js provider to expose fake User Credential CC imports."""
+    monkeypatch.setattr(zwave_js_provider, "_HAS_CREDENTIAL_CC", True)
+    monkeypatch.setattr(zwave_js_provider, "SetCredentialResult", FakeSetCredentialResult)
+    monkeypatch.setattr(zwave_js_provider, "SetUserOptions", FakeSetUserOptions)
+    monkeypatch.setattr(zwave_js_provider, "SetUserResult", FakeSetUserResult)
+    monkeypatch.setattr(zwave_js_provider, "UserCredentialType", FakeUserCredentialType)
+
+
+def setup_successful_connect(
+    zwave_provider: ZWaveJSLockProvider,
+    mock_zwave_client: MagicMock,
+) -> MagicMock:
+    """Set up registry mocks for a successful Z-Wave JS connection."""
+    mock_entity = MagicMock()
+    mock_entity.config_entry_id = "zwave_entry_id"
+    mock_entity.device_id = "device_id"
+    zwave_provider.entity_registry.async_get.return_value = mock_entity
+
+    mock_zwave_entry = MagicMock()
+    mock_zwave_entry.runtime_data = MagicMock()
+    mock_zwave_entry.runtime_data.client = mock_zwave_client
+    zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
+
+    mock_device = MagicMock()
+    mock_device.identifiers = {("zwave_js", "12345-14")}
+    mock_device.id = "device_id"
+    zwave_provider.device_registry.async_get.return_value = mock_device
+    return mock_device
 
 
 @pytest.fixture
@@ -191,26 +267,70 @@ class TestZWaveJSLockProviderConnect:
 
     async def test_connect_success(self, zwave_provider, mock_zwave_client, mock_zwave_node):
         """Test successful connection."""
-        mock_entity = MagicMock()
-        mock_entity.config_entry_id = "zwave_entry_id"
-        mock_entity.device_id = "device_id"
-        zwave_provider.entity_registry.async_get.return_value = mock_entity
-
-        mock_zwave_entry = MagicMock()
-        mock_zwave_entry.runtime_data = MagicMock()
-        mock_zwave_entry.runtime_data.client = mock_zwave_client
-        zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
-
-        mock_device = MagicMock()
-        mock_device.identifiers = {("zwave_js", "12345-14")}  # Node ID 14
-        mock_device.id = "device_id"
-        zwave_provider.device_registry.async_get.return_value = mock_device
+        mock_device = setup_successful_connect(zwave_provider, mock_zwave_client)
 
         result = await zwave_provider.async_connect()
 
         assert result is True
         assert zwave_provider.node is mock_zwave_node
         assert zwave_provider.device is mock_device
+
+    async def test_connect_detects_credential_cc(
+        self, zwave_provider, mock_zwave_client, mock_zwave_node, monkeypatch
+    ):
+        """Test connect enables credential path when User Credential CC is supported."""
+        enable_fake_credential_cc(monkeypatch)
+        setup_successful_connect(zwave_provider, mock_zwave_client)
+        mock_zwave_node.access_control = MagicMock()
+        mock_zwave_node.access_control.is_supported = AsyncMock(return_value=True)
+
+        result = await zwave_provider.async_connect()
+
+        assert result is True
+        assert zwave_provider._uses_credential_cc is True
+
+    async def test_connect_uses_legacy_when_credential_cc_unsupported(
+        self, zwave_provider, mock_zwave_client, mock_zwave_node, monkeypatch
+    ):
+        """Test connect keeps legacy path when User Credential CC is unsupported."""
+        enable_fake_credential_cc(monkeypatch)
+        setup_successful_connect(zwave_provider, mock_zwave_client)
+        mock_zwave_node.access_control = MagicMock()
+        mock_zwave_node.access_control.is_supported = AsyncMock(return_value=False)
+
+        result = await zwave_provider.async_connect()
+
+        assert result is True
+        assert zwave_provider._uses_credential_cc is False
+
+    async def test_connect_probe_falls_back_on_error(
+        self, zwave_provider, mock_zwave_client, mock_zwave_node, monkeypatch
+    ):
+        """Test connect keeps legacy path when credential support probe raises."""
+        enable_fake_credential_cc(monkeypatch)
+        setup_successful_connect(zwave_provider, mock_zwave_client)
+        mock_zwave_node.access_control = MagicMock()
+        mock_zwave_node.access_control.is_supported = AsyncMock(side_effect=RuntimeError("boom"))
+
+        result = await zwave_provider.async_connect()
+
+        assert result is True
+        assert zwave_provider._uses_credential_cc is False
+
+    async def test_connect_falls_back_without_access_control(
+        self, zwave_provider, mock_zwave_client, monkeypatch
+    ):
+        """Test connect keeps legacy path when zwave-js-server lacks access_control."""
+        enable_fake_credential_cc(monkeypatch)
+        old_node = OldLibraryNode()
+        mock_zwave_client.driver.controller.nodes = {14: old_node}
+        setup_successful_connect(zwave_provider, mock_zwave_client)
+
+        result = await zwave_provider.async_connect()
+
+        assert result is True
+        assert zwave_provider.node is old_node
+        assert zwave_provider._uses_credential_cc is False
 
 
 class TestZWaveJSLockProviderIsConnected:
@@ -437,6 +557,278 @@ class TestZWaveJSLockProviderUsercodes:
             result = await zwave_provider.async_clear_usercode(1)
 
         assert result is True
+
+
+class TestZWaveJSLockProviderCredentialCC:
+    """Test Z-Wave JS User Credential CC code operations."""
+
+    @pytest.fixture
+    def credential_provider(self, zwave_provider, mock_zwave_node, monkeypatch):
+        """Create a provider using the credential CC path."""
+        enable_fake_credential_cc(monkeypatch)
+        access_control = MagicMock()
+        mock_zwave_node.access_control = access_control
+        zwave_provider._node = mock_zwave_node
+        zwave_provider._uses_credential_cc = True
+        return zwave_provider, access_control
+
+    async def test_set_usercode_success(self, credential_provider):
+        """Test credential CC set creates an active user then PIN credential."""
+        zwave_provider, access_control = credential_provider
+        access_control.set_user = AsyncMock(return_value=FakeSetUserResult.OK)
+        access_control.set_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
+
+        result = await zwave_provider.async_set_usercode(2, "2468", name="Guest")
+
+        assert result is True
+        access_control.set_user.assert_awaited_once()
+        slot_num, options = access_control.set_user.await_args.args
+        assert slot_num == 2
+        assert options == FakeSetUserOptions(active=True, user_name="Guest")
+        access_control.set_credential.assert_awaited_once_with(
+            2,
+            FakeUserCredentialType.PIN_CODE,
+            1,
+            "2468",
+        )
+
+    async def test_set_usercode_fails_when_set_user_fails(self, credential_provider):
+        """Test credential CC set stops when setting the user fails."""
+        zwave_provider, access_control = credential_provider
+        access_control.set_user = AsyncMock(return_value=FakeSetUserResult.ERROR_INVALID)
+        access_control.set_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
+
+        result = await zwave_provider.async_set_usercode(2, "2468")
+
+        assert result is False
+        access_control.set_credential.assert_not_awaited()
+
+    async def test_set_usercode_fails_when_set_credential_fails(self, credential_provider):
+        """Test credential CC set fails when setting the PIN fails."""
+        zwave_provider, access_control = credential_provider
+        access_control.set_user = AsyncMock(return_value=FakeSetUserResult.OK)
+        access_control.set_credential = AsyncMock(
+            return_value=FakeSetCredentialResult.ERROR_INVALID
+        )
+
+        result = await zwave_provider.async_set_usercode(2, "2468")
+
+        assert result is False
+
+    async def test_clear_usercode_success(self, credential_provider):
+        """Test credential CC clear deletes PIN credential then user."""
+        zwave_provider, access_control = credential_provider
+        access_control.delete_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
+        access_control.delete_user = AsyncMock(return_value=FakeSetUserResult.OK)
+
+        result = await zwave_provider.async_clear_usercode(3)
+
+        assert result is True
+        access_control.delete_credential.assert_awaited_once_with(
+            3,
+            FakeUserCredentialType.PIN_CODE,
+            1,
+        )
+        access_control.delete_user.assert_awaited_once_with(3)
+
+    async def test_clear_usercode_tolerates_empty_slot(self, credential_provider):
+        """Test credential CC clear accepts already-empty result codes."""
+        zwave_provider, access_control = credential_provider
+        access_control.delete_credential = AsyncMock(
+            return_value=FakeSetCredentialResult.ERROR_MODIFY_REJECTED_LOCATION_EMPTY
+        )
+        access_control.delete_user = AsyncMock(
+            return_value=FakeSetUserResult.ERROR_MODIFY_REJECTED_LOCATION_EMPTY
+        )
+
+        result = await zwave_provider.async_clear_usercode(3)
+
+        assert result is True
+
+    async def test_clear_usercode_fails_on_delete_credential_error(self, credential_provider):
+        """Test credential CC clear fails when deleting the credential fails."""
+        zwave_provider, access_control = credential_provider
+        access_control.delete_credential = AsyncMock(
+            return_value=FakeSetCredentialResult.ERROR_INVALID
+        )
+        access_control.delete_user = AsyncMock(return_value=FakeSetUserResult.OK)
+
+        result = await zwave_provider.async_clear_usercode(3)
+
+        assert result is False
+        access_control.delete_user.assert_not_awaited()
+
+    async def test_clear_usercode_fails_on_delete_user_error(self, credential_provider):
+        """Test credential CC clear fails when deleting the user fails."""
+        zwave_provider, access_control = credential_provider
+        access_control.delete_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
+        access_control.delete_user = AsyncMock(return_value=FakeSetUserResult.ERROR_INVALID)
+
+        result = await zwave_provider.async_clear_usercode(3)
+
+        assert result is False
+
+    async def test_get_usercodes_reconstructs_slots(self, credential_provider):
+        """Test credential CC get all combines users and PIN credentials."""
+        zwave_provider, access_control = credential_provider
+        users = [
+            SimpleNamespace(user_id=1, active=True),
+            SimpleNamespace(user_id=2, active=False),
+            SimpleNamespace(user_id=3, active=True),
+        ]
+        credentials = [
+            SimpleNamespace(user_id=1, type=FakeUserCredentialType.PIN_CODE, data="1111"),
+            SimpleNamespace(user_id=2, type=FakeUserCredentialType.PIN_CODE, data="2222"),
+            SimpleNamespace(user_id=3, type=FakeUserCredentialType.RFID, data="tag"),
+        ]
+        access_control.get_users_cached = AsyncMock(return_value=users)
+        access_control.get_all_credentials_cached = AsyncMock(return_value=credentials)
+
+        result = await zwave_provider.async_get_usercodes()
+
+        assert result[0].slot_num == 1
+        assert result[0].code == "1111"
+        assert result[0].in_use is True
+        assert result[1].slot_num == 2
+        assert result[1].code == "2222"
+        assert result[1].in_use is False
+        assert result[2].slot_num == 3
+        assert result[2].code is None
+        assert result[2].in_use is False
+
+    async def test_get_usercodes_handles_exception(self, credential_provider):
+        """Test credential CC get all handles server errors."""
+        zwave_provider, access_control = credential_provider
+        access_control.get_users_cached = AsyncMock(side_effect=BaseZwaveJSServerError("error"))
+
+        result = await zwave_provider.async_get_usercodes()
+
+        assert result == []
+
+    async def test_get_usercode_existing_and_missing_user(self, credential_provider):
+        """Test credential CC get slot returns code or inactive slot for missing user."""
+        zwave_provider, access_control = credential_provider
+        access_control.get_user_cached = AsyncMock(
+            side_effect=[SimpleNamespace(user_id=4, active=True), None]
+        )
+        access_control.get_credentials_cached = AsyncMock(
+            return_value=[
+                SimpleNamespace(user_id=4, type=FakeUserCredentialType.PIN_CODE, data="4444")
+            ]
+        )
+
+        existing = await zwave_provider.async_get_usercode(4)
+        missing = await zwave_provider.async_get_usercode(5)
+
+        assert existing is not None
+        assert existing.slot_num == 4
+        assert existing.code == "4444"
+        assert existing.in_use is True
+        assert missing is not None
+        assert missing.slot_num == 5
+        assert missing.code is None
+        assert missing.in_use is False
+        access_control.get_credentials_cached.assert_awaited_once_with(4)
+
+    async def test_get_usercode_handles_exception(self, credential_provider):
+        """Test credential CC get slot handles server errors."""
+        zwave_provider, access_control = credential_provider
+        access_control.get_user_cached = AsyncMock(side_effect=BaseZwaveJSServerError("error"))
+
+        result = await zwave_provider.async_get_usercode(5)
+
+        assert result is None
+
+    async def test_refresh_usercode_uses_non_cached_getters(self, credential_provider):
+        """Test credential CC refresh reads user and credentials from the node."""
+        zwave_provider, access_control = credential_provider
+        access_control.get_user = AsyncMock(return_value=SimpleNamespace(user_id=6, active=True))
+        access_control.get_credentials = AsyncMock(
+            return_value=[
+                SimpleNamespace(user_id=6, type=FakeUserCredentialType.PIN_CODE, data="6666")
+            ]
+        )
+        access_control.get_user_cached = AsyncMock()
+        access_control.get_credentials_cached = AsyncMock()
+
+        result = await zwave_provider.async_refresh_usercode(6)
+
+        assert result is not None
+        assert result.code == "6666"
+        access_control.get_user.assert_awaited_once_with(6)
+        access_control.get_credentials.assert_awaited_once_with(6)
+        access_control.get_user_cached.assert_not_called()
+        access_control.get_credentials_cached.assert_not_called()
+
+    async def test_refresh_usercode_handles_exception(self, credential_provider):
+        """Test credential CC refresh handles server errors."""
+        zwave_provider, access_control = credential_provider
+        access_control.get_user = AsyncMock(side_effect=BaseZwaveJSServerError("error"))
+
+        result = await zwave_provider.async_refresh_usercode(6)
+
+        assert result is None
+
+    async def test_set_usercode_handles_set_user_exception(self, credential_provider):
+        """Test credential CC set handles set_user server errors."""
+        zwave_provider, access_control = credential_provider
+        access_control.set_user = AsyncMock(side_effect=BaseZwaveJSServerError("error"))
+        access_control.set_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
+
+        result = await zwave_provider.async_set_usercode(2, "2468")
+
+        assert result is False
+        access_control.set_credential.assert_not_awaited()
+
+    async def test_set_usercode_handles_set_credential_exception(self, credential_provider):
+        """Test credential CC set handles set_credential server errors."""
+        zwave_provider, access_control = credential_provider
+        access_control.set_user = AsyncMock(return_value=FakeSetUserResult.OK)
+        access_control.set_credential = AsyncMock(side_effect=BaseZwaveJSServerError("error"))
+
+        result = await zwave_provider.async_set_usercode(2, "2468")
+
+        assert result is False
+
+    async def test_clear_usercode_handles_delete_credential_exception(self, credential_provider):
+        """Test credential CC clear handles delete_credential server errors."""
+        zwave_provider, access_control = credential_provider
+        access_control.delete_credential = AsyncMock(side_effect=BaseZwaveJSServerError("error"))
+        access_control.delete_user = AsyncMock(return_value=FakeSetUserResult.OK)
+
+        result = await zwave_provider.async_clear_usercode(3)
+
+        assert result is False
+        access_control.delete_user.assert_not_awaited()
+
+    async def test_clear_usercode_handles_delete_user_exception(self, credential_provider):
+        """Test credential CC clear handles delete_user server errors."""
+        zwave_provider, access_control = credential_provider
+        access_control.delete_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
+        access_control.delete_user = AsyncMock(side_effect=BaseZwaveJSServerError("error"))
+
+        result = await zwave_provider.async_clear_usercode(3)
+
+        assert result is False
+
+    async def test_legacy_path_with_credential_cc_imports(
+        self, zwave_provider, mock_zwave_node, monkeypatch
+    ):
+        """Test legacy User Code CC path still works when credential imports exist."""
+        enable_fake_credential_cc(monkeypatch)
+        mock_zwave_node.access_control = MagicMock()
+        mock_zwave_node.access_control.is_supported = AsyncMock(return_value=False)
+        zwave_provider._node = mock_zwave_node
+        zwave_provider._uses_credential_cc = False
+
+        with patch(
+            "custom_components.keymaster.providers.zwave_js.set_usercode",
+            new_callable=AsyncMock,
+        ) as mock_set_usercode:
+            result = await zwave_provider.async_set_usercode(7, "7777")
+
+        assert result is True
+        mock_set_usercode.assert_awaited_once_with(mock_zwave_node, 7, "7777")
 
 
 class TestZWaveJSLockProviderEventSubscription:

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -1,8 +1,11 @@
 """Tests for the Z-Wave JS lock provider."""
 
+import builtins
 from dataclasses import dataclass
 from enum import Enum
-from types import SimpleNamespace
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -30,6 +33,7 @@ class FakeSetCredentialResult(Enum):
 
     OK = "ok"
     ERROR_MODIFY_REJECTED_LOCATION_EMPTY = "empty"
+    ERROR_UNKNOWN = 255
     ERROR_INVALID = "invalid"
 
 
@@ -38,6 +42,7 @@ class FakeSetUserResult(Enum):
 
     OK = "ok"
     ERROR_MODIFY_REJECTED_LOCATION_EMPTY = "empty"
+    ERROR_UNKNOWN = 255
     ERROR_INVALID = "invalid"
 
 
@@ -52,7 +57,7 @@ class FakeUserCredentialType(Enum):
 class FakeSetUserOptions:
     """Fake SetUserOptions value."""
 
-    active: bool
+    active: bool | None = None
     user_name: str | None = None
 
 
@@ -456,6 +461,19 @@ class TestZWaveJSLockProviderUsercodes:
         assert result is not None
         assert result.code == "9999"
 
+    async def test_get_usercode_from_node_error(self, zwave_provider, mock_zwave_node):
+        """Test get_usercode_from_node handles errors gracefully."""
+        zwave_provider._node = mock_zwave_node
+
+        with patch(
+            "custom_components.keymaster.providers.zwave_js.get_usercode_from_node",
+            new_callable=AsyncMock,
+            side_effect=BaseZwaveJSServerError("error"),
+        ):
+            result = await zwave_provider.async_refresh_usercode(1)
+
+        assert result is None
+
     async def test_set_usercode_no_node(self, zwave_provider):
         """Test set_usercode returns False when no node."""
         result = await zwave_provider.async_set_usercode(1, "1234")
@@ -567,13 +585,56 @@ class TestZWaveJSLockProviderCredentialCC:
         """Create a provider using the credential CC path."""
         enable_fake_credential_cc(monkeypatch)
         access_control = MagicMock()
+        access_control.get_user = AsyncMock(return_value=None)
+        access_control.get_credentials = AsyncMock(return_value=[])
         mock_zwave_node.access_control = access_control
         zwave_provider._node = mock_zwave_node
         zwave_provider._uses_credential_cc = True
         return zwave_provider, access_control
 
+    async def test_verify_credential_state_without_node(self, zwave_provider, monkeypatch):
+        """Test credential state verification fails without a node."""
+        enable_fake_credential_cc(monkeypatch)
+
+        result = await zwave_provider._verify_credential_state(1, expect_present=True)
+
+        assert result is False
+
+    async def test_verify_credential_state_handles_exception(self, credential_provider):
+        """Test credential state verification handles server errors."""
+        zwave_provider, access_control = credential_provider
+        access_control.get_user = AsyncMock(side_effect=BaseZwaveJSServerError("error"))
+
+        result = await zwave_provider._verify_credential_state(1, expect_present=True)
+
+        assert result is False
+
+    async def test_verify_credential_state_requires_pin_credential(self, credential_provider):
+        """Test credential state verification requires a PIN credential."""
+        zwave_provider, access_control = credential_provider
+        access_control.get_user = AsyncMock(return_value=SimpleNamespace(user_id=1, active=True))
+        access_control.get_credentials = AsyncMock(
+            return_value=[SimpleNamespace(user_id=1, type=FakeUserCredentialType.RFID, data="tag")]
+        )
+
+        result = await zwave_provider._verify_credential_state(1, expect_present=True)
+
+        assert result is False
+
+    async def test_refresh_usercode_returns_inactive_when_user_missing(self, credential_provider):
+        """Test credential CC refresh returns an inactive slot for a missing user."""
+        zwave_provider, access_control = credential_provider
+        access_control.get_user = AsyncMock(return_value=None)
+
+        result = await zwave_provider.async_refresh_usercode(6)
+
+        assert result is not None
+        assert result.slot_num == 6
+        assert result.code is None
+        assert result.in_use is False
+
     async def test_set_usercode_success(self, credential_provider):
-        """Test credential CC set creates an active user then PIN credential."""
+        """Test credential CC set creates the PIN credential before naming the user."""
         zwave_provider, access_control = credential_provider
         access_control.set_user = AsyncMock(return_value=FakeSetUserResult.OK)
         access_control.set_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
@@ -581,27 +642,37 @@ class TestZWaveJSLockProviderCredentialCC:
         result = await zwave_provider.async_set_usercode(2, "2468", name="Guest")
 
         assert result is True
-        access_control.set_user.assert_awaited_once()
-        slot_num, options = access_control.set_user.await_args.args
-        assert slot_num == 2
-        assert options == FakeSetUserOptions(active=True, user_name="Guest")
         access_control.set_credential.assert_awaited_once_with(
             2,
             FakeUserCredentialType.PIN_CODE,
-            1,
+            2,
             "2468",
         )
+        access_control.set_user.assert_awaited_once()
+        slot_num, options = access_control.set_user.await_args.args
+        assert slot_num == 2
+        assert options == FakeSetUserOptions(user_name="Guest")
 
-    async def test_set_usercode_fails_when_set_user_fails(self, credential_provider):
-        """Test credential CC set stops when setting the user fails."""
+    async def test_set_usercode_skips_set_user_without_name(self, credential_provider):
+        """Test credential CC set does not set user metadata without a name."""
         zwave_provider, access_control = credential_provider
-        access_control.set_user = AsyncMock(return_value=FakeSetUserResult.ERROR_INVALID)
+        access_control.set_user = AsyncMock(return_value=FakeSetUserResult.OK)
         access_control.set_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
 
         result = await zwave_provider.async_set_usercode(2, "2468")
 
-        assert result is False
-        access_control.set_credential.assert_not_awaited()
+        assert result is True
+        access_control.set_user.assert_not_awaited()
+
+    async def test_set_usercode_ignores_set_user_failure(self, credential_provider):
+        """Test credential CC set succeeds when only setting the user name fails."""
+        zwave_provider, access_control = credential_provider
+        access_control.set_user = AsyncMock(return_value=FakeSetUserResult.ERROR_INVALID)
+        access_control.set_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
+
+        result = await zwave_provider.async_set_usercode(2, "2468", name="Guest")
+
+        assert result is True
 
     async def test_set_usercode_fails_when_set_credential_fails(self, credential_provider):
         """Test credential CC set fails when setting the PIN fails."""
@@ -614,6 +685,40 @@ class TestZWaveJSLockProviderCredentialCC:
         result = await zwave_provider.async_set_usercode(2, "2468")
 
         assert result is False
+        access_control.set_user.assert_not_awaited()
+
+    async def test_set_usercode_verifies_error_unknown(self, credential_provider):
+        """Test credential CC set verifies transient ERROR_UNKNOWN results."""
+        zwave_provider, access_control = credential_provider
+        access_control.set_credential = AsyncMock(
+            return_value=FakeSetCredentialResult.ERROR_UNKNOWN
+        )
+        access_control.get_user = AsyncMock(return_value=SimpleNamespace(user_id=2, active=True))
+        access_control.get_credentials = AsyncMock(
+            return_value=[
+                SimpleNamespace(user_id=2, type=FakeUserCredentialType.PIN_CODE, data="2468")
+            ]
+        )
+        access_control.set_user = AsyncMock(return_value=FakeSetUserResult.OK)
+
+        result = await zwave_provider.async_set_usercode(2, "2468", name="Guest")
+
+        assert result is True
+        access_control.set_user.assert_awaited_once()
+
+    async def test_set_usercode_fails_when_error_unknown_not_verified(self, credential_provider):
+        """Test credential CC set fails when transient result cannot be verified."""
+        zwave_provider, access_control = credential_provider
+        access_control.set_credential = AsyncMock(
+            return_value=FakeSetCredentialResult.ERROR_UNKNOWN
+        )
+        access_control.get_user = AsyncMock(return_value=None)
+        access_control.set_user = AsyncMock(return_value=FakeSetUserResult.OK)
+
+        result = await zwave_provider.async_set_usercode(2, "2468", name="Guest")
+
+        assert result is False
+        access_control.set_user.assert_not_awaited()
 
     async def test_clear_usercode_success(self, credential_provider):
         """Test credential CC clear deletes PIN credential then user."""
@@ -627,7 +732,7 @@ class TestZWaveJSLockProviderCredentialCC:
         access_control.delete_credential.assert_awaited_once_with(
             3,
             FakeUserCredentialType.PIN_CODE,
-            1,
+            3,
         )
         access_control.delete_user.assert_awaited_once_with(3)
 
@@ -644,6 +749,48 @@ class TestZWaveJSLockProviderCredentialCC:
         result = await zwave_provider.async_clear_usercode(3)
 
         assert result is True
+
+    async def test_clear_usercode_verifies_error_unknown(self, credential_provider):
+        """Test credential CC clear verifies transient ERROR_UNKNOWN results."""
+        zwave_provider, access_control = credential_provider
+        access_control.delete_credential = AsyncMock(
+            return_value=FakeSetCredentialResult.ERROR_UNKNOWN
+        )
+        access_control.delete_user = AsyncMock(return_value=FakeSetUserResult.ERROR_UNKNOWN)
+        access_control.get_user = AsyncMock(return_value=None)
+
+        result = await zwave_provider.async_clear_usercode(3)
+
+        assert result is True
+
+    async def test_clear_usercode_fails_when_not_verified_empty(self, credential_provider):
+        """Test credential CC clear fails if final verification still sees a user."""
+        zwave_provider, access_control = credential_provider
+        access_control.delete_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
+        access_control.delete_user = AsyncMock(return_value=FakeSetUserResult.OK)
+        access_control.get_user = AsyncMock(return_value=SimpleNamespace(user_id=3, active=True))
+
+        result = await zwave_provider.async_clear_usercode(3)
+
+        assert result is False
+
+    async def test_clear_usercode_fails_when_pin_remains(self, credential_provider):
+        """Test credential CC clear fails if final verification still sees a PIN."""
+        zwave_provider, access_control = credential_provider
+        access_control.delete_credential = AsyncMock(
+            return_value=FakeSetCredentialResult.ERROR_UNKNOWN
+        )
+        access_control.delete_user = AsyncMock(return_value=FakeSetUserResult.OK)
+        access_control.get_user = AsyncMock(return_value=None)
+        access_control.get_credentials = AsyncMock(
+            return_value=[
+                SimpleNamespace(user_id=3, type=FakeUserCredentialType.PIN_CODE, data="3333")
+            ]
+        )
+
+        result = await zwave_provider.async_clear_usercode(3)
+
+        assert result is False
 
     async def test_clear_usercode_fails_on_delete_credential_error(self, credential_provider):
         """Test credential CC clear fails when deleting the credential fails."""
@@ -770,15 +917,14 @@ class TestZWaveJSLockProviderCredentialCC:
         assert result is None
 
     async def test_set_usercode_handles_set_user_exception(self, credential_provider):
-        """Test credential CC set handles set_user server errors."""
+        """Test credential CC set handles set_user server errors as non-fatal."""
         zwave_provider, access_control = credential_provider
         access_control.set_user = AsyncMock(side_effect=BaseZwaveJSServerError("error"))
         access_control.set_credential = AsyncMock(return_value=FakeSetCredentialResult.OK)
 
-        result = await zwave_provider.async_set_usercode(2, "2468")
+        result = await zwave_provider.async_set_usercode(2, "2468", name="Guest")
 
-        assert result is False
-        access_control.set_credential.assert_not_awaited()
+        assert result is True
 
     async def test_set_usercode_handles_set_credential_exception(self, credential_provider):
         """Test credential CC set handles set_credential server errors."""
@@ -935,6 +1081,54 @@ class TestZWaveJSLockProviderDiagnostics:
         assert result["node_id"] == 14
         assert result["node_status"] == "alive"
         assert result["lock_config_entry_id"] == "entry_123"
+
+
+def test_credential_cc_import_success(monkeypatch: pytest.MonkeyPatch):
+    """Test provider imports when User Credential CC is available."""
+    access_control_module = ModuleType("zwave_js_server.const.command_class.access_control")
+    setattr(access_control_module, "SetCredentialResult", FakeSetCredentialResult)
+    setattr(access_control_module, "SetUserResult", FakeSetUserResult)
+    setattr(access_control_module, "UserCredentialType", FakeUserCredentialType)
+    model_module = ModuleType("zwave_js_server.model.access_control")
+    setattr(model_module, "SetUserOptions", FakeSetUserOptions)
+    monkeypatch.setitem(
+        sys.modules,
+        "zwave_js_server.const.command_class.access_control",
+        access_control_module,
+    )
+    monkeypatch.setitem(sys.modules, "zwave_js_server.model.access_control", model_module)
+
+    importlib.reload(zwave_js_provider)
+
+    assert zwave_js_provider._HAS_CREDENTIAL_CC is True
+    assert zwave_js_provider.SetCredentialResult is FakeSetCredentialResult
+    assert zwave_js_provider.SetUserResult is FakeSetUserResult
+    assert zwave_js_provider.UserCredentialType is FakeUserCredentialType
+    assert zwave_js_provider.SetUserOptions is FakeSetUserOptions
+
+    monkeypatch.delitem(
+        sys.modules, "zwave_js_server.const.command_class.access_control", raising=False
+    )
+    monkeypatch.delitem(sys.modules, "zwave_js_server.model.access_control", raising=False)
+    importlib.reload(zwave_js_provider)
+
+
+def test_credential_cc_import_fallback(monkeypatch: pytest.MonkeyPatch):
+    """Test provider imports when User Credential CC is unavailable."""
+    original_import = builtins.__import__
+
+    def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("zwave_js_server.const.command_class.access_control"):
+            raise ImportError
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    importlib.reload(zwave_js_provider)
+
+    assert zwave_js_provider._HAS_CREDENTIAL_CC is False
+
+    monkeypatch.setattr(builtins, "__import__", original_import)
+    importlib.reload(zwave_js_provider)
 
 
 class TestProviderFactory:


### PR DESCRIPTION
HA Core 2026.6 adds zwave-js-server-python 0.71.0, where locks
that advertise User Credential CC may no longer expose legacy User Code
CC values. Keymaster then cannot find slots and PIN set or clear
operations fail with NotFoundError.

This keeps backward compatibility with guarded imports and probes each
Z-Wave JS node after connect. Locks without the new API, unsupported
credential CC, or probe errors continue through the legacy User Code CC
helpers. Locks with User Credential CC use user_id = slot number and
credential slot 1 for PIN credentials.

Behavior matrix:

- old HA without access_control imports: legacy User Code CC path
- new HA with old-firmware locks: legacy User Code CC path
- new HA with User Credential CC locks: credential user/PIN path

Tests cover connect probing and fallbacks, legacy dispatch with guarded
imports, credential get/set/refresh/clear flows, empty delete results,
user_name propagation, non-OK results, and server exceptions.

Closes #618