### PR TITLE
refactor(entities): keep value-bearing entities always available

### DIFF
--- a/custom_components/keymaster/number.py
+++ b/custom_components/keymaster/number.py
@@ -149,22 +149,6 @@ class KeymasterNumber(KeymasterEntity, NumberEntity):
             self.async_write_ha_state()
             return
 
-        if self._is_accesslimit_count and (
-            not self._kmlock.code_slots
-            or not self._code_slot
-            or not self._kmlock.code_slots[self._code_slot].accesslimit_count_enabled
-        ):
-            self._attr_available = False
-            self.async_write_ha_state()
-            return
-
-        if (
-            self._property.split(".")[-1].startswith("autolock")
-        ) and not self._kmlock.autolock_enabled:
-            self._attr_available = False
-            self.async_write_ha_state()
-            return
-
         self._attr_available = True
         self._attr_native_value = self._get_property_value()
         self.async_write_ha_state()

--- a/custom_components/keymaster/sensor.py
+++ b/custom_components/keymaster/sensor.py
@@ -170,11 +170,6 @@ class KeymasterAutoLockSensor(KeymasterEntity, SensorEntity):
             self.async_write_ha_state()
             return
 
-        if not self._kmlock.autolock_enabled:
-            self._attr_available = False
-            self.async_write_ha_state()
-            return
-
         self._attr_available = True
         timer = self._kmlock.autolock_timer
 

--- a/custom_components/keymaster/time.py
+++ b/custom_components/keymaster/time.py
@@ -120,15 +120,6 @@ class KeymasterTime(KeymasterEntity, TimeEntity):
             self.async_write_ha_state()
             return
 
-        if ".accesslimit_day_of_week" in self._property and (
-            not self._kmlock.code_slots
-            or not self._code_slot
-            or not self._kmlock.code_slots[self._code_slot].accesslimit_day_of_week_enabled
-        ):
-            self._attr_available = False
-            self.async_write_ha_state()
-            return
-
         if self._property.endswith(".time_start") or self._property.endswith(".time_end"):
             # code_slots and _code_slot validation already handled by lines 117-121 above
             # Safe to assert these are not None here
@@ -145,29 +136,6 @@ class KeymasterTime(KeymasterEntity, TimeEntity):
                 self._attr_available = False
                 self.async_write_ha_state()
                 return
-
-            day_of_week: KeymasterCodeSlotDayOfWeek | None = accesslimit_day_of_week[
-                self._day_of_week_num
-            ]
-            if day_of_week is None or not day_of_week.dow_enabled or not day_of_week.limit_by_time:
-                self._attr_available = False
-                self.async_write_ha_state()
-                return
-
-        # if (
-        #     self._property.endswith(".time_start")
-        #     or self._property.endswith(".time_end")
-        # ) and (
-        #     not self._kmlock.code_slots[self._code_slot]
-        #     .accesslimit_day_of_week[self._day_of_week_num]
-        #     .dow_enabled
-        #     or not self._kmlock.code_slots[self._code_slot]
-        #     .accesslimit_day_of_week[self._day_of_week_num]
-        #     .limit_by_time
-        # ):
-        #     self._attr_available = False
-        #     self.async_write_ha_state()
-        #     return
 
         self._attr_available = True
         self._attr_native_value = self._get_property_value()

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -375,3 +375,58 @@ async def test_datetime_entity_available_with_valid_code_slot(
     # Should be available and have the value
     assert entity._attr_available
     assert entity._attr_native_value == datetime(2024, 1, 1, 0, 0, 0)
+
+
+@pytest.mark.parametrize(
+    ("key", "attr_name", "value"),
+    [
+        (
+            "datetime.code_slots:1.accesslimit_date_range_start",
+            "accesslimit_date_range_start",
+            datetime(2025, 1, 1, 8, 0, 0),
+        ),
+        (
+            "datetime.code_slots:1.accesslimit_date_range_end",
+            "accesslimit_date_range_end",
+            datetime(2025, 1, 2, 18, 0, 0),
+        ),
+    ],
+)
+async def test_datetime_entities_can_be_preset_when_feature_disabled(
+    hass: HomeAssistant, datetime_config_entry, coordinator, key, attr_name, value
+):
+    """Test date range datetimes are available and writable while disabled."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=datetime_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(
+            number=1,
+            enabled=True,
+            accesslimit_date_range_enabled=False,
+        )
+    }
+    coordinator.kmlocks[datetime_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterDateTimeEntityDescription(
+        key=key,
+        name="Date Range",
+        icon="mdi:calendar",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=datetime_config_entry,
+        coordinator=coordinator,
+    )
+    entity = KeymasterDateTime(entity_description=entity_description)
+
+    with patch.object(coordinator, "async_request_debounced_refresh", new=AsyncMock()):
+        await entity.async_set_value(value)
+    with patch.object(entity, "async_write_ha_state"):
+        entity._handle_coordinator_update()
+
+    assert entity._attr_available
+    assert entity._attr_native_value == value
+    assert getattr(kmlock.code_slots[1], attr_name) == value

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -284,10 +284,10 @@ async def test_number_entity_unavailable_when_code_slot_missing(
     assert not entity._attr_available
 
 
-async def test_number_entity_unavailable_when_accesslimit_not_enabled(
+async def test_number_entity_available_when_accesslimit_not_enabled(
     hass: HomeAssistant, number_config_entry, coordinator
 ):
-    """Test number entity becomes unavailable when accesslimit_count is not enabled."""
+    """Test number entity stays available when accesslimit_count is not enabled."""
 
     # Create a lock with code slot but accesslimit_count_enabled is False
     kmlock = KeymasterLock(
@@ -325,13 +325,14 @@ async def test_number_entity_unavailable_when_accesslimit_not_enabled(
     with patch.object(entity, "async_write_ha_state"):
         entity._handle_coordinator_update()
 
-    assert not entity._attr_available
+    assert entity._attr_available
+    assert entity._attr_native_value is None
 
 
-async def test_number_entity_unavailable_when_autolock_not_enabled(
+async def test_number_entity_available_when_autolock_not_enabled(
     hass: HomeAssistant, number_config_entry, coordinator
 ):
-    """Test autolock number entity becomes unavailable when autolock is not enabled."""
+    """Test autolock number entity stays available when autolock is not enabled."""
 
     # Create a lock with autolock disabled
     kmlock = KeymasterLock(
@@ -364,7 +365,8 @@ async def test_number_entity_unavailable_when_autolock_not_enabled(
     with patch.object(entity, "async_write_ha_state"):
         entity._handle_coordinator_update()
 
-    assert not entity._attr_available
+    assert entity._attr_available
+    assert entity._attr_native_value is None
 
 
 async def test_number_entity_available_when_autolock_enabled(
@@ -614,3 +616,61 @@ async def test_number_entity_autolock_float_to_int(
         assert isinstance(entity._attr_native_value, int)
         assert getattr(kmlock, attr_name) == 5
         assert isinstance(getattr(kmlock, attr_name), int)
+
+
+@pytest.mark.parametrize(
+    ("key", "slot_kwargs", "lock_attr", "value"),
+    [
+        ("number.autolock_min_day", None, "autolock_min_day", 15),
+        ("number.autolock_min_night", None, "autolock_min_night", 20),
+        (
+            "number.code_slots:1.accesslimit_count",
+            {"accesslimit_count_enabled": False},
+            "accesslimit_count",
+            7,
+        ),
+    ],
+)
+async def test_number_entities_can_be_preset_when_feature_disabled(
+    hass: HomeAssistant, number_config_entry, coordinator, key, slot_kwargs, lock_attr, value
+):
+    """Test number entities remain available and writable while feature is disabled."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=number_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.autolock_enabled = False
+    if slot_kwargs is not None:
+        kmlock.code_slots = {1: KeymasterCodeSlot(number=1, enabled=True, **slot_kwargs)}
+    coordinator.kmlocks[number_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterNumberEntityDescription(
+        key=key,
+        name="Preset Number",
+        icon="mdi:numeric",
+        mode=NumberMode.BOX,
+        native_min_value=0,
+        native_step=1,
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=number_config_entry,
+        coordinator=coordinator,
+    )
+    entity = KeymasterNumber(entity_description=entity_description)
+
+    with (
+        patch.object(coordinator, "async_request_debounced_refresh", new=AsyncMock()),
+        patch.object(entity, "async_write_ha_state"),
+    ):
+        await entity.async_set_native_value(value)
+        entity._handle_coordinator_update()
+
+    assert entity._attr_available
+    assert entity._attr_native_value == value
+    target: object = kmlock
+    if slot_kwargs is not None:
+        assert kmlock.code_slots is not None
+        target = kmlock.code_slots[1]
+    assert getattr(target, lock_attr) == value

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -323,10 +323,10 @@ async def test_autolock_sensor_unavailable_when_not_connected(
     assert not entity._attr_available
 
 
-async def test_autolock_sensor_unavailable_when_autolock_disabled(
+async def test_autolock_sensor_available_when_autolock_disabled(
     hass: HomeAssistant, sensor_config_entry, coordinator
 ):
-    """Test auto-lock timer sensor becomes unavailable when autolock is not enabled."""
+    """Test auto-lock timer sensor stays available when autolock is not enabled."""
     kmlock = KeymasterLock(
         lock_name="frontdoor",
         lock_entity_id="lock.test",
@@ -351,7 +351,9 @@ async def test_autolock_sensor_unavailable_when_autolock_disabled(
     with patch.object(entity, "async_write_ha_state"):
         entity._handle_coordinator_update()
 
-    assert not entity._attr_available
+    assert entity._attr_available
+    assert entity._attr_native_value is None
+    assert entity._attr_extra_state_attributes["is_running"] is False
 
 
 async def test_autolock_sensor_idle_when_timer_not_running(
@@ -527,3 +529,45 @@ async def test_autolock_sensor_created_in_setup(hass: HomeAssistant):
 def test_autolock_sensor_seconds_to_hhmmss(seconds, expected):
     """Test _seconds_to_hhmmss formats correctly."""
     assert KeymasterAutoLockSensor._seconds_to_hhmmss(seconds) == expected
+
+
+async def test_autolock_sensor_keeps_value_when_autolock_disabled(
+    hass: HomeAssistant, sensor_config_entry, coordinator
+):
+    """Test auto-lock timer sensor remains available after disabling autolock."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=sensor_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.autolock_enabled = True
+
+    end_time = dt.now(tz=UTC) + timedelta(minutes=5)
+    mock_timer = Mock()
+    mock_timer.is_running = True
+    mock_timer.end_time = end_time
+    mock_timer.remaining_seconds = 300
+    mock_timer.duration = 600
+    kmlock.autolock_timer = mock_timer
+    coordinator.kmlocks[sensor_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterSensorEntityDescription(
+        key="sensor.autolock_timer",
+        name="Auto Lock Timer",
+        icon="mdi:lock-clock",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=sensor_config_entry,
+        coordinator=coordinator,
+    )
+    entity = KeymasterAutoLockSensor(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state"):
+        entity._handle_coordinator_update()
+        kmlock.autolock_enabled = False
+        entity._handle_coordinator_update()
+
+    assert entity._attr_available
+    assert entity._attr_native_value == end_time
+    assert entity._attr_extra_state_attributes["is_running"] is True

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -285,8 +285,8 @@ async def test_time_entity_child_lock_ignores_change_without_override(
         assert "not set to override parent. Ignoring change" in caplog.text
 
 
-async def test_time_entity_unavailable_when_dow_not_enabled(hass: HomeAssistant, time_config_entry):
-    """Test time entity is unavailable when day of week is not enabled."""
+async def test_time_entity_available_when_dow_not_enabled(hass: HomeAssistant, time_config_entry):
+    """Test time entity stays available when day of week is not enabled."""
 
     coordinator = hass.data[DOMAIN][COORDINATOR]
 
@@ -332,13 +332,14 @@ async def test_time_entity_unavailable_when_dow_not_enabled(hass: HomeAssistant,
     with patch.object(entity, "async_write_ha_state"):
         entity._handle_coordinator_update()
 
-    assert not entity._attr_available
+    assert entity._attr_available
+    assert entity._attr_native_value is None
 
 
-async def test_time_entity_unavailable_when_limit_by_time_disabled(
+async def test_time_entity_available_when_limit_by_time_disabled(
     hass: HomeAssistant, time_config_entry
 ):
-    """Test time entity is unavailable when limit_by_time is disabled."""
+    """Test time entity stays available when limit_by_time is disabled."""
 
     coordinator = hass.data[DOMAIN][COORDINATOR]
 
@@ -384,7 +385,8 @@ async def test_time_entity_unavailable_when_limit_by_time_disabled(
     with patch.object(entity, "async_write_ha_state"):
         entity._handle_coordinator_update()
 
-    assert not entity._attr_available
+    assert entity._attr_available
+    assert entity._attr_native_value is None
 
 
 async def test_time_entity_child_lock_unavailable_without_code_slots(
@@ -606,3 +608,58 @@ async def test_time_entity_available_with_valid_configuration(
     # Should be available with proper native_value set
     assert entity._attr_available
     assert entity._attr_native_value == test_time
+
+
+@pytest.mark.parametrize(
+    ("key", "attr_name", "value"),
+    [
+        ("time.code_slots:1.accesslimit_day_of_week:0.time_start", "time_start", dt_time(8, 30)),
+        ("time.code_slots:1.accesslimit_day_of_week:0.time_end", "time_end", dt_time(17, 45)),
+    ],
+)
+async def test_time_entities_can_be_preset_when_feature_disabled(
+    hass: HomeAssistant, time_config_entry, key, attr_name, value
+):
+    """Test day-of-week time entities are available and writable while disabled."""
+    coordinator = hass.data[DOMAIN][COORDINATOR]
+    day_of_week = KeymasterCodeSlotDayOfWeek(
+        day_of_week_num=0,
+        day_of_week_name="Monday",
+        dow_enabled=False,
+        limit_by_time=False,
+    )
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=time_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(
+            number=1,
+            enabled=True,
+            accesslimit_day_of_week_enabled=False,
+            accesslimit_day_of_week={0: day_of_week},
+        )
+    }
+    coordinator.kmlocks[time_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterTimeEntityDescription(
+        key=key,
+        name="Code Slot 1: Monday Time",
+        icon="mdi:clock",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=time_config_entry,
+        coordinator=coordinator,
+    )
+    entity = KeymasterTime(entity_description=entity_description)
+
+    with patch.object(coordinator, "async_request_debounced_refresh"):
+        await entity.async_set_value(value)
+    with patch.object(entity, "async_write_ha_state"):
+        entity._handle_coordinator_update()
+
+    assert entity._attr_available
+    assert entity._attr_native_value == value
+    assert getattr(day_of_week, attr_name) == value


### PR DESCRIPTION
## Summary

Remove cosmetic availability gating on child entities so they remain
available whenever the integration is loaded. Values persist at their
last-set value when the owning feature toggle is disabled.

## Entities affected

- `sensor.autolock_timer`
- `number.autolock_min_day` / `autolock_min_night`
- `number.accesslimit_count`
- `datetime.accesslimit_date_range_start` / `_end`
- `time.accesslimit_day_of_week_*_time_start` / `_end`

## Rationale

- Health-check integrations (Watchman, etc.) flag perpetually-
  unavailable entities as broken devices, producing false-positive
  warnings.
- The coordinator already gates feature behavior on the real toggles
  (`autolock_enabled`, `accesslimit_*_enabled`, `_is_slot_active()`),
  so entity availability gating served no functional purpose.
- Always-available entities allow users to pre-set values before
  enabling a feature, which is useful for automation patterns.

## Out of scope

The `*_enabled` switch entities and parent/child override gating are
intentionally untouched; they need a separate Phase 2 pass.

Fixes #622
