### PR TITLE
fix: declare lovelace as after_dependency to fix #620

### DIFF
--- a/custom_components/keymaster/manifest.json
+++ b/custom_components/keymaster/manifest.json
@@ -9,6 +9,7 @@
     "input_number",
     "input_text",
     "local_akuvox",
+    "lovelace",
     "mqtt",
     "ozw",
     "schlage",

--- a/custom_components/keymaster/resources.py
+++ b/custom_components/keymaster/resources.py
@@ -31,6 +31,11 @@ async def async_register_strategy_resource(hass: HomeAssistant) -> None:
     """Register the Lovelace strategy resource when supported."""
     resources = get_lovelace_resources(hass)
     if not resources:
+        _LOGGER.warning(
+            "Lovelace integration not available; skipping strategy module "
+            "registration. The keymaster dashboard strategy will not work "
+            "until Lovelace is loaded and Home Assistant is restarted."
+        )
         return
 
     if isinstance(resources, ResourceStorageCollection) and not resources.loaded:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -139,13 +139,15 @@ async def test_register_strategy_resource_yaml_mode_already_exists(
     assert "YAML mode" not in caplog.text
 
 
-async def test_register_strategy_resource_no_resources(hass: HomeAssistant):
-    """Test registering when no resources available."""
+async def test_register_strategy_resource_no_resources(hass: HomeAssistant, caplog):
+    """Test registering when no resources available logs a warning."""
     # No lovelace domain
     hass.data[DOMAIN] = {}
 
-    # Should not raise
-    await async_register_strategy_resource(hass)
+    with caplog.at_level(logging.WARNING):
+        await async_register_strategy_resource(hass)
+
+    assert "Lovelace integration not available" in caplog.text
 
 
 async def test_cleanup_strategy_resource_removes(hass: HomeAssistant, mock_storage_resources):


### PR DESCRIPTION
## Summary
- Adds `lovelace` to `after_dependencies` in `manifest.json` so keymaster's `async_setup` runs **after** Home Assistant has populated `hass.data["lovelace"]`. Without this hint, the resource-registration step can silently no-op when keymaster loads before Lovelace, leaving the dashboard strategy module unregistered.
- Promotes the previously-silent "no Lovelace data" branch in `async_register_strategy_resource` from a bare `return` to a `_LOGGER.warning`, so any future occurrence of this skip path is visible in HA logs instead of debug-only.
- Updates the existing `test_register_strategy_resource_no_resources` test to assert the warning is emitted.

Fixes #620.

### Why this is the root cause
The reporter confirmed in #620 that:
- `keymaster.js` was never requested in the browser network tab.
- No keymaster entry was present in Settings → Dashboards → Resources.

That points to `async_register_strategy_resource` not running its `async_create_item` path. Looking at `resources.py:33`, the function returns silently when `hass.data.get("lovelace")` is falsy — which happens if keymaster sets up before the Lovelace integration. There was no dependency hint in the manifest forcing the order, so the bug surfaces non-deterministically depending on integration load order on a given install. This matches the pattern in the closed #583 where a version bump alone "fixed" the issue (a different boot ordering won the race).

## Test plan
- [ ] `pytest tests/test_resources.py` — passes locally (13/13).
- [ ] Manually reproduce on an install where the dashboard strategy was failing: install this branch, restart HA, confirm `/keymaster_files/keymaster.js` shows up in browser network tab and a keymaster module entry appears in Settings → Dashboards → Resources.
- [ ] Confirm the new WARNING line is emitted in `home-assistant.log` only on installs where Lovelace truly isn't loaded (edge case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)