### PR TITLE
fix(zwave_js): verify User Credential CC support before using it

### DIFF
--- a/custom_components/keymaster/providers/zwave_js.py
+++ b/custom_components/keymaster/providers/zwave_js.py
@@ -476,7 +476,9 @@ class ZWaveJSLockProvider(BaseLockProvider):
         self._uses_credential_cc = False
         if _HAS_CREDENTIAL_CC and hasattr(self._node, "access_control"):
             try:
-                self._uses_credential_cc = await self._node.access_control.is_supported()
+                self._uses_credential_cc = await self._node.access_control.is_supported() and any(
+                    cc.id == 18 for cc in self._node.command_classes
+                )
             except Exception:  # noqa: BLE001
                 self._uses_credential_cc = False
             _LOGGER.debug(

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -289,6 +289,10 @@ class TestZWaveJSLockProviderConnect:
         mock_zwave_node.access_control = MagicMock()
         mock_zwave_node.access_control.is_supported = AsyncMock(return_value=True)
 
+        mock_cc = MagicMock()
+        mock_cc.id = 18
+        mock_zwave_node.command_classes = [mock_cc]
+
         result = await zwave_provider.async_connect()
 
         assert result is True


### PR DESCRIPTION
# Summary
<!--
  Please include a summary of the change and which issue is fixed or linked.
  Please also include relevant motivation and context.
-->
This PR fixes issue #626 by refining how Keymaster detects support for the User Credential Command Class (CC) when initializing the Z-Wave JS lock provider. 

Previously, Keymaster checked `await self._node.access_control.is_supported()`. However, the Z-Wave JS API's `access_control.is_supported()` returns `True` if **either** the legacy User Code CC (CC 0x62) or the newer User Credential CC (CC 0x12) is supported. This caused Keymaster to assume User Credential CC support (`_uses_credential_cc = True`) on older locks (like the Schlage BE469) that only support the legacy User Code CC. Consequently, attempts to configure or clear PIN codes failed with:
`Z-Wave error 322 - Credential slot XX is out of range for credential type PINCode (ZW0322)`

## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change updates the connection logic so that we check both `await self._node.access_control.is_supported()` and verify that the node supports Command Class ID `18` (decimal for `0x12` - User Credential CC) before setting `self._uses_credential_cc = True`. This ensures that older locks correctly fall back to the legacy User Code CC APIs.

Additionally, the unit test `test_connect_detects_credential_cc` in `tests/providers/test_zwave_js.py` has been updated to mock a supported Command Class list containing ID `18` on the fake node.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #626
- This PR is related to issue: #626
