### PR TITLE
fix: settings wiped during reconfiguration by separating unloading and removal lifecycles

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -219,7 +219,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Handle removal of an entry."""
+    """Handle unloading of an entry."""
     lockname: str = config_entry.data[CONF_LOCK_NAME]
     _LOGGER.info("Unloading %s", lockname)
     unload_ok: bool = all(
@@ -233,19 +233,11 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
     if unload_ok and DOMAIN in hass.data and COORDINATOR in hass.data[DOMAIN]:
         coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
-        await coordinator.delete_lock_by_config_entry_id(config_entry.entry_id, immediate=True)
-
-        if coordinator.count_locks_not_pending_delete == 0:
-            delay = 0 if "pytest" in sys.modules else 20
-            _LOGGER.debug(
-                "[async_unload_entry] Possibly empty coordinator. Will evaluate for removal at %s",
-                dt.now().astimezone() + timedelta(seconds=delay),
-            )
-            async_call_later(
-                hass=hass,
-                delay=delay,
-                action=functools.partial(delete_coordinator, hass, config_entry.entry_id),
-            )
+        kmlock = coordinator.sync_get_lock_by_config_entry_id(config_entry.entry_id)
+        if kmlock:
+            await KeymasterCoordinator._unsubscribe_listeners(kmlock)  # noqa: SLF001
+            if kmlock.provider:
+                await kmlock.provider.async_unload()
 
     # Clean up strategy resource if no other keymaster entries need it
     remaining_entries = [
@@ -261,6 +253,25 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         await async_cleanup_strategy_resource(hass, hass_data)
 
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    """Handle removal of an entry."""
+    if DOMAIN in hass.data and COORDINATOR in hass.data[DOMAIN]:
+        coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+        await coordinator.delete_lock_by_config_entry_id(config_entry.entry_id, immediate=True)
+
+        if coordinator.count_locks_not_pending_delete == 0:
+            delay = 0 if "pytest" in sys.modules else 20
+            _LOGGER.debug(
+                "[async_remove_entry] Possibly empty coordinator. Will evaluate for removal at %s",
+                dt.now().astimezone() + timedelta(seconds=delay),
+            )
+            async_call_later(
+                hass=hass,
+                delay=delay,
+                action=functools.partial(delete_coordinator, hass, config_entry.entry_id),
+            )
 
 
 async def delete_coordinator(hass: HomeAssistant, unloaded_entry_id: str, _: dt) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,6 +21,7 @@ from custom_components.keymaster.const import (
     CONF_PARENT_ENTRY_ID,
     CONF_SLOTS,
     CONF_START,
+    COORDINATOR,
     DEFAULT_ADVANCED_DATE_RANGE,
     DEFAULT_ADVANCED_DAY_OF_WEEK,
     DOMAIN,
@@ -274,3 +275,30 @@ async def test_setup_entry_calls_add_lock_with_update_true_for_existing_lock(has
     assert add_lock_await_args is not None
     add_lock_kwargs = add_lock_await_args.kwargs
     assert add_lock_kwargs["update"] is True
+
+
+async def test_unload_vs_remove_lock_preservation(
+    hass,
+    mock_async_call_later,
+    lock_kwikset_910,
+    integration,
+):
+    """Test that unloading does not delete the lock, but removing does."""
+
+    entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][COORDINATOR]
+    assert entry.entry_id in coordinator.kmlocks
+
+    # Unload should NOT delete the lock from the coordinator
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.entry_id in coordinator.kmlocks
+
+    # Remove should delete the lock from the coordinator
+    assert await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.entry_id not in coordinator.kmlocks

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -293,10 +293,16 @@ async def test_unload_vs_remove_lock_preservation(
     coordinator = hass.data[DOMAIN][COORDINATOR]
     assert entry.entry_id in coordinator.kmlocks
 
+    # Set up a mock provider to ensure line 240 is covered
+    kmlock = coordinator.kmlocks[entry.entry_id]
+    mock_provider = AsyncMock()
+    kmlock.provider = mock_provider
+
     # Unload should NOT delete the lock from the coordinator
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
     assert entry.entry_id in coordinator.kmlocks
+    mock_provider.async_unload.assert_awaited_once()
 
     # Remove should delete the lock from the coordinator
     assert await hass.config_entries.async_remove(entry.entry_id)


### PR DESCRIPTION
# Summary

Separates the config entry unloading and removal lifecycles. 

Previously, when a user reconfigured or reloaded their lock integration, Keymaster would call `coordinator.delete_lock_by_config_entry_id(..., immediate=True)` inside `async_unload_entry`. This popped the lock from `coordinator.kmlocks` and updated the persistent JSON store on disk, effectively wiping out all configured settings, code slot names, and PINs. Upon reload, a defaulted lock instance was created.

By introducing `async_remove_entry` (which is only triggered when the integration is permanently deleted), we ensure that a lock's persistent settings survive simple reloads and reconfigurations.

## Proposed change

- Modified `async_unload_entry` in `custom_components/keymaster/__init__.py` to perform temporary, non-destructive cleanup (unsubscribing listeners, unloading the lock provider) and leave the lock registered in the coordinator.
- Added `async_remove_entry` to permanently delete the lock config and update the persistent JSON storage when the integration config entry is removed by the user.
- Added `test_unload_vs_remove_lock_preservation` in `tests/test_init.py` to assert that the lock is preserved in `coordinator.kmlocks` upon unload, but deleted upon removal.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #627
- This PR is related to issue:
