### PR TITLE
feat: add native Zigbee2MQTT lock provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,22 @@ wiki page for setup instructions and configuration options.
 Please visit this project's
 [Wiki](https://github.com/FutureTense/keymaster/wiki) for the latest
 installation and update procedure.
+
+## Zigbee2MQTT Support
+
+Keymaster supports Zigbee locks integrated via Zigbee2MQTT. Because Keymaster
+needs to read and write PIN codes directly from the lock, you **must** enable
+PIN code exposure in Zigbee2MQTT.
+
+To do this, ensure `expose_pin` is set to `true` in your Zigbee2MQTT settings
+for the lock. For example, in your `configuration.yaml` for Zigbee2MQTT:
+
+```yaml
+devices:
+  '0x000d6f000d6f000d':
+    friendly_name: front_door_lock
+    expose_pin: true
+```
+
+Without this setting, Keymaster will not be able to retrieve or set user codes
+on the lock.

--- a/custom_components/keymaster/exceptions.py
+++ b/custom_components/keymaster/exceptions.py
@@ -21,3 +21,11 @@ class NotFoundError(HomeAssistantError):
 
 class NotSupportedError(HomeAssistantError):
     """Raised when action is not supported."""
+
+
+class LockDisconnected(HomeAssistantError):
+    """Raised when the lock is disconnected or unavailable."""
+
+
+class LockOperationFailed(HomeAssistantError):
+    """Raised when a lock operation fails."""

--- a/custom_components/keymaster/providers/__init__.py
+++ b/custom_components/keymaster/providers/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from ._base import BaseLockProvider, CodeSlot, ConnectionCallback, LockEventCallback
 from .akuvox import AkuvoxLockProvider
 from .schlage import SchlageLockProvider
+from .zigbee2mqtt import Zigbee2MQTTLockProvider
 from .zwave_js import ZWaveJSLockProvider
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 # configured in Home Assistant.
 PROVIDER_MAP: dict[str, type[BaseLockProvider]] = {
     "local_akuvox": AkuvoxLockProvider,
+    "mqtt": Zigbee2MQTTLockProvider,
     "schlage": SchlageLockProvider,
     "zwave_js": ZWaveJSLockProvider,
 }

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -162,9 +162,9 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
 
             # Check for keypad actions
             action = payload.get("action")
-            slot_num = payload.get("action_user")
-            if action or slot_num:
-                self.hass.async_create_task(self._async_handle_action(action, slot_num))
+            action_slot_num = payload.get("action_user")
+            if action or action_slot_num:
+                self.hass.async_create_task(self._async_handle_action(action, action_slot_num))
 
             # Parse bulk users list if available
             if "users" in payload and isinstance(payload["users"], dict):
@@ -201,7 +201,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
                 pin_data = payload["pin_code"]
                 user_slot = pin_data.get("user")
                 if isinstance(user_slot, int):
-                    user_enabled = pin_data.get("user_enabled", True)
+                    user_enabled = pin_data.get("user_enabled", False)
                     if "pin_code" not in pin_data:
                         slot_data = CodeSlot(
                             slot_num=user_slot,

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -52,6 +52,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
     _pending_usercode_futures: dict[int, asyncio.Future[CodeSlot]] = field(
         default_factory=dict, init=False, repr=False
     )
+    _lock_event_callback: LockEventCallback | None = field(default=None, init=False, repr=False)
 
     @property
     def domain(self) -> str:
@@ -66,7 +67,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
     @property
     def supports_connection_status(self) -> bool:
         """Zigbee2MQTT can report connection status."""
-        return True
+        return False
 
     @property
     def base_topic(self) -> str | None:
@@ -159,6 +160,12 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
             except ValueError:
                 return
 
+            # Check for keypad actions
+            action = payload.get("action")
+            slot_num = payload.get("action_user")
+            if action or slot_num:
+                self.hass.async_create_task(self._async_handle_action(action, slot_num))
+
             # Parse bulk users list if available
             if "users" in payload and isinstance(payload["users"], dict):
                 for slot_str, info in payload["users"].items():
@@ -169,10 +176,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
 
                     status = info.get("status")
                     if "pin_code" not in info:
-                        if status == "enabled":
-                            # Skip slot if it's enabled but code is not exposed (pin_code key is missing)
-                            continue
-                        in_use = False
+                        in_use = status == "enabled"
                         code = None
                     else:
                         code_val = info["pin_code"]
@@ -199,21 +203,16 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
                 if isinstance(user_slot, int):
                     user_enabled = pin_data.get("user_enabled", True)
                     if "pin_code" not in pin_data:
-                        if user_enabled:
-                            # Skip if enabled but code is not exposed (pin_code key is missing)
-                            pass
-                        else:
-                            # If disabled, it's not in use
-                            slot_data = CodeSlot(
-                                slot_num=user_slot,
-                                code=None,
-                                in_use=False,
-                            )
-                            self._usercodes_cache[user_slot] = slot_data
-                            if user_slot in self._pending_usercode_futures:
-                                fut = self._pending_usercode_futures[user_slot]
-                                if not fut.done():
-                                    fut.set_result(slot_data)
+                        slot_data = CodeSlot(
+                            slot_num=user_slot,
+                            code=None,
+                            in_use=bool(user_enabled),
+                        )
+                        self._usercodes_cache[user_slot] = slot_data
+                        if user_slot in self._pending_usercode_futures:
+                            fut = self._pending_usercode_futures[user_slot]
+                            if not fut.done():
+                                fut.set_result(slot_data)
                     else:
                         code_val = pin_data["pin_code"]
                         code = _get_pin_code_value(code_val)
@@ -357,52 +356,35 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         )
         return True
 
+    async def _async_handle_action(self, action: Any, slot_num: Any) -> None:
+        """Handle keypad action events."""
+        if not isinstance(slot_num, int):
+            return
+
+        if self._lock_event_callback:
+            if action == "keypad_unlock":
+                await self._lock_event_callback(slot_num, "Unlocked via Keypad", 1)
+            elif action == "keypad_lock":
+                await self._lock_event_callback(slot_num, "Keypad Lock", 5)
+
+        if action in ("pin_code_added", "pin_code_deleted"):
+            # Re-query the slot so the cache reflects the keypad-side change.
+            get_topic = self.get_topic
+            if get_topic:
+                await self._async_publish(get_topic, json.dumps({"pin_code": {"user": slot_num}}))
+
     def subscribe_lock_events(
         self, kmlock: KeymasterLock, callback: LockEventCallback
     ) -> Callable[[], None]:
         """Subscribe to keypad lock/unlock events."""
-        unsub_list: list[Callable[[], None]] = []
+        self._lock_event_callback = callback
 
-        async def handle_lock_message(msg: mqtt.ReceiveMessage) -> None:
-            """Handle lock events from MQTT state topic."""
-            try:
-                payload = json.loads(msg.payload)
-            except ValueError:
-                return
+        def unsubscribe() -> None:
+            """Unsubscribe from lock events."""
+            if self._lock_event_callback == callback:
+                self._lock_event_callback = None
 
-            action = payload.get("action")
-            slot_num = payload.get("action_user")
-
-            if action == "keypad_unlock" and isinstance(slot_num, int):
-                # Trigger Keymaster callback (user code slot unlocked keypad)
-                # action_code 1 represents keypad unlock in Keymaster
-                await callback(slot_num, "Unlocked via Keypad", 1)
-            elif action == "keypad_lock" and isinstance(slot_num, int):
-                # action_code 5 represents keypad lock in Keymaster
-                await callback(slot_num, "Keypad Lock", 5)
-
-        # Subscribe using HAs MQTT API and wrap in task to execute callback safely
-        async def subscribe() -> None:
-            state_topic = self.state_topic
-            if not state_topic:
-                _LOGGER.error("[Zigbee2MQTTProvider] State topic not available for subscribe")
-                return
-            unsub = await mqtt.async_subscribe(
-                self.hass,
-                state_topic,
-                lambda msg: self.hass.async_create_task(handle_lock_message(msg)),
-            )
-            unsub_list.append(unsub)
-            self._listeners.append(unsub)
-
-        self.hass.async_create_task(subscribe())
-
-        def unsubscribe_all() -> None:
-            """Unsubscribe all listeners."""
-            for unsub_fn in unsub_list:
-                unsub_fn()
-
-        return unsubscribe_all
+        return unsubscribe
 
     def subscribe_connection_events(self, callback: ConnectionCallback) -> Callable[[], None]:
         """Subscribe to availability events (connection status monitoring)."""

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -115,7 +115,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
             """Handle incoming state updates."""
             try:
                 payload = json.loads(msg.payload)
-            except (json.JSONDecodeError, TypeError):
+            except ValueError:
                 return
 
             # Parse bulk users list if available
@@ -267,7 +267,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
             """Handle unlock events from MQTT state topic."""
             try:
                 payload = json.loads(msg.payload)
-            except (json.JSONDecodeError, TypeError):
+            except ValueError:
                 return
 
             action = payload.get("action")

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -7,11 +7,14 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from custom_components.keymaster.const import CONF_SLOTS, CONF_START
+from custom_components.keymaster.exceptions import LockDisconnected, LockOperationFailed
 from homeassistant.components import mqtt
+from homeassistant.components.mqtt import mqtt_config_entry_enabled
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 
 from ._base import BaseLockProvider, CodeSlot, ConnectionCallback, LockEventCallback
 
@@ -21,14 +24,34 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _mqtt_payload_pin_has_code_value(value: Any) -> bool:
+    """Check if the payload pin_code has a valid code value."""
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int | float):
+        return True
+    if isinstance(value, str):
+        return value.strip() != ""
+    return False
+
+
+def _get_pin_code_value(value: Any) -> str | None:
+    """Get pin code string value if valid, otherwise None."""
+    if _mqtt_payload_pin_has_code_value(value):
+        return str(value)
+    return None
+
+
 @dataclass
 class Zigbee2MQTTLockProvider(BaseLockProvider):
     """Zigbee2MQTT lock provider implementation."""
 
-    _base_topic: str | None = field(default=None, init=False, repr=False)
-    _command_topic: str | None = field(default=None, init=False, repr=False)
-    _state_topic: str | None = field(default=None, init=False, repr=False)
     _usercodes_cache: dict[int, CodeSlot] = field(default_factory=dict, init=False, repr=False)
+    _pending_usercode_futures: dict[int, asyncio.Future[CodeSlot]] = field(
+        default_factory=dict, init=False, repr=False
+    )
 
     @property
     def domain(self) -> str:
@@ -44,6 +67,43 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
     def supports_connection_status(self) -> bool:
         """Zigbee2MQTT can report connection status."""
         return True
+
+    @property
+    def base_topic(self) -> str | None:
+        """Get the base topic dynamically from the device name."""
+        device_entry = self.get_device_entry()
+        if not device_entry or not device_entry.name:
+            return None
+        return f"zigbee2mqtt/{device_entry.name}"
+
+    @property
+    def set_topic(self) -> str | None:
+        """Get the set topic dynamically."""
+        base = self.base_topic
+        return f"{base}/set" if base else None
+
+    @property
+    def get_topic(self) -> str | None:
+        """Get the get topic dynamically."""
+        base = self.base_topic
+        return f"{base}/get" if base else None
+
+    @property
+    def state_topic(self) -> str | None:
+        """Get the state topic dynamically."""
+        return self.base_topic
+
+    async def _async_publish(self, topic: str, payload: str) -> None:
+        """Publish a message to MQTT with error handling."""
+        if not mqtt_config_entry_enabled(self.hass):
+            raise LockDisconnected("MQTT integration config entry is not enabled")
+
+        try:
+            await mqtt.async_publish(self.hass, topic, payload, qos=1, retain=False)
+        except OSError as err:
+            raise LockDisconnected(f"Failed to publish to MQTT: {err}") from err
+        except HomeAssistantError as err:
+            raise LockOperationFailed(f"Failed to publish to MQTT: {err}") from err
 
     async def async_connect(self) -> bool:
         """Connect to the Zigbee2MQTT lock."""
@@ -68,46 +128,27 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
 
         self.lock_config_entry_id = lock_entry.config_entry_id
 
-        # Get the actual lock entity to read its configuration topics
-        lock_component = self.hass.data.get("entity_components", {}).get("lock")
-        if not lock_component:
-            _LOGGER.error("[Zigbee2MQTTProvider] Lock component not found in hass.data")
-            return False
-
-        lock_entity = lock_component.get_entity(self.lock_entity_id)
-        if not lock_entity:
+        # Verify device is a Zigbee2MQTT device via identifiers
+        device_entry = self.get_device_entry()
+        if not device_entry:
             _LOGGER.error(
-                "[Zigbee2MQTTProvider] Entity not found in lock component: %s",
+                "[Zigbee2MQTTProvider] Can't find lock device in Device Registry: %s",
                 self.lock_entity_id,
             )
             return False
 
-        # Read config topics from the MQTT lock entity
-        if not hasattr(lock_entity, "_config") or not isinstance(lock_entity._config, dict):  # noqa: SLF001
+        is_z2m = False
+        for domain, identifier in device_entry.identifiers:
+            if domain == "mqtt" and identifier.startswith("zigbee2mqtt_"):
+                is_z2m = True
+                break
+
+        if not is_z2m:
             _LOGGER.error(
-                "[Zigbee2MQTTProvider] Lock entity lacks MQTT config: %s",
+                "[Zigbee2MQTTProvider] Lock device is not a Zigbee2MQTT device: %s",
                 self.lock_entity_id,
             )
             return False
-
-        command_topic = lock_entity._config.get("command_topic")  # noqa: SLF001
-        state_topic = lock_entity._config.get("state_topic")  # noqa: SLF001
-
-        if not command_topic or not state_topic:
-            _LOGGER.error(
-                "[Zigbee2MQTTProvider] Lock entity missing command/state topics: %s",
-                self.lock_entity_id,
-            )
-            return False
-
-        self._command_topic = command_topic
-        self._state_topic = state_topic
-
-        # Extract base topic by stripping '/set' if present
-        if command_topic.endswith("/set"):
-            self._base_topic = command_topic[:-4]
-        else:
-            self._base_topic = command_topic
 
         # Subscribe to lock's state topic to cache user code updates
         @callback
@@ -126,47 +167,89 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
                     except ValueError:
                         continue
 
-                    pin_code = info.get("pin_code")
                     status = info.get("status")
-                    in_use = status == "enabled"
+                    if "pin_code" not in info:
+                        if status == "enabled":
+                            # Skip slot if it's enabled but code is not exposed (pin_code key is missing)
+                            continue
+                        in_use = False
+                        code = None
+                    else:
+                        code_val = info["pin_code"]
+                        code = _get_pin_code_value(code_val)
+                        in_use = bool(code and status == "enabled")
 
-                    self._usercodes_cache[slot_num] = CodeSlot(
+                    slot_data = CodeSlot(
                         slot_num=slot_num,
-                        code=pin_code or None,
+                        code=code,
                         in_use=in_use,
                     )
+                    self._usercodes_cache[slot_num] = slot_data
+
+                    # Resolve pending future if any
+                    if slot_num in self._pending_usercode_futures:
+                        fut = self._pending_usercode_futures[slot_num]
+                        if not fut.done():
+                            fut.set_result(slot_data)
 
             # Parse single user pin_code update
             if "pin_code" in payload and isinstance(payload["pin_code"], dict):
                 pin_data = payload["pin_code"]
                 user_slot = pin_data.get("user")
                 if isinstance(user_slot, int):
-                    pin_code = pin_data.get("pin_code")
                     user_enabled = pin_data.get("user_enabled", True)
-                    in_use = bool(pin_code and user_enabled)
-
-                    self._usercodes_cache[user_slot] = CodeSlot(
-                        slot_num=user_slot,
-                        code=pin_code or None,
-                        in_use=in_use,
-                    )
+                    if "pin_code" not in pin_data:
+                        if user_enabled:
+                            # Skip if enabled but code is not exposed (pin_code key is missing)
+                            pass
+                        else:
+                            # If disabled, it's not in use
+                            slot_data = CodeSlot(
+                                slot_num=user_slot,
+                                code=None,
+                                in_use=False,
+                            )
+                            self._usercodes_cache[user_slot] = slot_data
+                            if user_slot in self._pending_usercode_futures:
+                                fut = self._pending_usercode_futures[user_slot]
+                                if not fut.done():
+                                    fut.set_result(slot_data)
+                    else:
+                        code_val = pin_data["pin_code"]
+                        code = _get_pin_code_value(code_val)
+                        in_use = bool(code and user_enabled)
+                        slot_data = CodeSlot(
+                            slot_num=user_slot,
+                            code=code,
+                            in_use=in_use,
+                        )
+                        self._usercodes_cache[user_slot] = slot_data
+                        if user_slot in self._pending_usercode_futures:
+                            fut = self._pending_usercode_futures[user_slot]
+                            if not fut.done():
+                                fut.set_result(slot_data)
 
         # Listen to state topic for code changes
+        state_topic = self.state_topic
+        if not state_topic:
+            _LOGGER.error("[Zigbee2MQTTProvider] Base topic could not be derived from device name")
+            return False
+
         self._listeners.append(
-            await mqtt.async_subscribe(self.hass, self._state_topic, handle_state_message)
+            await mqtt.async_subscribe(self.hass, state_topic, handle_state_message)
         )
 
         self._connected = True
         _LOGGER.debug(
             "[Zigbee2MQTTProvider] Connected to lock %s (base_topic: %s)",
             self.lock_entity_id,
-            self._base_topic,
+            self.base_topic,
         )
         return True
 
     async def async_is_connected(self) -> bool:
         """Check if Zigbee2MQTT lock connection is active."""
-        if not self._base_topic:
+        if not self.base_topic:
             self._connected = False
             return False
 
@@ -179,28 +262,44 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         self._connected = True
         return True
 
+    async def _async_query_slot(self, slot_num: int) -> CodeSlot:
+        """Query a single slot and wait for its response."""
+        get_topic = self.get_topic
+        if not get_topic:
+            raise LockDisconnected("No topic derived")
+
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        self._pending_usercode_futures[slot_num] = fut
+
+        try:
+            payload = {"pin_code": {"user": slot_num}}
+            await self._async_publish(get_topic, json.dumps(payload))
+            return await asyncio.wait_for(fut, timeout=10.0)
+        except TimeoutError as err:
+            _LOGGER.error("[Zigbee2MQTTProvider] Timeout querying slot %s", slot_num)
+            raise LockOperationFailed(f"Timeout querying slot {slot_num}") from err
+        finally:
+            self._pending_usercode_futures.pop(slot_num, None)
+
     async def async_get_usercodes(self) -> list[CodeSlot]:
         """Get all user codes from the Zigbee2MQTT lock."""
-        if not self._base_topic:
+        if not self.base_topic:
             _LOGGER.error("[Zigbee2MQTTProvider] Not connected to lock")
             return []
-
-        # Request user codes from the lock
-        # Note: expose_pin must be true in Zigbee2MQTT lock configuration
-        await mqtt.async_publish(self.hass, f"{self._base_topic}/get", '{"pin_code": ""}')
-
-        # Brief delay to allow messages to arrive
-        await asyncio.sleep(2.0)
 
         slot_start = self.keymaster_config_entry.data.get(CONF_START, 1)
         slot_count = self.keymaster_config_entry.data.get(CONF_SLOTS, 0)
 
+        # Query all slots concurrently
+        tasks = [self._async_query_slot(i) for i in range(slot_start, slot_start + slot_count)]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
         result: list[CodeSlot] = []
-        for i in range(slot_start, slot_start + slot_count):
-            if i in self._usercodes_cache:
-                result.append(self._usercodes_cache[i])
-            else:
-                result.append(CodeSlot(slot_num=i, code=None, in_use=False))
+        for res in results:
+            if isinstance(res, BaseException):
+                raise res
+            result.append(res)
 
         return result
 
@@ -210,7 +309,8 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
 
     async def async_set_usercode(self, slot_num: int, code: str, name: str | None = None) -> bool:
         """Set user code on a slot."""
-        if not self._base_topic:
+        set_topic = self.set_topic
+        if not set_topic:
             _LOGGER.error("[Zigbee2MQTTProvider] Not connected to lock")
             return False
 
@@ -222,9 +322,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
                 "pin_code": code,
             }
         }
-        await mqtt.async_publish(
-            self.hass, f"{self._base_topic}/set", json.dumps(payload), qos=1, retain=False
-        )
+        await self._async_publish(set_topic, json.dumps(payload))
 
         # Update local cache optimistically
         self._usercodes_cache[slot_num] = CodeSlot(
@@ -236,18 +334,20 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
 
     async def async_clear_usercode(self, slot_num: int) -> bool:
         """Clear user code from a slot."""
-        if not self._base_topic:
+        set_topic = self.set_topic
+        if not set_topic:
             _LOGGER.error("[Zigbee2MQTTProvider] Not connected to lock")
             return False
 
         payload = {
             "pin_code": {
                 "user": slot_num,
+                "user_type": "unrestricted",
+                "user_enabled": False,
+                "pin_code": None,
             }
         }
-        await mqtt.async_publish(
-            self.hass, f"{self._base_topic}/set", json.dumps(payload), qos=1, retain=False
-        )
+        await self._async_publish(set_topic, json.dumps(payload))
 
         # Update local cache optimistically
         self._usercodes_cache[slot_num] = CodeSlot(
@@ -264,26 +364,32 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         unsub_list: list[Callable[[], None]] = []
 
         async def handle_lock_message(msg: mqtt.ReceiveMessage) -> None:
-            """Handle unlock events from MQTT state topic."""
+            """Handle lock events from MQTT state topic."""
             try:
                 payload = json.loads(msg.payload)
             except ValueError:
                 return
 
             action = payload.get("action")
-            source = payload.get("action_source_name")
             slot_num = payload.get("action_user")
 
-            if action == "unlock" and source == "keypad" and isinstance(slot_num, int):
+            if action == "keypad_unlock" and isinstance(slot_num, int):
                 # Trigger Keymaster callback (user code slot unlocked keypad)
                 # action_code 1 represents keypad unlock in Keymaster
                 await callback(slot_num, "Unlocked via Keypad", 1)
+            elif action == "keypad_lock" and isinstance(slot_num, int):
+                # action_code 5 represents keypad lock in Keymaster
+                await callback(slot_num, "Keypad Lock", 5)
 
         # Subscribe using HAs MQTT API and wrap in task to execute callback safely
         async def subscribe() -> None:
+            state_topic = self.state_topic
+            if not state_topic:
+                _LOGGER.error("[Zigbee2MQTTProvider] State topic not available for subscribe")
+                return
             unsub = await mqtt.async_subscribe(
                 self.hass,
-                self._state_topic,
+                state_topic,
                 lambda msg: self.hass.async_create_task(handle_lock_message(msg)),
             )
             unsub_list.append(unsub)
@@ -300,7 +406,4 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
 
     def subscribe_connection_events(self, callback: ConnectionCallback) -> Callable[[], None]:
         """Subscribe to availability events (connection status monitoring)."""
-        # Listen to MQTT availability topic if available
-        # But Zigbee2MQTT status is usually represented by lock entity itself
-        # For simplicity, Keymaster checks async_is_connected which queries EntityRegistry
         return lambda: None

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -1,0 +1,306 @@
+"""Zigbee2MQTT lock provider for keymaster."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass, field
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from custom_components.keymaster.const import CONF_SLOTS, CONF_START
+from homeassistant.components import mqtt
+from homeassistant.core import callback
+
+from ._base import BaseLockProvider, CodeSlot, ConnectionCallback, LockEventCallback
+
+if TYPE_CHECKING:
+    from custom_components.keymaster.lock import KeymasterLock
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Zigbee2MQTTLockProvider(BaseLockProvider):
+    """Zigbee2MQTT lock provider implementation."""
+
+    _base_topic: str | None = field(default=None, init=False, repr=False)
+    _command_topic: str | None = field(default=None, init=False, repr=False)
+    _state_topic: str | None = field(default=None, init=False, repr=False)
+    _usercodes_cache: dict[int, CodeSlot] = field(default_factory=dict, init=False, repr=False)
+
+    @property
+    def domain(self) -> str:
+        """Return the integration domain."""
+        return "mqtt"
+
+    @property
+    def supports_push_updates(self) -> bool:
+        """Zigbee2MQTT supports real-time event updates."""
+        return True
+
+    @property
+    def supports_connection_status(self) -> bool:
+        """Zigbee2MQTT can report connection status."""
+        return True
+
+    async def async_connect(self) -> bool:
+        """Connect to the Zigbee2MQTT lock."""
+        self._connected = False
+
+        # Get lock entity registry entry
+        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
+        if not lock_entry:
+            _LOGGER.error(
+                "[Zigbee2MQTTProvider] Can't find lock in Entity Registry: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        if lock_entry.platform != "mqtt":
+            _LOGGER.error(
+                "[Zigbee2MQTTProvider] Lock platform is not mqtt: %s (%s)",
+                self.lock_entity_id,
+                lock_entry.platform,
+            )
+            return False
+
+        self.lock_config_entry_id = lock_entry.config_entry_id
+
+        # Get the actual lock entity to read its configuration topics
+        lock_component = self.hass.data.get("entity_components", {}).get("lock")
+        if not lock_component:
+            _LOGGER.error("[Zigbee2MQTTProvider] Lock component not found in hass.data")
+            return False
+
+        lock_entity = lock_component.get_entity(self.lock_entity_id)
+        if not lock_entity:
+            _LOGGER.error(
+                "[Zigbee2MQTTProvider] Entity not found in lock component: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        # Read config topics from the MQTT lock entity
+        if not hasattr(lock_entity, "_config") or not isinstance(lock_entity._config, dict):  # noqa: SLF001
+            _LOGGER.error(
+                "[Zigbee2MQTTProvider] Lock entity lacks MQTT config: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        command_topic = lock_entity._config.get("command_topic")  # noqa: SLF001
+        state_topic = lock_entity._config.get("state_topic")  # noqa: SLF001
+
+        if not command_topic or not state_topic:
+            _LOGGER.error(
+                "[Zigbee2MQTTProvider] Lock entity missing command/state topics: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        self._command_topic = command_topic
+        self._state_topic = state_topic
+
+        # Extract base topic by stripping '/set' if present
+        if command_topic.endswith("/set"):
+            self._base_topic = command_topic[:-4]
+        else:
+            self._base_topic = command_topic
+
+        # Subscribe to lock's state topic to cache user code updates
+        @callback
+        def handle_state_message(msg: mqtt.ReceiveMessage) -> None:
+            """Handle incoming state updates."""
+            try:
+                payload = json.loads(msg.payload)
+            except (json.JSONDecodeError, TypeError):
+                return
+
+            # Parse bulk users list if available
+            if "users" in payload and isinstance(payload["users"], dict):
+                for slot_str, info in payload["users"].items():
+                    try:
+                        slot_num = int(slot_str)
+                    except ValueError:
+                        continue
+
+                    pin_code = info.get("pin_code")
+                    status = info.get("status")
+                    in_use = status == "enabled"
+
+                    self._usercodes_cache[slot_num] = CodeSlot(
+                        slot_num=slot_num,
+                        code=pin_code or None,
+                        in_use=in_use,
+                    )
+
+            # Parse single user pin_code update
+            if "pin_code" in payload and isinstance(payload["pin_code"], dict):
+                pin_data = payload["pin_code"]
+                user_slot = pin_data.get("user")
+                if isinstance(user_slot, int):
+                    pin_code = pin_data.get("pin_code")
+                    user_enabled = pin_data.get("user_enabled", True)
+                    in_use = bool(pin_code and user_enabled)
+
+                    self._usercodes_cache[user_slot] = CodeSlot(
+                        slot_num=user_slot,
+                        code=pin_code or None,
+                        in_use=in_use,
+                    )
+
+        # Listen to state topic for code changes
+        self._listeners.append(
+            await mqtt.async_subscribe(self.hass, self._state_topic, handle_state_message)
+        )
+
+        self._connected = True
+        _LOGGER.debug(
+            "[Zigbee2MQTTProvider] Connected to lock %s (base_topic: %s)",
+            self.lock_entity_id,
+            self._base_topic,
+        )
+        return True
+
+    async def async_is_connected(self) -> bool:
+        """Check if Zigbee2MQTT lock connection is active."""
+        if not self._base_topic:
+            self._connected = False
+            return False
+
+        # Verify entity exists and is still registered as mqtt domain
+        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
+        if not lock_entry or lock_entry.platform != "mqtt":
+            self._connected = False
+            return False
+
+        self._connected = True
+        return True
+
+    async def async_get_usercodes(self) -> list[CodeSlot]:
+        """Get all user codes from the Zigbee2MQTT lock."""
+        if not self._base_topic:
+            _LOGGER.error("[Zigbee2MQTTProvider] Not connected to lock")
+            return []
+
+        # Request user codes from the lock
+        # Note: expose_pin must be true in Zigbee2MQTT lock configuration
+        await mqtt.async_publish(self.hass, f"{self._base_topic}/get", '{"pin_code": ""}')
+
+        # Brief delay to allow messages to arrive
+        await asyncio.sleep(2.0)
+
+        slot_start = self.keymaster_config_entry.data.get(CONF_START, 1)
+        slot_count = self.keymaster_config_entry.data.get(CONF_SLOTS, 0)
+
+        result: list[CodeSlot] = []
+        for i in range(slot_start, slot_start + slot_count):
+            if i in self._usercodes_cache:
+                result.append(self._usercodes_cache[i])
+            else:
+                result.append(CodeSlot(slot_num=i, code=None, in_use=False))
+
+        return result
+
+    async def async_get_usercode(self, slot_num: int) -> CodeSlot | None:
+        """Get a specific user code from the lock cache."""
+        return self._usercodes_cache.get(slot_num)
+
+    async def async_set_usercode(self, slot_num: int, code: str, name: str | None = None) -> bool:
+        """Set user code on a slot."""
+        if not self._base_topic:
+            _LOGGER.error("[Zigbee2MQTTProvider] Not connected to lock")
+            return False
+
+        payload = {
+            "pin_code": {
+                "user": slot_num,
+                "user_type": "unrestricted",
+                "user_enabled": True,
+                "pin_code": code,
+            }
+        }
+        await mqtt.async_publish(
+            self.hass, f"{self._base_topic}/set", json.dumps(payload), qos=1, retain=False
+        )
+
+        # Update local cache optimistically
+        self._usercodes_cache[slot_num] = CodeSlot(
+            slot_num=slot_num,
+            code=code,
+            in_use=True,
+        )
+        return True
+
+    async def async_clear_usercode(self, slot_num: int) -> bool:
+        """Clear user code from a slot."""
+        if not self._base_topic:
+            _LOGGER.error("[Zigbee2MQTTProvider] Not connected to lock")
+            return False
+
+        payload = {
+            "pin_code": {
+                "user": slot_num,
+            }
+        }
+        await mqtt.async_publish(
+            self.hass, f"{self._base_topic}/set", json.dumps(payload), qos=1, retain=False
+        )
+
+        # Update local cache optimistically
+        self._usercodes_cache[slot_num] = CodeSlot(
+            slot_num=slot_num,
+            code=None,
+            in_use=False,
+        )
+        return True
+
+    def subscribe_lock_events(
+        self, kmlock: KeymasterLock, callback: LockEventCallback
+    ) -> Callable[[], None]:
+        """Subscribe to keypad lock/unlock events."""
+        unsub_list: list[Callable[[], None]] = []
+
+        async def handle_lock_message(msg: mqtt.ReceiveMessage) -> None:
+            """Handle unlock events from MQTT state topic."""
+            try:
+                payload = json.loads(msg.payload)
+            except (json.JSONDecodeError, TypeError):
+                return
+
+            action = payload.get("action")
+            source = payload.get("action_source_name")
+            slot_num = payload.get("action_user")
+
+            if action == "unlock" and source == "keypad" and isinstance(slot_num, int):
+                # Trigger Keymaster callback (user code slot unlocked keypad)
+                # action_code 1 represents keypad unlock in Keymaster
+                await callback(slot_num, "Unlocked via Keypad", 1)
+
+        # Subscribe using HAs MQTT API and wrap in task to execute callback safely
+        async def subscribe() -> None:
+            unsub = await mqtt.async_subscribe(
+                self.hass,
+                self._state_topic,
+                lambda msg: self.hass.async_create_task(handle_lock_message(msg)),
+            )
+            unsub_list.append(unsub)
+            self._listeners.append(unsub)
+
+        self.hass.async_create_task(subscribe())
+
+        def unsubscribe_all() -> None:
+            """Unsubscribe all listeners."""
+            for unsub_fn in unsub_list:
+                unsub_fn()
+
+        return unsubscribe_all
+
+    def subscribe_connection_events(self, callback: ConnectionCallback) -> Callable[[], None]:
+        """Subscribe to availability events (connection status monitoring)."""
+        # Listen to MQTT availability topic if available
+        # But Zigbee2MQTT status is usually represented by lock entity itself
+        # For simplicity, Keymaster checks async_is_connected which queries EntityRegistry
+        return lambda: None

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -13,6 +13,7 @@ from custom_components.keymaster.const import CONF_SLOTS, CONF_START
 from custom_components.keymaster.exceptions import LockDisconnected, LockOperationFailed
 from homeassistant.components import mqtt
 from homeassistant.components.mqtt import mqtt_config_entry_enabled
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 
@@ -67,7 +68,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
     @property
     def supports_connection_status(self) -> bool:
         """Zigbee2MQTT can report connection status."""
-        return False
+        return True
 
     @property
     def base_topic(self) -> str | None:
@@ -255,6 +256,12 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         # Verify entity exists and is still registered as mqtt domain
         lock_entry = self.entity_registry.async_get(self.lock_entity_id)
         if not lock_entry or lock_entry.platform != "mqtt":
+            self._connected = False
+            return False
+
+        # Verify lock entity state is available
+        state = self.hass.states.get(self.lock_entity_id)
+        if not state or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             self._connected = False
             return False
 

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from custom_components.keymaster.const import CONF_SLOTS, CONF_START
 from custom_components.keymaster.exceptions import LockDisconnected, LockOperationFailed
 from homeassistant.components import mqtt
-from homeassistant.components.mqtt import mqtt_config_entry_enabled
+from homeassistant.components.mqtt import DOMAIN as MQTT_DOMAIN, mqtt_config_entry_enabled
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
@@ -58,7 +58,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
     @property
     def domain(self) -> str:
         """Return the integration domain."""
-        return "mqtt"
+        return MQTT_DOMAIN
 
     @property
     def supports_push_updates(self) -> bool:
@@ -74,9 +74,12 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
     def base_topic(self) -> str | None:
         """Get the base topic dynamically from the device name."""
         device_entry = self.get_device_entry()
-        if not device_entry or not device_entry.name:
+        if not device_entry:
             return None
-        return f"zigbee2mqtt/{device_entry.name}"
+        name = device_entry.original_name or device_entry.name
+        if not name:
+            return None
+        return f"zigbee2mqtt/{name}"
 
     @property
     def set_topic(self) -> str | None:
@@ -120,7 +123,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
             )
             return False
 
-        if lock_entry.platform != "mqtt":
+        if lock_entry.platform != MQTT_DOMAIN:
             _LOGGER.error(
                 "[Zigbee2MQTTProvider] Lock platform is not mqtt: %s (%s)",
                 self.lock_entity_id,
@@ -141,7 +144,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
 
         is_z2m = False
         for domain, identifier in device_entry.identifiers:
-            if domain == "mqtt" and identifier.startswith("zigbee2mqtt_"):
+            if domain == MQTT_DOMAIN and identifier.startswith("zigbee2mqtt_"):
                 is_z2m = True
                 break
 
@@ -255,7 +258,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
 
         # Verify entity exists and is still registered as mqtt domain
         lock_entry = self.entity_registry.async_get(self.lock_entity_id)
-        if not lock_entry or lock_entry.platform != "mqtt":
+        if not lock_entry or lock_entry.platform != MQTT_DOMAIN:
             self._connected = False
             return False
 

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -697,6 +697,31 @@ class TestCoverageExtra:
             assert len(result) == 6
             assert result[0] == CodeSlot(slot_num=1, code=None, in_use=False)
 
+    async def test_get_usercodes_enabled_no_pin_resolves_future(self, provider, mock_hass):
+        """Test that single pin update with user_enabled=True and no pin_code resolves future."""
+        mock_subscribe = await connect_provider(provider, mock_hass)
+        callback_captured = mock_subscribe.call_args[0][2]
+
+        async def mock_publish(hass, topic, payload, qos=0, retain=False):
+            parsed = json.loads(payload)
+            slot_num = parsed["pin_code"]["user"]
+
+            # Response without pin_code key but user_enabled=True
+            response_payload = {
+                "pin_code": {
+                    "user": slot_num,
+                    "user_enabled": True,
+                }
+            }
+            msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(response_payload), 0, False)
+            callback_captured(msg)
+
+        with patch("homeassistant.components.mqtt.async_publish", side_effect=mock_publish):
+            result = await provider.async_get_usercodes()
+            assert len(result) == 6
+            assert result[0] == CodeSlot(slot_num=1, code=None, in_use=True)
+            assert result[5] == CodeSlot(slot_num=6, code=None, in_use=True)
+
     async def test_subscribe_lock_events_returns_unsubscribe(self, provider, mock_hass):
         """Test subscribing to events returns unsubscribe function."""
         await connect_provider(provider, mock_hass)

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -1,0 +1,621 @@
+"""Tests for the Zigbee2MQTT lock provider."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import NamedTuple
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.keymaster.providers._base import CodeSlot
+from custom_components.keymaster.providers.zigbee2mqtt import Zigbee2MQTTLockProvider
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+
+class ReceiveMessage(NamedTuple):
+    """Mock MQTT receive message."""
+
+    topic: str
+    payload: str
+    qos: int
+    retain: bool
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    hass.data = {}
+
+    def async_create_task(coro):
+        return asyncio.create_task(coro)
+
+    hass.async_create_task = MagicMock(side_effect=async_create_task)
+    return hass
+
+
+@pytest.fixture
+def mock_entity_registry():
+    """Create a mock entity registry."""
+    return MagicMock(spec=er.EntityRegistry)
+
+
+@pytest.fixture
+def mock_device_registry():
+    """Create a mock device registry."""
+    return MagicMock(spec=dr.DeviceRegistry)
+
+
+@pytest.fixture
+def mock_config_entry():
+    """Create a mock keymaster config entry."""
+    entry = MagicMock()
+    entry.entry_id = "keymaster_test_entry"
+    entry.data = {"start_from": 1, "slots": 6}
+    return entry
+
+
+@pytest.fixture
+def provider(mock_hass, mock_entity_registry, mock_device_registry, mock_config_entry):
+    """Create a Zigbee2MQTTLockProvider instance."""
+    return Zigbee2MQTTLockProvider(
+        hass=mock_hass,
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry=mock_config_entry,
+        device_registry=mock_device_registry,
+        entity_registry=mock_entity_registry,
+    )
+
+
+def setup_successful_connect(
+    provider,
+    mock_hass,
+    command_topic="zigbee2mqtt/my_lock/set",
+    state_topic="zigbee2mqtt/my_lock",
+):
+    """Set up registry and entity mocks for a successful connection."""
+    # 1. Entity Registry Setup
+    lock_entry = MagicMock()
+    lock_entry.config_entry_id = "mqtt_config_entry_id"
+    lock_entry.platform = "mqtt"
+    provider.entity_registry.async_get.return_value = lock_entry
+
+    # 2. Lock Entity Setup
+    lock_entity = MagicMock()
+    lock_entity._config = {
+        "command_topic": command_topic,
+        "state_topic": state_topic,
+    }
+
+    lock_component = MagicMock()
+    lock_component.get_entity.return_value = lock_entity
+
+    mock_hass.data["entity_components"] = {"lock": lock_component}
+
+
+class TestProperties:
+    """Test Zigbee2MQTTLockProvider properties."""
+
+    def test_domain(self, provider):
+        """Test domain property."""
+        assert provider.domain == "mqtt"
+
+    def test_supports_push_updates(self, provider):
+        """Test supports_push_updates property."""
+        assert provider.supports_push_updates is True
+
+    def test_supports_connection_status(self, provider):
+        """Test supports_connection_status property."""
+        assert provider.supports_connection_status is True
+
+
+class TestConnect:
+    """Test Zigbee2MQTTLockProvider async_connect."""
+
+    async def test_connect_success_with_set_suffix(self, provider, mock_hass):
+        """Test successful connection where command topic ends with /set."""
+        setup_successful_connect(
+            provider,
+            mock_hass,
+            command_topic="zigbee2mqtt/my_lock/set",
+            state_topic="zigbee2mqtt/my_lock",
+        )
+
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_subscribe:
+            mock_subscribe.return_value = lambda: None
+
+            result = await provider.async_connect()
+
+            assert result is True
+            assert provider.connected is True
+            assert provider._command_topic == "zigbee2mqtt/my_lock/set"
+            assert provider._state_topic == "zigbee2mqtt/my_lock"
+            assert provider._base_topic == "zigbee2mqtt/my_lock"
+            mock_subscribe.assert_called_once_with(mock_hass, "zigbee2mqtt/my_lock", ANY)
+
+    async def test_connect_success_without_set_suffix(self, provider, mock_hass):
+        """Test successful connection where command topic does not end with /set."""
+        setup_successful_connect(
+            provider,
+            mock_hass,
+            command_topic="zigbee2mqtt/my_lock",
+            state_topic="zigbee2mqtt/my_lock",
+        )
+
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_subscribe:
+            mock_subscribe.return_value = lambda: None
+
+            result = await provider.async_connect()
+
+            assert result is True
+            assert provider.connected is True
+            assert provider._base_topic == "zigbee2mqtt/my_lock"
+
+    async def test_connect_entity_not_found(self, provider):
+        """Test connection fails when lock entity is not found in Entity Registry."""
+        provider.entity_registry.async_get.return_value = None
+
+        result = await provider.async_connect()
+
+        assert result is False
+        assert provider.connected is False
+
+    async def test_connect_platform_not_mqtt(self, provider):
+        """Test connection fails when lock entity platform is not mqtt."""
+        lock_entry = MagicMock()
+        lock_entry.platform = "zwave_js"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        result = await provider.async_connect()
+
+        assert result is False
+        assert provider.connected is False
+
+    async def test_connect_lock_component_missing(self, provider, mock_hass):
+        """Test connection fails when lock component is missing from Home Assistant."""
+        lock_entry = MagicMock()
+        lock_entry.platform = "mqtt"
+        provider.entity_registry.async_get.return_value = lock_entry
+        mock_hass.data["entity_components"] = {}
+
+        result = await provider.async_connect()
+
+        assert result is False
+        assert provider.connected is False
+
+    async def test_connect_lock_entity_missing(self, provider, mock_hass):
+        """Test connection fails when lock entity is missing from lock component."""
+        lock_entry = MagicMock()
+        lock_entry.platform = "mqtt"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        lock_component = MagicMock()
+        lock_component.get_entity.return_value = None
+        mock_hass.data["entity_components"] = {"lock": lock_component}
+
+        result = await provider.async_connect()
+
+        assert result is False
+        assert provider.connected is False
+
+    async def test_connect_lock_entity_lacks_config(self, provider, mock_hass):
+        """Test connection fails when lock entity lacks _config attribute."""
+        lock_entry = MagicMock()
+        lock_entry.platform = "mqtt"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        lock_entity = MagicMock()
+        del lock_entity._config
+
+        lock_component = MagicMock()
+        lock_component.get_entity.return_value = lock_entity
+        mock_hass.data["entity_components"] = {"lock": lock_component}
+
+        result = await provider.async_connect()
+
+        assert result is False
+        assert provider.connected is False
+
+    async def test_connect_lock_entity_missing_topics(self, provider, mock_hass):
+        """Test connection fails when command or state topics are missing."""
+        lock_entry = MagicMock()
+        lock_entry.platform = "mqtt"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        lock_entity = MagicMock()
+        lock_entity._config = {
+            "command_topic": None,
+            "state_topic": "zigbee2mqtt/my_lock",
+        }
+
+        lock_component = MagicMock()
+        lock_component.get_entity.return_value = lock_entity
+        mock_hass.data["entity_components"] = {"lock": lock_component}
+
+        result = await provider.async_connect()
+
+        assert result is False
+        assert provider.connected is False
+
+    async def test_connect_handles_bulk_users_message(self, provider, mock_hass):
+        """Test that incoming bulk users messages update the cache."""
+        setup_successful_connect(provider, mock_hass)
+
+        callback_captured = None
+
+        def mock_subscribe(hass, topic, callback_fn):
+            nonlocal callback_captured
+            callback_captured = callback_fn
+            return lambda: None
+
+        with patch("homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe):
+            await provider.async_connect()
+
+        assert callback_captured is not None
+
+        # Construct a mock ReceiveMessage
+
+        # Test bulk update
+        payload = {
+            "users": {
+                "1": {"pin_code": "1234", "status": "enabled"},
+                "2": {"pin_code": "", "status": "disabled"},
+                "invalid": {"pin_code": "0000", "status": "enabled"},
+            }
+        }
+        msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload), 0, False)
+
+        callback_captured(msg)
+
+        # Check cache
+        assert len(provider._usercodes_cache) == 2
+        assert provider._usercodes_cache[1] == CodeSlot(slot_num=1, code="1234", in_use=True)
+        assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code=None, in_use=False)
+
+    async def test_connect_handles_single_pin_code_message(self, provider, mock_hass):
+        """Test that incoming single pin code messages update the cache."""
+        setup_successful_connect(provider, mock_hass)
+
+        callback_captured = None
+
+        def mock_subscribe(hass, topic, callback_fn):
+            nonlocal callback_captured
+            callback_captured = callback_fn
+            return lambda: None
+
+        with patch("homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe):
+            await provider.async_connect()
+
+        # Test single update
+        payload = {
+            "pin_code": {
+                "user": 3,
+                "pin_code": "5678",
+                "user_enabled": True,
+            }
+        }
+        msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload), 0, False)
+
+        assert callback_captured is not None
+        callback_captured(msg)
+
+        # Check cache
+        assert provider._usercodes_cache[3] == CodeSlot(slot_num=3, code="5678", in_use=True)
+
+    async def test_connect_ignores_invalid_json(self, provider, mock_hass):
+        """Test that invalid json payloads are handled gracefully."""
+        setup_successful_connect(provider, mock_hass)
+
+        callback_captured = None
+
+        def mock_subscribe(hass, topic, callback_fn):
+            nonlocal callback_captured
+            callback_captured = callback_fn
+            return lambda: None
+
+        with patch("homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe):
+            await provider.async_connect()
+
+        msg = ReceiveMessage("zigbee2mqtt/my_lock", "invalid json", 0, False)
+
+        # Should not raise exception
+        assert callback_captured is not None
+        callback_captured(msg)
+        assert len(provider._usercodes_cache) == 0
+
+
+class TestIsConnected:
+    """Test Zigbee2MQTTLockProvider async_is_connected."""
+
+    async def test_is_connected_not_connected_initially(self, provider):
+        """Test it returns False before connection."""
+        assert await provider.async_is_connected() is False
+
+    async def test_is_connected_success(self, provider, mock_hass):
+        """Test it returns True when connected and registry confirms."""
+        setup_successful_connect(provider, mock_hass)
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_subscribe:
+            mock_subscribe.return_value = lambda: None
+            await provider.async_connect()
+
+        # Mock registry entry is still there
+        lock_entry = MagicMock()
+        lock_entry.platform = "mqtt"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        assert await provider.async_is_connected() is True
+
+    async def test_is_connected_registry_missing(self, provider, mock_hass):
+        """Test it returns False if entity is removed from registry."""
+        setup_successful_connect(provider, mock_hass)
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_subscribe:
+            mock_subscribe.return_value = lambda: None
+            await provider.async_connect()
+
+        # Entity missing now
+        provider.entity_registry.async_get.return_value = None
+
+        assert await provider.async_is_connected() is False
+        assert provider.connected is False
+
+    async def test_is_connected_platform_changed(self, provider, mock_hass):
+        """Test it returns False if entity platform changes."""
+        setup_successful_connect(provider, mock_hass)
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_subscribe:
+            mock_subscribe.return_value = lambda: None
+            await provider.async_connect()
+
+        # Platform changed now
+        lock_entry = MagicMock()
+        lock_entry.platform = "other"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        assert await provider.async_is_connected() is False
+        assert provider.connected is False
+
+
+class TestUsercodeOperations:
+    """Test user code operations in Zigbee2MQTTLockProvider."""
+
+    async def test_get_usercodes_not_connected(self, provider):
+        """Test get_usercodes returns empty list and logs error when not connected."""
+        result = await provider.async_get_usercodes()
+        assert result == []
+
+    async def test_get_usercodes_success(self, provider, mock_hass):
+        """Test get_usercodes publishes to get topic and returns slot range."""
+        setup_successful_connect(provider, mock_hass)
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_subscribe:
+            mock_subscribe.return_value = lambda: None
+            await provider.async_connect()
+
+        # Populate cache for slot 1
+        provider._usercodes_cache[1] = CodeSlot(slot_num=1, code="1234", in_use=True)
+
+        with (
+            patch(
+                "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+            ) as mock_publish,
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            result = await provider.async_get_usercodes()
+
+            mock_publish.assert_called_once_with(
+                mock_hass, "zigbee2mqtt/my_lock/get", '{"pin_code": ""}'
+            )
+            mock_sleep.assert_called_once_with(2.0)
+
+            # mock_config_entry configures start: 1, slots: 6
+            assert len(result) == 6
+            assert result[0] == CodeSlot(slot_num=1, code="1234", in_use=True)
+            assert result[1] == CodeSlot(slot_num=2, code=None, in_use=False)
+
+    async def test_get_usercode_cached(self, provider):
+        """Test get_usercode retrieves from cache."""
+        provider._usercodes_cache[3] = CodeSlot(slot_num=3, code="5678", in_use=True)
+
+        result = await provider.async_get_usercode(3)
+        assert result == CodeSlot(slot_num=3, code="5678", in_use=True)
+
+        result_missing = await provider.async_get_usercode(4)
+        assert result_missing is None
+
+    async def test_set_usercode_not_connected(self, provider):
+        """Test set_usercode returns False when not connected."""
+        result = await provider.async_set_usercode(1, "1234")
+        assert result is False
+
+    async def test_set_usercode_success(self, provider, mock_hass):
+        """Test set_usercode publishes correct payload and updates cache."""
+        setup_successful_connect(provider, mock_hass)
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_subscribe:
+            mock_subscribe.return_value = lambda: None
+            await provider.async_connect()
+
+        with patch(
+            "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+        ) as mock_publish:
+            result = await provider.async_set_usercode(2, "4321", "Test User")
+
+            assert result is True
+            expected_payload = json.dumps(
+                {
+                    "pin_code": {
+                        "user": 2,
+                        "user_type": "unrestricted",
+                        "user_enabled": True,
+                        "pin_code": "4321",
+                    }
+                }
+            )
+            mock_publish.assert_called_once_with(
+                mock_hass,
+                "zigbee2mqtt/my_lock/set",
+                expected_payload,
+                qos=1,
+                retain=False,
+            )
+            # Optimistically updated
+            assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code="4321", in_use=True)
+
+    async def test_clear_usercode_not_connected(self, provider):
+        """Test clear_usercode returns False when not connected."""
+        result = await provider.async_clear_usercode(1)
+        assert result is False
+
+    async def test_clear_usercode_success(self, provider, mock_hass):
+        """Test clear_usercode publishes correct payload and updates cache."""
+        setup_successful_connect(provider, mock_hass)
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_subscribe:
+            mock_subscribe.return_value = lambda: None
+            await provider.async_connect()
+
+        # Set it first in cache
+        provider._usercodes_cache[2] = CodeSlot(slot_num=2, code="4321", in_use=True)
+
+        with patch(
+            "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+        ) as mock_publish:
+            result = await provider.async_clear_usercode(2)
+
+            assert result is True
+            expected_payload = json.dumps(
+                {
+                    "pin_code": {
+                        "user": 2,
+                    }
+                }
+            )
+            mock_publish.assert_called_once_with(
+                mock_hass,
+                "zigbee2mqtt/my_lock/set",
+                expected_payload,
+                qos=1,
+                retain=False,
+            )
+            # Optimistically cleared
+            assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code=None, in_use=False)
+
+
+class TestLockEvents:
+    """Test lock event subscription."""
+
+    async def test_subscribe_lock_events(self, provider, mock_hass):
+        """Test subscribing to keypad unlock events works and triggers callback."""
+        setup_successful_connect(provider, mock_hass)
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_subscribe:
+            mock_subscribe.return_value = lambda: None
+            await provider.async_connect()
+
+        # Capture the callback passed to async_subscribe inside subscribe_lock_events
+        captured_callback = None
+        unsub_mock = MagicMock()
+
+        async def mock_subscribe_events(hass, topic, callback_fn):
+            nonlocal captured_callback
+            captured_callback = callback_fn
+            return unsub_mock
+
+        mock_callback = AsyncMock()
+        mock_kmlock = MagicMock()
+
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe_events
+        ):
+            unsubscribe_fn = provider.subscribe_lock_events(mock_kmlock, mock_callback)
+
+            # Let the event loop run scheduled tasks (since subscribe is called inside async_create_task)
+            await asyncio.sleep(0.01)
+
+        assert captured_callback is not None
+
+        # Build mock ReceiveMessage
+
+        # Construct a keypad unlock event
+        payload = {
+            "action": "unlock",
+            "action_source_name": "keypad",
+            "action_user": 2,
+        }
+        msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload), 0, False)
+
+        # Trigger captured callback
+        captured_callback(msg)
+
+        # Let the event loop run scheduled tasks (since handle_lock_message is called inside async_create_task)
+        await asyncio.sleep(0.01)
+
+        mock_callback.assert_called_once_with(2, "Unlocked via Keypad", 1)
+
+        # Unsubscribe
+        unsubscribe_fn()
+        unsub_mock.assert_called_once()
+
+    async def test_subscribe_lock_events_ignores_non_keypad_unlock(self, provider, mock_hass):
+        """Test subscribing to keypad unlock events ignores other actions/sources."""
+        setup_successful_connect(provider, mock_hass)
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_subscribe:
+            mock_subscribe.return_value = lambda: None
+            await provider.async_connect()
+
+        captured_callback = None
+
+        async def mock_subscribe_events(hass, topic, callback_fn):
+            nonlocal captured_callback
+            captured_callback = callback_fn
+            return lambda: None
+
+        mock_callback = AsyncMock()
+        mock_kmlock = MagicMock()
+
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe_events
+        ):
+            provider.subscribe_lock_events(mock_kmlock, mock_callback)
+            await asyncio.sleep(0.01)
+
+        # Non-keypad source
+        payload1 = {"action": "unlock", "action_source_name": "rf", "action_user": 2}
+        assert captured_callback is not None
+        captured_callback(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload1), 0, False))
+
+        # Lock action instead of unlock
+        payload2 = {"action": "lock", "action_source_name": "keypad", "action_user": 2}
+        captured_callback(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload2), 0, False))
+
+        # Invalid json
+        captured_callback(ReceiveMessage("zigbee2mqtt/my_lock", "invalid json", 0, False))
+
+        await asyncio.sleep(0.01)
+        mock_callback.assert_not_called()
+
+    def test_subscribe_connection_events(self, provider):
+        """Test subscribing to connection events returns a dummy unsubscribe function."""
+        callback = MagicMock()
+        unsub = provider.subscribe_connection_events(callback)
+        assert callable(unsub)
+        unsub()

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -141,7 +141,7 @@ class TestProperties:
 
     def test_supports_connection_status(self, provider):
         """Test supports_connection_status property."""
-        assert provider.supports_connection_status is True
+        assert provider.supports_connection_status is False
 
 
 class TestConnect:
@@ -252,7 +252,7 @@ class TestConnect:
         assert provider._usercodes_cache[1] == CodeSlot(slot_num=1, code="1234", in_use=True)
         assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code=None, in_use=False)
         assert provider._usercodes_cache[3] == CodeSlot(slot_num=3, code=None, in_use=False)
-        assert 4 not in provider._usercodes_cache
+        assert provider._usercodes_cache[4] == CodeSlot(slot_num=4, code=None, in_use=True)
         assert provider._usercodes_cache[5] == CodeSlot(slot_num=5, code="0", in_use=True)
         assert provider._usercodes_cache[6] == CodeSlot(slot_num=6, code=None, in_use=False)
         assert "invalid" not in provider._usercodes_cache
@@ -281,7 +281,7 @@ class TestConnect:
 
         payload2 = {"pin_code": {"user": 2, "user_enabled": True}}
         callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload2), 0, False))
-        assert 2 not in provider._usercodes_cache
+        assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code=None, in_use=True)
 
         payload3 = {"pin_code": {"user": 3, "user_enabled": False}}
         callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload3), 0, False))
@@ -529,26 +529,13 @@ class TestLockEvents:
 
     async def test_subscribe_lock_events(self, provider, mock_hass):
         """Test subscribing to keypad unlock/lock events works and triggers callback."""
-        await connect_provider(provider, mock_hass)
-
-        captured_callback = None
-        unsub_mock = MagicMock()
-
-        async def mock_subscribe_events(hass, topic, callback_fn):
-            nonlocal captured_callback
-            captured_callback = callback_fn
-            return unsub_mock
+        mock_subscribe = await connect_provider(provider, mock_hass)
+        captured_callback = mock_subscribe.call_args[0][2]
 
         mock_callback = AsyncMock()
         mock_kmlock = MagicMock()
 
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe_events
-        ):
-            unsubscribe_fn = provider.subscribe_lock_events(mock_kmlock, mock_callback)
-            await asyncio.sleep(0.01)
-
-        assert captured_callback is not None
+        unsubscribe_fn = provider.subscribe_lock_events(mock_kmlock, mock_callback)
 
         # 1. Keypad unlock event
         payload_unlock = {
@@ -574,29 +561,16 @@ class TestLockEvents:
         mock_callback.assert_called_once_with(3, "Keypad Lock", 5)
 
         unsubscribe_fn()
-        unsub_mock.assert_called_once()
 
     async def test_subscribe_lock_events_ignores_other_actions(self, provider, mock_hass):
         """Test subscribing to keypad unlock/lock events ignores other actions."""
-        await connect_provider(provider, mock_hass)
-
-        captured_callback = None
-
-        async def mock_subscribe_events(hass, topic, callback_fn):
-            nonlocal captured_callback
-            captured_callback = callback_fn
-            return lambda: None
+        mock_subscribe = await connect_provider(provider, mock_hass)
+        captured_callback = mock_subscribe.call_args[0][2]
 
         mock_callback = AsyncMock()
         mock_kmlock = MagicMock()
 
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe_events
-        ):
-            provider.subscribe_lock_events(mock_kmlock, mock_callback)
-            await asyncio.sleep(0.01)
-
-        assert captured_callback is not None
+        provider.subscribe_lock_events(mock_kmlock, mock_callback)
 
         # RF unlock/lock action
         payload1 = {"action": "unlock", "action_user": 2}
@@ -612,6 +586,34 @@ class TestLockEvents:
 
         await asyncio.sleep(0.01)
         mock_callback.assert_not_called()
+
+    async def test_keypad_pin_changed_requeries_slot(self, provider, mock_hass):
+        """Test that pin_code_added/deleted triggers a get request to query the slot."""
+        mock_subscribe = await connect_provider(provider, mock_hass)
+        captured_callback = mock_subscribe.call_args[0][2]
+
+        mock_callback = AsyncMock()
+        mock_kmlock = MagicMock()
+        provider.subscribe_lock_events(mock_kmlock, mock_callback)
+
+        payload = {
+            "action": "pin_code_added",
+            "action_user": 4,
+        }
+        msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload), 0, False)
+
+        with patch(
+            "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
+        ) as mock_pub:
+            captured_callback(msg)
+            await asyncio.sleep(0.01)
+            mock_pub.assert_called_once_with(
+                mock_hass,
+                "zigbee2mqtt/my_lock/get",
+                json.dumps({"pin_code": {"user": 4}}),
+                qos=1,
+                retain=False,
+            )
 
     def test_subscribe_connection_events(self, provider):
         """Test subscribing to connection events returns a dummy unsubscribe function."""
@@ -695,21 +697,16 @@ class TestCoverageExtra:
             assert len(result) == 6
             assert result[0] == CodeSlot(slot_num=1, code=None, in_use=False)
 
-    async def test_subscribe_lock_events_missing_state_topic(self, provider, mock_hass):
-        """Test subscribing to events returns dummy unsubscribe when state topic is missing."""
+    async def test_subscribe_lock_events_returns_unsubscribe(self, provider, mock_hass):
+        """Test subscribing to events returns unsubscribe function."""
         await connect_provider(provider, mock_hass)
-
-        with patch(
-            "custom_components.keymaster.providers.zigbee2mqtt.Zigbee2MQTTLockProvider.state_topic",
-            new_callable=PropertyMock,
-        ) as mock_state_topic:
-            mock_state_topic.return_value = None
-            mock_callback = AsyncMock()
-            mock_kmlock = MagicMock()
-            unsubscribe_fn = provider.subscribe_lock_events(mock_kmlock, mock_callback)
-            await asyncio.sleep(0.01)
-
-            assert callable(unsubscribe_fn)
+        mock_callback = AsyncMock()
+        mock_kmlock = MagicMock()
+        unsubscribe_fn = provider.subscribe_lock_events(mock_kmlock, mock_callback)
+        assert provider._lock_event_callback == mock_callback
+        assert callable(unsubscribe_fn)
+        unsubscribe_fn()
+        assert provider._lock_event_callback is None
 
     async def test_async_query_slot_missing_get_topic(self, provider, mock_hass):
         """Test that _async_query_slot raises LockDisconnected when get_topic is missing."""

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import NamedTuple
+from typing import Any, NamedTuple
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.keymaster.const import CONF_SLOTS, CONF_START
+from custom_components.keymaster.exceptions import LockDisconnected, LockOperationFailed
 from custom_components.keymaster.providers._base import CodeSlot
 from custom_components.keymaster.providers.zigbee2mqtt import Zigbee2MQTTLockProvider
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 
@@ -41,13 +44,17 @@ def mock_hass():
 @pytest.fixture
 def mock_entity_registry():
     """Create a mock entity registry."""
-    return MagicMock(spec=er.EntityRegistry)
+    reg = MagicMock(spec=er.EntityRegistry)
+    reg.async_get.return_value = None
+    return reg
 
 
 @pytest.fixture
 def mock_device_registry():
     """Create a mock device registry."""
-    return MagicMock(spec=dr.DeviceRegistry)
+    reg = MagicMock(spec=dr.DeviceRegistry)
+    reg.async_get.return_value = None
+    return reg
 
 
 @pytest.fixture
@@ -55,7 +62,7 @@ def mock_config_entry():
     """Create a mock keymaster config entry."""
     entry = MagicMock()
     entry.entry_id = "keymaster_test_entry"
-    entry.data = {"start_from": 1, "slots": 6}
+    entry.data = {CONF_START: 1, CONF_SLOTS: 6}
     return entry
 
 
@@ -71,30 +78,50 @@ def provider(mock_hass, mock_entity_registry, mock_device_registry, mock_config_
     )
 
 
+@pytest.fixture(autouse=True)
+def mock_mqtt_enabled():
+    """Mock mqtt_config_entry_enabled to return True by default."""
+    with patch(
+        "custom_components.keymaster.providers.zigbee2mqtt.mqtt_config_entry_enabled",
+        return_value=True,
+    ) as mock:
+        yield mock
+
+
 def setup_successful_connect(
     provider,
     mock_hass,
-    command_topic="zigbee2mqtt/my_lock/set",
-    state_topic="zigbee2mqtt/my_lock",
+    device_name="my_lock",
+    identifiers=None,
 ):
     """Set up registry and entity mocks for a successful connection."""
+    if identifiers is None:
+        identifiers = {("mqtt", "zigbee2mqtt_my_lock")}
+
     # 1. Entity Registry Setup
     lock_entry = MagicMock()
     lock_entry.config_entry_id = "mqtt_config_entry_id"
     lock_entry.platform = "mqtt"
+    lock_entry.device_id = "my_lock_device_id"
     provider.entity_registry.async_get.return_value = lock_entry
 
-    # 2. Lock Entity Setup
-    lock_entity = MagicMock()
-    lock_entity._config = {
-        "command_topic": command_topic,
-        "state_topic": state_topic,
-    }
+    # 2. Device Registry Setup
+    device_entry = MagicMock()
+    device_entry.identifiers = identifiers
+    device_entry.name = device_name
+    provider.device_registry.async_get.return_value = device_entry
 
-    lock_component = MagicMock()
-    lock_component.get_entity.return_value = lock_entity
 
-    mock_hass.data["entity_components"] = {"lock": lock_component}
+async def connect_provider(provider, mock_hass):
+    """Successfully connect the provider in tests."""
+    setup_successful_connect(provider, mock_hass)
+    with patch(
+        "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+    ) as mock_subscribe:
+        mock_subscribe.return_value = lambda: None
+        result = await provider.async_connect()
+        assert result is True
+        return mock_subscribe
 
 
 class TestProperties:
@@ -116,48 +143,30 @@ class TestProperties:
 class TestConnect:
     """Test Zigbee2MQTTLockProvider async_connect."""
 
-    async def test_connect_success_with_set_suffix(self, provider, mock_hass):
-        """Test successful connection where command topic ends with /set."""
-        setup_successful_connect(
-            provider,
-            mock_hass,
-            command_topic="zigbee2mqtt/my_lock/set",
-            state_topic="zigbee2mqtt/my_lock",
-        )
+    async def test_connect_success(self, provider, mock_hass):
+        """Test successful connection and dynamic topic derivation."""
+        mock_subscribe = await connect_provider(provider, mock_hass)
 
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
-        ) as mock_subscribe:
-            mock_subscribe.return_value = lambda: None
+        assert provider.connected is True
+        assert provider.base_topic == "zigbee2mqtt/my_lock"
+        assert provider.set_topic == "zigbee2mqtt/my_lock/set"
+        assert provider.get_topic == "zigbee2mqtt/my_lock/get"
+        assert provider.state_topic == "zigbee2mqtt/my_lock"
+        mock_subscribe.assert_called_once_with(mock_hass, "zigbee2mqtt/my_lock", ANY)
 
-            result = await provider.async_connect()
+    async def test_connect_success_rename_device(self, provider, mock_hass):
+        """Test that device rename changes the topics dynamically."""
+        await connect_provider(provider, mock_hass)
+        assert provider.base_topic == "zigbee2mqtt/my_lock"
 
-            assert result is True
-            assert provider.connected is True
-            assert provider._command_topic == "zigbee2mqtt/my_lock/set"
-            assert provider._state_topic == "zigbee2mqtt/my_lock"
-            assert provider._base_topic == "zigbee2mqtt/my_lock"
-            mock_subscribe.assert_called_once_with(mock_hass, "zigbee2mqtt/my_lock", ANY)
+        # Now simulate a device rename in registry
+        device_entry = provider.device_registry.async_get.return_value
+        device_entry.name = "new_lock_name"
 
-    async def test_connect_success_without_set_suffix(self, provider, mock_hass):
-        """Test successful connection where command topic does not end with /set."""
-        setup_successful_connect(
-            provider,
-            mock_hass,
-            command_topic="zigbee2mqtt/my_lock",
-            state_topic="zigbee2mqtt/my_lock",
-        )
-
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
-        ) as mock_subscribe:
-            mock_subscribe.return_value = lambda: None
-
-            result = await provider.async_connect()
-
-            assert result is True
-            assert provider.connected is True
-            assert provider._base_topic == "zigbee2mqtt/my_lock"
+        assert provider.base_topic == "zigbee2mqtt/new_lock_name"
+        assert provider.set_topic == "zigbee2mqtt/new_lock_name/set"
+        assert provider.get_topic == "zigbee2mqtt/new_lock_name/get"
+        assert provider.state_topic == "zigbee2mqtt/new_lock_name"
 
     async def test_connect_entity_not_found(self, provider):
         """Test connection fails when lock entity is not found in Entity Registry."""
@@ -179,69 +188,24 @@ class TestConnect:
         assert result is False
         assert provider.connected is False
 
-    async def test_connect_lock_component_missing(self, provider, mock_hass):
-        """Test connection fails when lock component is missing from Home Assistant."""
+    async def test_connect_device_not_found(self, provider):
+        """Test connection fails when lock device is not found in registry."""
         lock_entry = MagicMock()
+        lock_entry.config_entry_id = "mqtt_config_entry_id"
         lock_entry.platform = "mqtt"
+        lock_entry.device_id = "my_lock_device_id"
         provider.entity_registry.async_get.return_value = lock_entry
-        mock_hass.data["entity_components"] = {}
+        provider.device_registry.async_get.return_value = None
 
         result = await provider.async_connect()
 
         assert result is False
         assert provider.connected is False
 
-    async def test_connect_lock_entity_missing(self, provider, mock_hass):
-        """Test connection fails when lock entity is missing from lock component."""
-        lock_entry = MagicMock()
-        lock_entry.platform = "mqtt"
-        provider.entity_registry.async_get.return_value = lock_entry
-
-        lock_component = MagicMock()
-        lock_component.get_entity.return_value = None
-        mock_hass.data["entity_components"] = {"lock": lock_component}
-
+    async def test_connect_platform_not_z2m(self, provider, mock_hass):
+        """Test connection fails when lock device is not a Z2M device."""
+        setup_successful_connect(provider, mock_hass, identifiers={("mqtt", "not_z2m_device")})
         result = await provider.async_connect()
-
-        assert result is False
-        assert provider.connected is False
-
-    async def test_connect_lock_entity_lacks_config(self, provider, mock_hass):
-        """Test connection fails when lock entity lacks _config attribute."""
-        lock_entry = MagicMock()
-        lock_entry.platform = "mqtt"
-        provider.entity_registry.async_get.return_value = lock_entry
-
-        lock_entity = MagicMock()
-        del lock_entity._config
-
-        lock_component = MagicMock()
-        lock_component.get_entity.return_value = lock_entity
-        mock_hass.data["entity_components"] = {"lock": lock_component}
-
-        result = await provider.async_connect()
-
-        assert result is False
-        assert provider.connected is False
-
-    async def test_connect_lock_entity_missing_topics(self, provider, mock_hass):
-        """Test connection fails when command or state topics are missing."""
-        lock_entry = MagicMock()
-        lock_entry.platform = "mqtt"
-        provider.entity_registry.async_get.return_value = lock_entry
-
-        lock_entity = MagicMock()
-        lock_entity._config = {
-            "command_topic": None,
-            "state_topic": "zigbee2mqtt/my_lock",
-        }
-
-        lock_component = MagicMock()
-        lock_component.get_entity.return_value = lock_entity
-        mock_hass.data["entity_components"] = {"lock": lock_component}
-
-        result = await provider.async_connect()
-
         assert result is False
         assert provider.connected is False
 
@@ -249,26 +213,30 @@ class TestConnect:
         """Test that incoming bulk users messages update the cache."""
         setup_successful_connect(provider, mock_hass)
 
-        callback_captured = None
+        callback_captured: Any = None
 
         def mock_subscribe(hass, topic, callback_fn):
             nonlocal callback_captured
             callback_captured = callback_fn
             return lambda: None
 
-        with patch("homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe):
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_sub:
+            mock_sub.side_effect = mock_subscribe
             await provider.async_connect()
 
         assert callback_captured is not None
-
-        # Construct a mock ReceiveMessage
 
         # Test bulk update
         payload = {
             "users": {
                 "1": {"pin_code": "1234", "status": "enabled"},
                 "2": {"pin_code": "", "status": "disabled"},
-                "invalid": {"pin_code": "0000", "status": "enabled"},
+                "3": {"status": "disabled"},
+                "4": {"status": "enabled"},
+                "5": {"pin_code": 0, "status": "enabled"},
+                "6": {"pin_code": True, "status": "enabled"},
             }
         }
         msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload), 0, False)
@@ -276,39 +244,50 @@ class TestConnect:
         callback_captured(msg)
 
         # Check cache
-        assert len(provider._usercodes_cache) == 2
         assert provider._usercodes_cache[1] == CodeSlot(slot_num=1, code="1234", in_use=True)
         assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code=None, in_use=False)
+        assert provider._usercodes_cache[3] == CodeSlot(slot_num=3, code=None, in_use=False)
+        assert 4 not in provider._usercodes_cache
+        assert provider._usercodes_cache[5] == CodeSlot(slot_num=5, code="0", in_use=True)
+        assert provider._usercodes_cache[6] == CodeSlot(slot_num=6, code=None, in_use=False)
 
     async def test_connect_handles_single_pin_code_message(self, provider, mock_hass):
         """Test that incoming single pin code messages update the cache."""
         setup_successful_connect(provider, mock_hass)
 
-        callback_captured = None
+        callback_captured: Any = None
 
         def mock_subscribe(hass, topic, callback_fn):
             nonlocal callback_captured
             callback_captured = callback_fn
             return lambda: None
 
-        with patch("homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe):
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_sub:
+            mock_sub.side_effect = mock_subscribe
             await provider.async_connect()
 
-        # Test single update
-        payload = {
-            "pin_code": {
-                "user": 3,
-                "pin_code": "5678",
-                "user_enabled": True,
-            }
-        }
-        msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload), 0, False)
+        # Test single updates
+        payload1 = {"pin_code": {"user": 1, "pin_code": "5678", "user_enabled": True}}
+        callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload1), 0, False))
+        assert provider._usercodes_cache[1] == CodeSlot(slot_num=1, code="5678", in_use=True)
 
-        assert callback_captured is not None
-        callback_captured(msg)
+        payload2 = {"pin_code": {"user": 2, "user_enabled": True}}
+        callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload2), 0, False))
+        assert 2 not in provider._usercodes_cache
 
-        # Check cache
-        assert provider._usercodes_cache[3] == CodeSlot(slot_num=3, code="5678", in_use=True)
+        payload3 = {"pin_code": {"user": 3, "user_enabled": False}}
+        callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload3), 0, False))
+        assert provider._usercodes_cache[3] == CodeSlot(slot_num=3, code=None, in_use=False)
+
+        payload4 = {"pin_code": {"user": 4, "pin_code": 0, "user_enabled": True}}
+        callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload4), 0, False))
+        assert provider._usercodes_cache[4] == CodeSlot(slot_num=4, code="0", in_use=True)
+
+        payload5 = {"pin_code": {"user": 5, "pin_code": False, "user_enabled": True}}
+        callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload5), 0, False))
+        assert provider._usercodes_cache[5] == CodeSlot(slot_num=5, code=None, in_use=False)
 
     async def test_connect_ignores_invalid_json(self, provider, mock_hass):
         """Test that invalid json payloads are handled gracefully."""
@@ -321,12 +300,14 @@ class TestConnect:
             callback_captured = callback_fn
             return lambda: None
 
-        with patch("homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe):
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_sub:
+            mock_sub.side_effect = mock_subscribe
             await provider.async_connect()
 
         msg = ReceiveMessage("zigbee2mqtt/my_lock", "invalid json", 0, False)
 
-        # Should not raise exception
         assert callback_captured is not None
         callback_captured(msg)
         assert len(provider._usercodes_cache) == 0
@@ -341,30 +322,12 @@ class TestIsConnected:
 
     async def test_is_connected_success(self, provider, mock_hass):
         """Test it returns True when connected and registry confirms."""
-        setup_successful_connect(provider, mock_hass)
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
-        ) as mock_subscribe:
-            mock_subscribe.return_value = lambda: None
-            await provider.async_connect()
-
-        # Mock registry entry is still there
-        lock_entry = MagicMock()
-        lock_entry.platform = "mqtt"
-        provider.entity_registry.async_get.return_value = lock_entry
-
+        await connect_provider(provider, mock_hass)
         assert await provider.async_is_connected() is True
 
     async def test_is_connected_registry_missing(self, provider, mock_hass):
         """Test it returns False if entity is removed from registry."""
-        setup_successful_connect(provider, mock_hass)
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
-        ) as mock_subscribe:
-            mock_subscribe.return_value = lambda: None
-            await provider.async_connect()
-
-        # Entity missing now
+        await connect_provider(provider, mock_hass)
         provider.entity_registry.async_get.return_value = None
 
         assert await provider.async_is_connected() is False
@@ -372,14 +335,7 @@ class TestIsConnected:
 
     async def test_is_connected_platform_changed(self, provider, mock_hass):
         """Test it returns False if entity platform changes."""
-        setup_successful_connect(provider, mock_hass)
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
-        ) as mock_subscribe:
-            mock_subscribe.return_value = lambda: None
-            await provider.async_connect()
-
-        # Platform changed now
+        await connect_provider(provider, mock_hass)
         lock_entry = MagicMock()
         lock_entry.platform = "other"
         provider.entity_registry.async_get.return_value = lock_entry
@@ -392,39 +348,56 @@ class TestUsercodeOperations:
     """Test user code operations in Zigbee2MQTTLockProvider."""
 
     async def test_get_usercodes_not_connected(self, provider):
-        """Test get_usercodes returns empty list and logs error when not connected."""
+        """Test get_usercodes returns empty list when not connected."""
         result = await provider.async_get_usercodes()
         assert result == []
 
     async def test_get_usercodes_success(self, provider, mock_hass):
-        """Test get_usercodes publishes to get topic and returns slot range."""
-        setup_successful_connect(provider, mock_hass)
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
-        ) as mock_subscribe:
-            mock_subscribe.return_value = lambda: None
-            await provider.async_connect()
+        """Test get_usercodes queries slots concurrently and resolves futures."""
+        mock_subscribe = await connect_provider(provider, mock_hass)
+        callback_captured = mock_subscribe.call_args[0][2]
 
-        # Populate cache for slot 1
-        provider._usercodes_cache[1] = CodeSlot(slot_num=1, code="1234", in_use=True)
+        publish_calls = []
 
-        with (
-            patch(
-                "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
-            ) as mock_publish,
-            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-        ):
+        async def mock_publish(hass, topic, payload, qos=0, retain=False):
+            publish_calls.append((topic, payload))
+            parsed = json.loads(payload)
+            slot_num = parsed["pin_code"]["user"]
+
+            response_payload = {
+                "pin_code": {
+                    "user": slot_num,
+                    "pin_code": f"pin_{slot_num}",
+                    "user_enabled": True,
+                }
+            }
+            msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(response_payload), 0, False)
+            callback_captured(msg)
+
+        with patch("homeassistant.components.mqtt.async_publish", side_effect=mock_publish):
             result = await provider.async_get_usercodes()
 
-            mock_publish.assert_called_once_with(
-                mock_hass, "zigbee2mqtt/my_lock/get", '{"pin_code": ""}'
-            )
-            mock_sleep.assert_called_once_with(2.0)
+            assert len(publish_calls) == 6
+            for i in range(1, 7):
+                assert (
+                    "zigbee2mqtt/my_lock/get",
+                    json.dumps({"pin_code": {"user": i}}),
+                ) in publish_calls
 
-            # mock_config_entry configures start: 1, slots: 6
             assert len(result) == 6
-            assert result[0] == CodeSlot(slot_num=1, code="1234", in_use=True)
-            assert result[1] == CodeSlot(slot_num=2, code=None, in_use=False)
+            assert result[0] == CodeSlot(slot_num=1, code="pin_1", in_use=True)
+            assert result[5] == CodeSlot(slot_num=6, code="pin_6", in_use=True)
+
+    async def test_get_usercodes_timeout(self, provider, mock_hass):
+        """Test that get_usercodes raises LockOperationFailed when query times out."""
+        await connect_provider(provider, mock_hass)
+
+        with (
+            patch("homeassistant.components.mqtt.async_publish", new_callable=AsyncMock),
+            patch("asyncio.wait_for", side_effect=asyncio.TimeoutError),
+            pytest.raises(LockOperationFailed),
+        ):
+            await provider.async_get_usercodes()
 
     async def test_get_usercode_cached(self, provider):
         """Test get_usercode retrieves from cache."""
@@ -443,12 +416,7 @@ class TestUsercodeOperations:
 
     async def test_set_usercode_success(self, provider, mock_hass):
         """Test set_usercode publishes correct payload and updates cache."""
-        setup_successful_connect(provider, mock_hass)
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
-        ) as mock_subscribe:
-            mock_subscribe.return_value = lambda: None
-            await provider.async_connect()
+        await connect_provider(provider, mock_hass)
 
         with patch(
             "homeassistant.components.mqtt.async_publish", new_callable=AsyncMock
@@ -473,8 +441,45 @@ class TestUsercodeOperations:
                 qos=1,
                 retain=False,
             )
-            # Optimistically updated
             assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code="4321", in_use=True)
+
+    async def test_set_usercode_publish_failure_oserror(self, provider, mock_hass):
+        """Test that OSError on publish raises LockDisconnected."""
+        await connect_provider(provider, mock_hass)
+
+        with patch(
+            "homeassistant.components.mqtt.async_publish", side_effect=OSError("Network down")
+        ):
+            with pytest.raises(LockDisconnected):
+                await provider.async_set_usercode(2, "1234")
+
+            assert 2 not in provider._usercodes_cache
+
+    async def test_set_usercode_publish_failure_haerror(self, provider, mock_hass):
+        """Test that HomeAssistantError on publish raises LockOperationFailed."""
+        await connect_provider(provider, mock_hass)
+
+        with patch(
+            "homeassistant.components.mqtt.async_publish",
+            side_effect=HomeAssistantError("Publish failed"),
+        ):
+            with pytest.raises(LockOperationFailed):
+                await provider.async_set_usercode(2, "1234")
+
+            assert 2 not in provider._usercodes_cache
+
+    async def test_set_usercode_mqtt_disabled(self, provider, mock_hass):
+        """Test that set_usercode raises LockDisconnected when MQTT is disabled."""
+        await connect_provider(provider, mock_hass)
+
+        with patch(
+            "custom_components.keymaster.providers.zigbee2mqtt.mqtt_config_entry_enabled",
+            return_value=False,
+        ):
+            with pytest.raises(LockDisconnected):
+                await provider.async_set_usercode(2, "1234")
+
+            assert 2 not in provider._usercodes_cache
 
     async def test_clear_usercode_not_connected(self, provider):
         """Test clear_usercode returns False when not connected."""
@@ -482,15 +487,9 @@ class TestUsercodeOperations:
         assert result is False
 
     async def test_clear_usercode_success(self, provider, mock_hass):
-        """Test clear_usercode publishes correct payload and updates cache."""
-        setup_successful_connect(provider, mock_hass)
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
-        ) as mock_subscribe:
-            mock_subscribe.return_value = lambda: None
-            await provider.async_connect()
+        """Test clear_usercode publishes correct full shape payload and updates cache."""
+        await connect_provider(provider, mock_hass)
 
-        # Set it first in cache
         provider._usercodes_cache[2] = CodeSlot(slot_num=2, code="4321", in_use=True)
 
         with patch(
@@ -503,6 +502,9 @@ class TestUsercodeOperations:
                 {
                     "pin_code": {
                         "user": 2,
+                        "user_type": "unrestricted",
+                        "user_enabled": False,
+                        "pin_code": None,
                     }
                 }
             )
@@ -513,7 +515,6 @@ class TestUsercodeOperations:
                 qos=1,
                 retain=False,
             )
-            # Optimistically cleared
             assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code=None, in_use=False)
 
 
@@ -521,15 +522,9 @@ class TestLockEvents:
     """Test lock event subscription."""
 
     async def test_subscribe_lock_events(self, provider, mock_hass):
-        """Test subscribing to keypad unlock events works and triggers callback."""
-        setup_successful_connect(provider, mock_hass)
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
-        ) as mock_subscribe:
-            mock_subscribe.return_value = lambda: None
-            await provider.async_connect()
+        """Test subscribing to keypad unlock/lock events works and triggers callback."""
+        await connect_provider(provider, mock_hass)
 
-        # Capture the callback passed to async_subscribe inside subscribe_lock_events
         captured_callback = None
         unsub_mock = MagicMock()
 
@@ -545,42 +540,39 @@ class TestLockEvents:
             "homeassistant.components.mqtt.async_subscribe", side_effect=mock_subscribe_events
         ):
             unsubscribe_fn = provider.subscribe_lock_events(mock_kmlock, mock_callback)
-
-            # Let the event loop run scheduled tasks (since subscribe is called inside async_create_task)
             await asyncio.sleep(0.01)
 
         assert captured_callback is not None
 
-        # Build mock ReceiveMessage
-
-        # Construct a keypad unlock event
-        payload = {
-            "action": "unlock",
-            "action_source_name": "keypad",
+        # 1. Keypad unlock event
+        payload_unlock = {
+            "action": "keypad_unlock",
             "action_user": 2,
         }
-        msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload), 0, False)
-
-        # Trigger captured callback
-        captured_callback(msg)
-
-        # Let the event loop run scheduled tasks (since handle_lock_message is called inside async_create_task)
+        msg_unlock = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload_unlock), 0, False)
+        captured_callback(msg_unlock)
         await asyncio.sleep(0.01)
 
         mock_callback.assert_called_once_with(2, "Unlocked via Keypad", 1)
+        mock_callback.reset_mock()
 
-        # Unsubscribe
+        # 2. Keypad lock event
+        payload_lock = {
+            "action": "keypad_lock",
+            "action_user": 3,
+        }
+        msg_lock = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload_lock), 0, False)
+        captured_callback(msg_lock)
+        await asyncio.sleep(0.01)
+
+        mock_callback.assert_called_once_with(3, "Keypad Lock", 5)
+
         unsubscribe_fn()
         unsub_mock.assert_called_once()
 
-    async def test_subscribe_lock_events_ignores_non_keypad_unlock(self, provider, mock_hass):
-        """Test subscribing to keypad unlock events ignores other actions/sources."""
-        setup_successful_connect(provider, mock_hass)
-        with patch(
-            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
-        ) as mock_subscribe:
-            mock_subscribe.return_value = lambda: None
-            await provider.async_connect()
+    async def test_subscribe_lock_events_ignores_other_actions(self, provider, mock_hass):
+        """Test subscribing to keypad unlock/lock events ignores other actions."""
+        await connect_provider(provider, mock_hass)
 
         captured_callback = None
 
@@ -598,16 +590,18 @@ class TestLockEvents:
             provider.subscribe_lock_events(mock_kmlock, mock_callback)
             await asyncio.sleep(0.01)
 
-        # Non-keypad source
-        payload1 = {"action": "unlock", "action_source_name": "rf", "action_user": 2}
         assert captured_callback is not None
+
+        # RF unlock/lock action
+        payload1 = {"action": "unlock", "action_user": 2}
         captured_callback(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload1), 0, False))
 
-        # Lock action instead of unlock
-        payload2 = {"action": "lock", "action_source_name": "keypad", "action_user": 2}
+        payload2 = {"action": "keypad_unlock"}  # Missing user
         captured_callback(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload2), 0, False))
 
-        # Invalid json
+        payload3 = {"action": "keypad_lock", "action_user": "invalid"}  # User not int
+        captured_callback(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload3), 0, False))
+
         captured_callback(ReceiveMessage("zigbee2mqtt/my_lock", "invalid json", 0, False))
 
         await asyncio.sleep(0.01)

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -17,6 +17,7 @@ from custom_components.keymaster.providers.zigbee2mqtt import (
     _get_pin_code_value,
     _mqtt_payload_pin_has_code_value,
 )
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -37,6 +38,7 @@ def mock_hass():
     hass = MagicMock(spec=HomeAssistant)
     hass.config_entries = MagicMock()
     hass.data = {}
+    hass.states = MagicMock()
 
     def async_create_task(coro):
         return asyncio.create_task(coro)
@@ -141,7 +143,7 @@ class TestProperties:
 
     def test_supports_connection_status(self, provider):
         """Test supports_connection_status property."""
-        assert provider.supports_connection_status is False
+        assert provider.supports_connection_status is True
 
 
 class TestConnect:
@@ -329,7 +331,35 @@ class TestIsConnected:
     async def test_is_connected_success(self, provider, mock_hass):
         """Test it returns True when connected and registry confirms."""
         await connect_provider(provider, mock_hass)
+        mock_state = MagicMock()
+        mock_state.state = "locked"
+        mock_hass.states.get.return_value = mock_state
         assert await provider.async_is_connected() is True
+
+    async def test_is_connected_state_unavailable(self, provider, mock_hass):
+        """Test it returns False when state is unavailable."""
+        await connect_provider(provider, mock_hass)
+        mock_state = MagicMock()
+        mock_state.state = STATE_UNAVAILABLE
+        mock_hass.states.get.return_value = mock_state
+        assert await provider.async_is_connected() is False
+        assert provider.connected is False
+
+    async def test_is_connected_state_unknown(self, provider, mock_hass):
+        """Test it returns False when state is unknown."""
+        await connect_provider(provider, mock_hass)
+        mock_state = MagicMock()
+        mock_state.state = STATE_UNKNOWN
+        mock_hass.states.get.return_value = mock_state
+        assert await provider.async_is_connected() is False
+        assert provider.connected is False
+
+    async def test_is_connected_state_none(self, provider, mock_hass):
+        """Test it returns False when state is None."""
+        await connect_provider(provider, mock_hass)
+        mock_hass.states.get.return_value = None
+        assert await provider.async_is_connected() is False
+        assert provider.connected is False
 
     async def test_is_connected_registry_missing(self, provider, mock_hass):
         """Test it returns False if entity is removed from registry."""

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 import asyncio
 import json
 from typing import Any, NamedTuple
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 
 from custom_components.keymaster.const import CONF_SLOTS, CONF_START
 from custom_components.keymaster.exceptions import LockDisconnected, LockOperationFailed
 from custom_components.keymaster.providers._base import CodeSlot
-from custom_components.keymaster.providers.zigbee2mqtt import Zigbee2MQTTLockProvider
+from custom_components.keymaster.providers.zigbee2mqtt import (
+    Zigbee2MQTTLockProvider,
+    _get_pin_code_value,
+    _mqtt_payload_pin_has_code_value,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -237,6 +241,7 @@ class TestConnect:
                 "4": {"status": "enabled"},
                 "5": {"pin_code": 0, "status": "enabled"},
                 "6": {"pin_code": True, "status": "enabled"},
+                "invalid": {"pin_code": "0000", "status": "enabled"},
             }
         }
         msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload), 0, False)
@@ -250,6 +255,7 @@ class TestConnect:
         assert 4 not in provider._usercodes_cache
         assert provider._usercodes_cache[5] == CodeSlot(slot_num=5, code="0", in_use=True)
         assert provider._usercodes_cache[6] == CodeSlot(slot_num=6, code=None, in_use=False)
+        assert "invalid" not in provider._usercodes_cache
 
     async def test_connect_handles_single_pin_code_message(self, provider, mock_hass):
         """Test that incoming single pin code messages update the cache."""
@@ -613,3 +619,134 @@ class TestLockEvents:
         unsub = provider.subscribe_connection_events(callback)
         assert callable(unsub)
         unsub()
+
+
+def test_pin_has_code_value():
+    """Test the standalone pin helper functions."""
+
+    assert _mqtt_payload_pin_has_code_value(None) is False
+    assert _mqtt_payload_pin_has_code_value(True) is False
+    assert _mqtt_payload_pin_has_code_value(False) is False
+    assert _mqtt_payload_pin_has_code_value([]) is False
+    assert _mqtt_payload_pin_has_code_value("   ") is False
+    assert _mqtt_payload_pin_has_code_value(0) is True
+    assert _mqtt_payload_pin_has_code_value("1234") is True
+
+    assert _get_pin_code_value(None) is None
+    assert _get_pin_code_value(True) is None
+    assert _get_pin_code_value("1234") == "1234"
+
+
+class TestCoverageExtra:
+    """Extra tests to achieve 100% test coverage."""
+
+    async def test_get_usercodes_success_bulk(self, provider, mock_hass):
+        """Test get_usercodes queries slots concurrently and resolves futures via bulk users message."""
+        mock_subscribe = await connect_provider(provider, mock_hass)
+        callback_captured = mock_subscribe.call_args[0][2]
+
+        publish_calls = []
+
+        async def mock_publish(hass, topic, payload, qos=0, retain=False):
+            publish_calls.append((topic, payload))
+            parsed = json.loads(payload)
+            slot_num = parsed["pin_code"]["user"]
+
+            # Send bulk update response back containing this user
+            response_payload = {
+                "users": {
+                    str(slot_num): {
+                        "pin_code": f"pin_{slot_num}",
+                        "status": "enabled",
+                    }
+                }
+            }
+            msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(response_payload), 0, False)
+            callback_captured(msg)
+
+        with patch("homeassistant.components.mqtt.async_publish", side_effect=mock_publish):
+            result = await provider.async_get_usercodes()
+
+            assert len(result) == 6
+            assert result[0] == CodeSlot(slot_num=1, code="pin_1", in_use=True)
+            assert result[5] == CodeSlot(slot_num=6, code="pin_6", in_use=True)
+
+    async def test_get_usercodes_disabled_no_pin_resolves_future(self, provider, mock_hass):
+        """Test that single pin update with user_enabled=False and no pin_code resolves future."""
+        mock_subscribe = await connect_provider(provider, mock_hass)
+        callback_captured = mock_subscribe.call_args[0][2]
+
+        async def mock_publish(hass, topic, payload, qos=0, retain=False):
+            parsed = json.loads(payload)
+            slot_num = parsed["pin_code"]["user"]
+
+            # Response without pin_code key but user_enabled=False
+            response_payload = {
+                "pin_code": {
+                    "user": slot_num,
+                    "user_enabled": False,
+                }
+            }
+            msg = ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(response_payload), 0, False)
+            callback_captured(msg)
+
+        with patch("homeassistant.components.mqtt.async_publish", side_effect=mock_publish):
+            result = await provider.async_get_usercodes()
+            assert len(result) == 6
+            assert result[0] == CodeSlot(slot_num=1, code=None, in_use=False)
+
+    async def test_subscribe_lock_events_missing_state_topic(self, provider, mock_hass):
+        """Test subscribing to events returns dummy unsubscribe when state topic is missing."""
+        await connect_provider(provider, mock_hass)
+
+        with patch(
+            "custom_components.keymaster.providers.zigbee2mqtt.Zigbee2MQTTLockProvider.state_topic",
+            new_callable=PropertyMock,
+        ) as mock_state_topic:
+            mock_state_topic.return_value = None
+            mock_callback = AsyncMock()
+            mock_kmlock = MagicMock()
+            unsubscribe_fn = provider.subscribe_lock_events(mock_kmlock, mock_callback)
+            await asyncio.sleep(0.01)
+
+            assert callable(unsubscribe_fn)
+
+    async def test_async_query_slot_missing_get_topic(self, provider, mock_hass):
+        """Test that _async_query_slot raises LockDisconnected when get_topic is missing."""
+        await connect_provider(provider, mock_hass)
+
+        with patch(
+            "custom_components.keymaster.providers.zigbee2mqtt.Zigbee2MQTTLockProvider.get_topic",
+            new_callable=PropertyMock,
+        ) as mock_get_topic:
+            mock_get_topic.return_value = None
+            with pytest.raises(LockDisconnected):
+                await provider._async_query_slot(1)
+
+    async def test_connect_missing_state_topic(self, provider, mock_hass):
+        """Test that async_connect returns False when state_topic cannot be derived."""
+        setup_successful_connect(provider, mock_hass, device_name="")
+        result = await provider.async_connect()
+        assert result is False
+
+    async def test_handles_single_pin_code_message_with_null(self, provider, mock_hass):
+        """Test that incoming single pin code messages with null pin_code update the cache correctly."""
+        setup_successful_connect(provider, mock_hass)
+
+        callback_captured: Any = None
+
+        def mock_subscribe(hass, topic, callback_fn):
+            nonlocal callback_captured
+            callback_captured = callback_fn
+            return lambda: None
+
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_sub:
+            mock_sub.side_effect = mock_subscribe
+            await provider.async_connect()
+
+        # Test single updates with null pin_code
+        payload1 = {"pin_code": {"user": 1, "pin_code": None, "user_enabled": True}}
+        callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload1), 0, False))
+        assert provider._usercodes_cache[1] == CodeSlot(slot_num=1, code=None, in_use=False)

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -115,6 +115,7 @@ def setup_successful_connect(
     device_entry = MagicMock()
     device_entry.identifiers = identifiers
     device_entry.name = device_name
+    device_entry.original_name = device_name
     provider.device_registry.async_get.return_value = device_entry
 
 
@@ -167,7 +168,7 @@ class TestConnect:
 
         # Now simulate a device rename in registry
         device_entry = provider.device_registry.async_get.return_value
-        device_entry.name = "new_lock_name"
+        device_entry.original_name = "new_lock_name"
 
         assert provider.base_topic == "zigbee2mqtt/new_lock_name"
         assert provider.set_topic == "zigbee2mqtt/new_lock_name/set"

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -1153,7 +1153,7 @@ class TestProviderFactory:
         """Test get_provider_class_for_lock returns None for unsupported platform."""
         mock_registry = MagicMock()
         mock_entity = MagicMock()
-        mock_entity.platform = "mqtt"
+        mock_entity.platform = "unsupported"
         mock_registry.async_get.return_value = mock_entity
 
         with patch(


### PR DESCRIPTION
# Summary
<!--
  Please include a summary of the change and which issue is fixed or linked.
  Please also include relevant motivation and context.
-->
This PR adds native support for Zigbee locks integrated via Zigbee2MQTT (MQTT platform domain) to Keymaster. It implements a dedicated lock provider, registers it, adds documentation in the README, and introduces a comprehensive test suite.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Added `Zigbee2MQTTLockProvider` in `custom_components/keymaster/providers/zigbee2mqtt.py` to manage connection, cached state parsing (handling both bulk `users` and single `pin_code` payloads), setting/clearing PIN codes, and keypad unlock event listeners.
- Registered `"mqtt": Zigbee2MQTTLockProvider` in `custom_components/keymaster/providers/__init__.py`.
- Added a dedicated configuration section to `README.md` explaining the `expose_pin: true` requirement for Zigbee2MQTT locks.
- Created `tests/providers/test_zigbee2mqtt.py` containing 28 test cases ensuring full unit test coverage (total test coverage is at 90.76%).
- Fixed `tests/providers/test_zwave_js.py` platform factory check mock platform to avoid collisions now that `"mqtt"` is supported.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
