### PR TITLE
fix: subscribe to lock entity state changes in coordinator to fix autolock

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -572,6 +572,50 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 inferred_action,
             )
 
+    async def _handle_lock_state_change(
+        self,
+        kmlock: KeymasterLock,
+        event: Event[EventStateChangedData],
+    ) -> None:
+        """Track state changes to lock entities."""
+        _LOGGER.debug("[handle_lock_state_change] %s: event: %s", kmlock.lock_name, event)
+        if not event:
+            return
+
+        changed_entity: str = event.data["entity_id"]
+
+        # Don't do anything if the changed entity is not this lock
+        if changed_entity != kmlock.lock_entity_id:
+            return
+
+        old_state: str | None = None
+        if temp_old_state := event.data.get("old_state"):
+            old_state = temp_old_state.state
+        new_state: str | None = None
+        if temp_new_state := event.data.get("new_state"):
+            new_state = temp_new_state.state
+        _LOGGER.debug(
+            "[handle_lock_state_change] %s: old_state: %s, new_state: %s",
+            kmlock.lock_name,
+            old_state,
+            new_state,
+        )
+
+        if new_state == LockState.UNLOCKED:
+            if kmlock.lock_state != LockState.UNLOCKED:
+                await self._lock_unlocked(
+                    kmlock=kmlock,
+                    source="state_change",
+                    event_label="State Change Update Unlock",
+                )
+        elif new_state == LockState.LOCKED:
+            if kmlock.lock_state != LockState.LOCKED:
+                await self._lock_locked(
+                    kmlock=kmlock,
+                    source="state_change",
+                    event_label="State Change Update Lock",
+                )
+
     async def _handle_door_state_change(
         self,
         kmlock: KeymasterLock,
@@ -644,6 +688,18 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     action=functools.partial(self._handle_door_state_change, kmlock),
                 ),
             )
+
+        _LOGGER.debug(
+            "[create_listeners] %s: Creating handle_lock_state_change listener",
+            kmlock.lock_name,
+        )
+        kmlock.listeners.append(
+            async_track_state_change_event(
+                hass=self.hass,
+                entity_ids=kmlock.lock_entity_id,
+                action=functools.partial(self._handle_lock_state_change, kmlock),
+            ),
+        )
 
     @staticmethod
     async def _unsubscribe_listeners(kmlock: KeymasterLock) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1486,6 +1486,53 @@ class TestLockStateEventHandlers:
         mock_coordinator._lock_unlocked.assert_not_called()
         mock_coordinator._lock_locked.assert_not_called()
 
+    async def test_handle_lock_state_change_no_event(self, mock_coordinator, mock_kmlock):
+        """Test _handle_lock_state_change does nothing when event is None."""
+        mock_coordinator._lock_unlocked = AsyncMock()
+        mock_coordinator._lock_locked = AsyncMock()
+
+        await mock_coordinator._handle_lock_state_change(mock_kmlock, None)
+
+        mock_coordinator._lock_unlocked.assert_not_called()
+        mock_coordinator._lock_locked.assert_not_called()
+
+    async def test_handle_lock_state_change_missing_states(self, mock_coordinator, mock_kmlock):
+        """Test _handle_lock_state_change handles missing old_state and new_state gracefully."""
+        mock_coordinator._lock_unlocked = AsyncMock()
+        mock_coordinator._lock_locked = AsyncMock()
+
+        event = Mock()
+        event.data = {
+            "entity_id": "lock.front_door",
+        }
+
+        await mock_coordinator._handle_lock_state_change(mock_kmlock, event)
+
+        mock_coordinator._lock_unlocked.assert_not_called()
+        mock_coordinator._lock_locked.assert_not_called()
+
+    async def test_handle_lock_state_change_no_change_locked(self, mock_coordinator, mock_kmlock):
+        """Test _handle_lock_state_change does nothing when lock is already locked."""
+        mock_kmlock.lock_state = LockState.LOCKED
+        mock_coordinator._lock_unlocked = AsyncMock()
+        mock_coordinator._lock_locked = AsyncMock()
+
+        mock_old = Mock()
+        mock_old.state = LockState.UNLOCKED
+        mock_new = Mock()
+        mock_new.state = LockState.LOCKED
+        event = Mock()
+        event.data = {
+            "entity_id": "lock.front_door",
+            "old_state": mock_old,
+            "new_state": mock_new,
+        }
+
+        await mock_coordinator._handle_lock_state_change(mock_kmlock, event)
+
+        mock_coordinator._lock_unlocked.assert_not_called()
+        mock_coordinator._lock_locked.assert_not_called()
+
 
 # ============================================================================
 # Timer Setup Tests

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1390,6 +1390,102 @@ class TestLockStateEventHandlers:
             await mock_coordinator._door_opened(mock_kmlock)
             assert mock_kmlock.door_state == STATE_OPEN
 
+    async def test_handle_lock_state_change_unlocked(self, mock_coordinator, mock_kmlock):
+        """Test _handle_lock_state_change triggers _lock_unlocked when lock transitions to UNLOCKED."""
+        mock_kmlock.lock_state = LockState.LOCKED
+        mock_coordinator._lock_unlocked = AsyncMock()
+        mock_coordinator._lock_locked = AsyncMock()
+
+        mock_old = Mock()
+        mock_old.state = LockState.LOCKED
+        mock_new = Mock()
+        mock_new.state = LockState.UNLOCKED
+        event = Mock()
+        event.data = {
+            "entity_id": "lock.front_door",
+            "old_state": mock_old,
+            "new_state": mock_new,
+        }
+
+        await mock_coordinator._handle_lock_state_change(mock_kmlock, event)
+
+        mock_coordinator._lock_unlocked.assert_called_once_with(
+            kmlock=mock_kmlock,
+            source="state_change",
+            event_label="State Change Update Unlock",
+        )
+        mock_coordinator._lock_locked.assert_not_called()
+
+    async def test_handle_lock_state_change_locked(self, mock_coordinator, mock_kmlock):
+        """Test _handle_lock_state_change triggers _lock_locked when lock transitions to LOCKED."""
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_coordinator._lock_unlocked = AsyncMock()
+        mock_coordinator._lock_locked = AsyncMock()
+
+        mock_old = Mock()
+        mock_old.state = LockState.UNLOCKED
+        mock_new = Mock()
+        mock_new.state = LockState.LOCKED
+        event = Mock()
+        event.data = {
+            "entity_id": "lock.front_door",
+            "old_state": mock_old,
+            "new_state": mock_new,
+        }
+
+        await mock_coordinator._handle_lock_state_change(mock_kmlock, event)
+
+        mock_coordinator._lock_locked.assert_called_once_with(
+            kmlock=mock_kmlock,
+            source="state_change",
+            event_label="State Change Update Lock",
+        )
+        mock_coordinator._lock_unlocked.assert_not_called()
+
+    async def test_handle_lock_state_change_no_change(self, mock_coordinator, mock_kmlock):
+        """Test _handle_lock_state_change does nothing when state has not changed from kmlock's state."""
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_coordinator._lock_unlocked = AsyncMock()
+        mock_coordinator._lock_locked = AsyncMock()
+
+        mock_old = Mock()
+        mock_old.state = LockState.LOCKED
+        mock_new = Mock()
+        mock_new.state = LockState.UNLOCKED
+        event = Mock()
+        event.data = {
+            "entity_id": "lock.front_door",
+            "old_state": mock_old,
+            "new_state": mock_new,
+        }
+
+        await mock_coordinator._handle_lock_state_change(mock_kmlock, event)
+
+        mock_coordinator._lock_unlocked.assert_not_called()
+        mock_coordinator._lock_locked.assert_not_called()
+
+    async def test_handle_lock_state_change_wrong_entity(self, mock_coordinator, mock_kmlock):
+        """Test _handle_lock_state_change does nothing when the entity_id does not match."""
+        mock_kmlock.lock_state = LockState.LOCKED
+        mock_coordinator._lock_unlocked = AsyncMock()
+        mock_coordinator._lock_locked = AsyncMock()
+
+        mock_old = Mock()
+        mock_old.state = LockState.LOCKED
+        mock_new = Mock()
+        mock_new.state = LockState.UNLOCKED
+        event = Mock()
+        event.data = {
+            "entity_id": "lock.wrong_door",
+            "old_state": mock_old,
+            "new_state": mock_new,
+        }
+
+        await mock_coordinator._handle_lock_state_change(mock_kmlock, event)
+
+        mock_coordinator._lock_unlocked.assert_not_called()
+        mock_coordinator._lock_locked.assert_not_called()
+
 
 # ============================================================================
 # Timer Setup Tests


### PR DESCRIPTION
# Summary

This PR fixes an issue where manual or Home Assistant UI-initiated lock/unlock transitions did not trigger the Auto Lock timer immediately (Issue #632).

## Proposed change

- Subscribes the coordinator directly to `kmlock.lock_entity_id` state change events in `_create_listeners()`.
- Adds a `_handle_lock_state_change()` method in the coordinator to handle those transitions.
- When a state transition to `UNLOCKED` or `LOCKED` occurs, it immediately fires `_lock_unlocked()` or `_lock_locked()` respectively.
- Since `_lock_unlocked()` checks `if kmlock.lock_state == LockState.UNLOCKED:` and returns early, this handles deduplication cleanly if a real-time provider event fires first.
- Added four new unit tests to `tests/test_coordinator.py` validating correct invocation on unlocking, locking, no-change state transitions, and non-matching entity IDs.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #632
- This PR is related to issue:
