### PR TITLE
fix: resolve stale _kmlock reference causing Auto Lock failure

### DIFF
--- a/custom_components/keymaster/entity.py
+++ b/custom_components/keymaster/entity.py
@@ -36,9 +36,6 @@ class KeymasterEntity(CoordinatorEntity[KeymasterCoordinator]):
         self._config_entry: ConfigEntry = entity_description.config_entry
         self.entity_description: KeymasterEntityDescription = entity_description
         self._property: str = entity_description.key  # <Platform>.<Property>.<SubProperty>:<Slot Number*>.<SubProperty>:<Slot Number*>  *Only if needed
-        self._kmlock: KeymasterLock | None = self.coordinator.sync_get_lock_by_config_entry_id(
-            self._config_entry.entry_id
-        )
         self._code_slot = self._get_x_num("code_slots")
         self._day_of_week_num = self._get_x_num("accesslimit_day_of_week")
 
@@ -68,6 +65,11 @@ class KeymasterEntity(CoordinatorEntity[KeymasterCoordinator]):
     def available(self) -> bool:
         """Return whether entity is available."""
         return self._attr_available
+
+    @property
+    def _kmlock(self) -> KeymasterLock | None:
+        """Get the live KeymasterLock instance."""
+        return self.coordinator.sync_get_lock_by_config_entry_id(self._config_entry.entry_id)
 
     def _get_property_value(self) -> Any:
         if "." not in self._property:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -895,3 +895,54 @@ async def test_entity_get_x_num_code_slots_no_segment_starts_with_code_slots(
     # Should return None because no segment starts with "code_slots"
     code_slot_num = entity._get_x_num("code_slots")
     assert code_slot_num is None
+
+
+async def test_entity_dynamic_kmlock_replacement(
+    hass: HomeAssistant, entity_config_entry, coordinator
+):
+    """Test that KeymasterEntity dynamically retrieves the live KeymasterLock instance from coordinator."""
+
+    # Create first lock instance
+    kmlock1 = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=entity_config_entry.entry_id,
+    )
+    kmlock1.autolock_enabled = False
+    coordinator.kmlocks[entity_config_entry.entry_id] = kmlock1
+
+    entity_description = KeymasterEntityDescription(
+        key="switch.autolock_enabled",
+        name="Auto Lock",
+        hass=hass,
+        config_entry=entity_config_entry,
+        coordinator=coordinator,
+    )
+
+    class MockEntity(KeymasterEntity):
+        def _handle_coordinator_update(self):
+            pass
+
+    entity = MockEntity(entity_description=entity_description)
+
+    # Initial check: it should point to kmlock1
+    assert entity._kmlock is kmlock1
+    assert entity._get_property_value() is False
+
+    # Now replace the lock in the coordinator with a new instance
+    kmlock2 = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=entity_config_entry.entry_id,
+    )
+    kmlock2.autolock_enabled = True
+    coordinator.kmlocks[entity_config_entry.entry_id] = kmlock2
+
+    # The entity should dynamically resolve to kmlock2 and reflect its values
+    assert entity._kmlock is kmlock2
+    assert entity._get_property_value() is True
+
+    # Mutating the property should also mutate kmlock2, not kmlock1
+    entity._set_property_value(False)
+    assert kmlock2.autolock_enabled is False
+    assert kmlock1.autolock_enabled is False  # untouched


### PR DESCRIPTION
# Summary

This PR resolves the issue where manual or Home Assistant UI/app lock/unlock events did not trigger the Auto Lock timer (Issue #632). It builds upon the changes in the previously closed PR #633 by fixing the stale `KeymasterLock` instance reference in entities (switches, sensors, etc.).

## Proposed change

1. **Dynamically Track Lock State Changes**: Subscribes the coordinator directly to the lock entity's state changes in `_create_listeners()` and processes transitions immediately.
2. **Resolve Stale Reference**: Removed the static assignment of `self._kmlock` in `KeymasterEntity.__init__` and converted `_kmlock` to a dynamic `@property` getter lookup from the coordinator's live `kmlocks` dict. This ensures all entities (such as switches or configuration inputs) always update properties on the active/live lock instance.
3. **Unit Tests**:
   - Added `test_handle_lock_state_change` transition tests to `tests/test_coordinator.py`.
   - Added `test_entity_dynamic_kmlock_replacement` to `tests/test_entity.py` to verify dynamic `_kmlock` resolution when the lock instance is replaced.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #632
- This PR is related to issue: #633
