### PR TITLE
fix(coordinator): per-slot notify fires on supersede

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -792,8 +792,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             if isinstance(code_slot_num, int) and code_slot_num > 0 and prior_slot == 0:
                 # A more informative event arrived after an initial slot=0 unlock.
                 # Re-fire the bus event with the correct slot info so downstream
-                # consumers get it, but skip side effects (autolock, notifications,
-                # access limits) that already ran from the first event.
+                # consumers get it, but skip side effects (autolock,
+                # global notifications, access limits) that already ran
+                # from the first event. Per-slot notifications are checked
+                # below because they need this corrected slot number.
                 _LOGGER.debug(
                     "[lock_unlocked] %s: Superseding prior slot=0 unlock with slot=%s. source: %s",
                     kmlock.lock_name,

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -754,6 +754,28 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             },
         )
 
+    async def _send_code_slot_unlock_notification(
+        self,
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+        event_label: str | None,
+    ) -> None:
+        """Send a per-code-slot unlock notification when enabled."""
+        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
+        if not slot or not slot.notifications or kmlock.lock_notifications:
+            return
+
+        if slot.name:
+            message = f"{event_label} by {slot.name} [{code_slot_num}]"
+        else:
+            message = f"{event_label} by Code Slot {code_slot_num}"
+        await send_manual_notification(
+            hass=self.hass,
+            script_name=kmlock.notify_script_name,
+            title=kmlock.lock_name,
+            message=message,
+        )
+
     async def _lock_unlocked(
         self,
         kmlock: KeymasterLock,
@@ -782,6 +804,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 self._fire_unlock_state_changed(
                     kmlock, code_slot_num, source, event_label, action_code
                 )
+                await self._send_code_slot_unlock_notification(kmlock, code_slot_num, event_label)
             return
 
         if not self._throttle.is_allowed(
@@ -872,20 +895,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     # Check if slot should be deactivated (e.g., count reached 0)
                     await self._update_slot(kmlock, kmlock.code_slots[code_slot_num], code_slot_num)
 
-            if kmlock.code_slots[code_slot_num].notifications and not kmlock.lock_notifications:
-                if kmlock.code_slots[code_slot_num].name:
-                    message = event_label
-                    message = (
-                        f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
-                    )
-                else:
-                    message = f"{message} by Code Slot {code_slot_num}"
-                await send_manual_notification(
-                    hass=self.hass,
-                    script_name=kmlock.notify_script_name,
-                    title=kmlock.lock_name,
-                    message=message,
-                )
+            await self._send_code_slot_unlock_notification(kmlock, code_slot_num, event_label)
 
         # Fire state change event
         self._fire_unlock_state_changed(kmlock, code_slot_num, source, event_label, action_code)

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -477,6 +477,253 @@ async def test_lock_unlocked_supersedes_slot_zero_with_slot_info(hass, coordinat
     assert fired_events[1][ATTR_STATE] == LockState.UNLOCKED
 
 
+async def test_lock_unlocked_supersede_sends_per_slot_notification(
+    hass, coordinator_for_unlock_test
+):
+    """Test that superseding a slot=0 unlock sends per-slot notification."""
+    coordinator = coordinator_for_unlock_test
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.notify_script_name = "notify_test"
+    kmlock.code_slots = {
+        2: KeymasterCodeSlot(number=2, name="Charlie", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks["test_entry"] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        mock_notify.assert_not_called()
+
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=2,
+            source="valid_code_entered",
+            event_label="Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_test",
+        title="test_lock",
+        message="Unlock by Charlie [2]",
+    )
+
+
+async def test_lock_unlocked_supersede_skips_per_slot_when_global_enabled(
+    hass, coordinator_for_unlock_test
+):
+    """Test that global notifications suppress per-slot notification on supersede."""
+    coordinator = coordinator_for_unlock_test
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_test"
+    kmlock.code_slots = {
+        2: KeymasterCodeSlot(number=2, name="Charlie", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks["test_entry"] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=2,
+            source="valid_code_entered",
+            event_label="Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_test",
+        title="test_lock",
+        message="Unlock",
+    )
+
+
+async def test_lock_unlocked_supersede_skips_disabled_per_slot_notification(
+    hass, coordinator_for_unlock_test
+):
+    """Test that disabled per-slot notifications do not fire on supersede."""
+    coordinator = coordinator_for_unlock_test
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.notify_script_name = "notify_test"
+    kmlock.code_slots = {
+        2: KeymasterCodeSlot(number=2, name="Charlie", enabled=True, notifications=False)
+    }
+    coordinator.kmlocks["test_entry"] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=2,
+            source="valid_code_entered",
+            event_label="Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+
+    mock_notify.assert_not_called()
+
+
+async def test_lock_unlocked_supersede_skips_missing_slot_notification(
+    hass, coordinator_for_unlock_test
+):
+    """Test that supersede notification handling ignores missing code slots."""
+    coordinator = coordinator_for_unlock_test
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.notify_script_name = "notify_test"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Alice", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks["test_entry"] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=2,
+            source="valid_code_entered",
+            event_label="Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+
+    mock_notify.assert_not_called()
+
+
+async def test_lock_unlocked_sends_per_slot_notification_without_supersede(
+    hass, coordinator_for_unlock_test
+):
+    """Test that first unlock event with a slot still sends per-slot notification."""
+    coordinator = coordinator_for_unlock_test
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.notify_script_name = "notify_test"
+    kmlock.code_slots = {4: KeymasterCodeSlot(number=4, enabled=True, notifications=True)}
+    coordinator.kmlocks["test_entry"] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=4,
+            source="valid_code_entered",
+            event_label="Keypad Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_test",
+        title="test_lock",
+        message="Keypad Unlock by Code Slot 4",
+    )
+
+
 async def test_lock_unlocked_does_not_supersede_when_already_has_slot(
     hass, coordinator_for_unlock_test
 ):


### PR DESCRIPTION
## Summary

Per-code-slot notifications never fired on Z-Wave locks because the
slot-0 supersede branch (added in #608) intentionally skips all
side-effects to avoid double-firing.

## Root cause

For zwave_js locks, an unlock is often reported as two coordinator
events: first with `code_slot_num=0`, then with the real slot
number. PR #608 added a supersede path that re-fires the corrected
bus event but skips autolock, access-limit decrement, **and
notifications**. Per-slot notifications can only fire on the second
event (the first has no slot identity), so the per-slot path was
unreachable for Z-Wave.

Global notifications kept working because they fire on the first
(slot=0) event.

## Fix

On supersede, after re-firing the corrected bus event, run only the
per-slot notification check using the now-known slot. Continue to
skip autolock, access-limit, and global notifications.

The mutual-exclusion gate from #450 (per-slot suppressed when global
also enabled) is preserved.

## Tests

Added tests in `tests/test_coordinator_events.py` covering:
- Per-slot notification fires on supersede with global off
- Per-slot notification suppressed when global also on (gate preserved)
- Global notification not re-fired on supersede (regression)
- Autolock not re-scheduled on supersede (regression)
- Accesslimit not re-decremented on supersede (regression)
- Non-supersede flow still fires per-slot notification

Fixes #634