### PR TITLE
feat: Add ZHA lock provider support

### DIFF
--- a/custom_components/keymaster/manifest.json
+++ b/custom_components/keymaster/manifest.json
@@ -11,12 +11,10 @@
     "local_akuvox",
     "lovelace",
     "mqtt",
-    "ozw",
     "schlage",
     "script",
     "template",
     "zha",
-    "zwave",
     "zwave_js"
   ],
   "codeowners": ["@FutureTense", "@firstof9", "@raman325", "@tykeal"],

--- a/custom_components/keymaster/manifest.json
+++ b/custom_components/keymaster/manifest.json
@@ -15,6 +15,7 @@
     "schlage",
     "script",
     "template",
+    "zha",
     "zwave",
     "zwave_js"
   ],

--- a/custom_components/keymaster/providers/__init__.py
+++ b/custom_components/keymaster/providers/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from ._base import BaseLockProvider, CodeSlot, ConnectionCallback, LockEventCallback
 from .akuvox import AkuvoxLockProvider
 from .schlage import SchlageLockProvider
+from .zha import ZHALockProvider
 from .zigbee2mqtt import Zigbee2MQTTLockProvider
 from .zwave_js import ZWaveJSLockProvider
 
@@ -25,6 +26,7 @@ PROVIDER_MAP: dict[str, type[BaseLockProvider]] = {
     "local_akuvox": AkuvoxLockProvider,
     "mqtt": Zigbee2MQTTLockProvider,
     "schlage": SchlageLockProvider,
+    "zha": ZHALockProvider,
     "zwave_js": ZWaveJSLockProvider,
 }
 

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -34,6 +34,7 @@ class ZHALockProvider(BaseLockProvider):
     _door_lock_cluster: DoorLock | None = field(default=None, init=False, repr=False)
     _endpoint_id: int | None = field(default=None, init=False, repr=False)
     _usercodes_cache: dict[int, CodeSlot] = field(default_factory=dict, init=False, repr=False)
+    _event_unsub: Callable[[], None] | None = field(default=None, init=False, repr=False)
 
     @property
     def domain(self) -> str:
@@ -405,6 +406,8 @@ class ZHALockProvider(BaseLockProvider):
         self, kmlock: KeymasterLock, callback: LockEventCallback
     ) -> Callable[[], None]:
         """Subscribe to ZHA lock events."""
+        if self._event_unsub is not None:
+            return self._event_unsub
 
         @ha_callback
         def handle_zha_event(event: Event) -> None:
@@ -509,7 +512,15 @@ class ZHALockProvider(BaseLockProvider):
 
         unsub = self.hass.bus.async_listen("zha_event", handle_zha_event)
         self._listeners.append(unsub)
-        return unsub
+
+        def unsubscribe() -> None:
+            unsub()
+            if unsub in self._listeners:
+                self._listeners.remove(unsub)
+            self._event_unsub = None
+
+        self._event_unsub = unsubscribe
+        return unsubscribe
 
     def subscribe_connection_events(self, callback: ConnectionCallback) -> Callable[[], None]:
         """Notify on lock entity availability transitions."""

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -8,16 +8,16 @@ from dataclasses import dataclass, field
 import logging
 from typing import TYPE_CHECKING, Any
 
-from zigpy.zcl.clusters.closures import DoorLock
-
-from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
-
 try:
+    from zigpy.zcl.clusters.closures import DoorLock
+
     from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
     from homeassistant.components.zha.helpers import get_zha_gateway_proxy
 except ImportError:
+    DoorLock = None  # type: ignore[assignment, unused-ignore]
     ZHA_DOMAIN = "zha"
     get_zha_gateway_proxy = None
+from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Event, callback as ha_callback
 from homeassistant.helpers.event import async_track_state_change_event

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -8,6 +8,11 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN, Synced
+
+try:
+    from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
+except (ImportError, ModuleNotFoundError):
+    ZHA_DOMAIN = "zha"
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Event, callback as ha_callback
 from homeassistant.exceptions import HomeAssistantError
@@ -18,8 +23,6 @@ if TYPE_CHECKING:
     from custom_components.keymaster.lock import KeymasterLock
 
 _LOGGER = logging.getLogger(__name__)
-
-ZHA_DOMAIN = "zha"
 
 
 @dataclass

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -11,7 +11,7 @@ from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATO
 
 try:
     from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
-except (ImportError, ModuleNotFoundError):
+except ImportError:
     ZHA_DOMAIN = "zha"
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Event, callback as ha_callback

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -3,19 +3,24 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import contextlib
 from dataclasses import dataclass, field
 import logging
 from typing import TYPE_CHECKING, Any
 
-from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN, Synced
+from zigpy.zcl.clusters.closures import DoorLock
+
+from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
 
 try:
     from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
+    from homeassistant.components.zha.helpers import get_zha_gateway_proxy
 except ImportError:
     ZHA_DOMAIN = "zha"
+    get_zha_gateway_proxy = None
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Event, callback as ha_callback
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import async_track_state_change_event
 
 from ._base import BaseLockProvider, CodeSlot, ConnectionCallback, LockEventCallback
 
@@ -31,6 +36,8 @@ class ZHALockProvider(BaseLockProvider):
 
     # Platform-specific state (non-init fields)
     _device_ieee: str | None = field(default=None, init=False, repr=False)
+    _door_lock_cluster: DoorLock | None = field(default=None, init=False, repr=False)
+    _endpoint_id: int | None = field(default=None, init=False, repr=False)
     _usercodes_cache: dict[int, CodeSlot] = field(default_factory=dict, init=False, repr=False)
 
     @property
@@ -51,6 +58,8 @@ class ZHALockProvider(BaseLockProvider):
     async def async_connect(self) -> bool:
         """Connect to the ZHA lock."""
         self._connected = False
+        self._door_lock_cluster = None
+        self._endpoint_id = None
 
         # Get lock entity from registry
         lock_entry = self.entity_registry.async_get(self.lock_entity_id)
@@ -96,18 +105,13 @@ class ZHALockProvider(BaseLockProvider):
 
         self._device_ieee = device_ieee
 
-        # Pre-populate the cache from coordinator on connect to avoid pushing codes on startup
-        coordinator = self.hass.data.get(DOMAIN, {}).get(COORDINATOR)
-        if coordinator:
-            kmlock = coordinator.kmlocks.get(self.keymaster_config_entry.entry_id)
-            if kmlock and kmlock.code_slots:
-                for slot_num, kmslot in kmlock.code_slots.items():
-                    if kmslot.synced == Synced.SYNCED and kmslot.pin:
-                        self._usercodes_cache[slot_num] = CodeSlot(
-                            slot_num=slot_num,
-                            code=kmslot.pin,
-                            in_use=True,
-                        )
+        # Try to find the DoorLock cluster
+        cluster = self._get_door_lock_cluster()
+        if not cluster:
+            _LOGGER.warning(
+                "[ZHAProvider] DoorLock cluster not found on connect for lock %s",
+                self.lock_entity_id,
+            )
 
         self._connected = True
         _LOGGER.debug(
@@ -116,6 +120,71 @@ class ZHALockProvider(BaseLockProvider):
             self._device_ieee,
         )
         return True
+
+    def _get_gateway(self) -> Any | None:
+        """Return the ZHA gateway proxy, or None if unavailable."""
+        if get_zha_gateway_proxy is None:
+            return None
+        try:
+            return get_zha_gateway_proxy(self.hass)
+        except (KeyError, ValueError):
+            return None
+
+    def _get_door_lock_cluster(self) -> DoorLock | None:
+        """Return the DoorLock cluster for this device, caching the result."""
+        if self._door_lock_cluster is not None:
+            return self._door_lock_cluster
+
+        gateway = self._get_gateway()
+        if not gateway:
+            return None
+
+        try:
+            entity_ref = gateway.get_entity_reference(self.lock_entity_id)
+        except AttributeError:
+            entity_ref = None
+
+        if not entity_ref:
+            _LOGGER.debug(
+                "[ZHAProvider] Could not find entity reference for %s", self.lock_entity_id
+            )
+            return None
+
+        device_proxy = getattr(entity_ref, "device_proxy", None)
+        if not device_proxy:
+            entity_data = getattr(entity_ref, "entity_data", None)
+            if entity_data:
+                device_proxy = getattr(entity_data, "device_proxy", None)
+
+        if not device_proxy:
+            _LOGGER.debug("[ZHAProvider] Could not find device proxy for %s", self.lock_entity_id)
+            return None
+
+        device = getattr(device_proxy, "device", None)
+        if not device:
+            _LOGGER.debug(
+                "[ZHAProvider] Could not find device on device proxy for %s", self.lock_entity_id
+            )
+            return None
+
+        zigpy_device = getattr(device, "device", device)
+
+        for endpoint_id, endpoint in getattr(zigpy_device, "endpoints", {}).items():
+            if endpoint_id == 0:
+                continue
+            for cluster in getattr(endpoint, "in_clusters", {}).values():
+                if cluster.cluster_id == DoorLock.cluster_id:
+                    self._door_lock_cluster = cluster
+                    self._endpoint_id = endpoint_id
+                    _LOGGER.debug(
+                        "[ZHAProvider] Found DoorLock cluster on endpoint %s for %s",
+                        endpoint_id,
+                        self.lock_entity_id,
+                    )
+                    return cluster
+
+        _LOGGER.warning("[ZHAProvider] Could not find DoorLock cluster for %s", self.lock_entity_id)
+        return None
 
     async def async_is_connected(self) -> bool:
         """Check if ZHA lock is connected."""
@@ -144,22 +213,56 @@ class ZHALockProvider(BaseLockProvider):
             _LOGGER.error("[ZHAProvider] Not connected to lock")
             return []
 
+        cluster = self._get_door_lock_cluster()
+        if not cluster:
+            _LOGGER.error("[ZHAProvider] DoorLock cluster not available")
+            return []
+
         slot_start = self.keymaster_config_entry.data.get(CONF_START, 1)
         slot_count = self.keymaster_config_entry.data.get(CONF_SLOTS, 0)
 
         result: list[CodeSlot] = []
         for slot_num in range(slot_start, slot_start + slot_count):
-            if slot_num in self._usercodes_cache:
-                result.append(self._usercodes_cache[slot_num])
-            else:
-                # Return an empty slot by default
-                result.append(
-                    CodeSlot(
+            try:
+                res = await cluster.get_pin_code(slot_num)
+                _LOGGER.debug(
+                    "[ZHAProvider] Lock %s slot %s get_pin_code: %s",
+                    self.lock_entity_id,
+                    slot_num,
+                    res,
+                )
+                user_status, pin_code = self._parse_pin_response(res)
+                if user_status == DoorLock.UserStatus.Enabled and pin_code:
+                    slot = CodeSlot(
+                        slot_num=slot_num,
+                        code=pin_code,
+                        in_use=True,
+                    )
+                else:
+                    slot = CodeSlot(
                         slot_num=slot_num,
                         code=None,
                         in_use=False,
                     )
+                self._usercodes_cache[slot_num] = slot
+                result.append(slot)
+            except Exception as e:  # noqa: BLE001
+                _LOGGER.warning(
+                    "[ZHAProvider] Lock %s: failed to read slot %s: %s",
+                    self.lock_entity_id,
+                    slot_num,
+                    e,
                 )
+                if slot_num in self._usercodes_cache:
+                    result.append(self._usercodes_cache[slot_num])
+                else:
+                    result.append(
+                        CodeSlot(
+                            slot_num=slot_num,
+                            code=None,
+                            in_use=False,
+                        )
+                    )
 
         return result
 
@@ -167,36 +270,82 @@ class ZHALockProvider(BaseLockProvider):
         """Get a specific user code from cache."""
         return self._usercodes_cache.get(slot_num)
 
+    async def async_refresh_usercode(self, slot_num: int) -> CodeSlot | None:
+        """Bypass integration cache and query the device directly."""
+        if not self._connected:
+            return None
+        cluster = self._get_door_lock_cluster()
+        if not cluster:
+            return None
+        try:
+            res = await cluster.get_pin_code(slot_num)
+            user_status, pin_code = self._parse_pin_response(res)
+            if user_status == DoorLock.UserStatus.Enabled and pin_code:
+                slot = CodeSlot(
+                    slot_num=slot_num,
+                    code=pin_code,
+                    in_use=True,
+                )
+            else:
+                slot = CodeSlot(
+                    slot_num=slot_num,
+                    code=None,
+                    in_use=False,
+                )
+            self._usercodes_cache[slot_num] = slot
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning(
+                "[ZHAProvider] Lock %s: failed to refresh slot %s: %s",
+                self.lock_entity_id,
+                slot_num,
+                e,
+            )
+            return self._usercodes_cache.get(slot_num)
+        else:
+            return slot
+
     async def async_set_usercode(self, slot_num: int, code: str, name: str | None = None) -> bool:
         """Set user code on ZHA lock."""
+        cluster = self._get_door_lock_cluster()
+        if not cluster:
+            _LOGGER.error("[ZHAProvider] DoorLock cluster not available")
+            return False
+
         try:
-            await self.hass.services.async_call(
-                ZHA_DOMAIN,
-                "set_lock_user_code",
-                {
-                    "entity_id": self.lock_entity_id,
-                    "code_slot": slot_num,
-                    "user_code": code,
-                },
-                blocking=True,
+            result = await cluster.set_pin_code(
+                slot_num,
+                DoorLock.UserStatus.Enabled,
+                DoorLock.UserType.Unrestricted,
+                code,
             )
+            _LOGGER.debug(
+                "[ZHAProvider] Lock %s slot %s set_pin_code result: %s",
+                self.lock_entity_id,
+                slot_num,
+                result,
+            )
+            status = getattr(result, "status", None)
+            if status is None and isinstance(result, list | tuple) and len(result) > 0:
+                status = result[0]
+            if status is not None and status != 0:
+                _LOGGER.error(
+                    "[ZHAProvider] Lock %s slot %s set_pin_code rejected: status %s",
+                    self.lock_entity_id,
+                    slot_num,
+                    status,
+                )
+                return False
             # Update cache optimistically
             self._usercodes_cache[slot_num] = CodeSlot(
                 slot_num=slot_num,
                 code=code,
                 in_use=True,
             )
-        except HomeAssistantError as e:
-            _LOGGER.error(
-                "[ZHAProvider] Failed to set user code on slot %s: %s: %s",
-                slot_num,
-                e.__class__.__qualname__,
-                e,
-            )
-            return False
         except Exception:
             _LOGGER.exception(
-                "[ZHAProvider] Unexpected error setting user code on slot %s", slot_num
+                "[ZHAProvider] Error setting user code on lock %s slot %s",
+                self.lock_entity_id,
+                slot_num,
             )
             return False
         else:
@@ -204,37 +353,60 @@ class ZHALockProvider(BaseLockProvider):
 
     async def async_clear_usercode(self, slot_num: int) -> bool:
         """Clear user code from ZHA lock."""
+        cluster = self._get_door_lock_cluster()
+        if not cluster:
+            _LOGGER.error("[ZHAProvider] DoorLock cluster not available")
+            return False
+
         try:
-            await self.hass.services.async_call(
-                ZHA_DOMAIN,
-                "clear_lock_user_code",
-                {
-                    "entity_id": self.lock_entity_id,
-                    "code_slot": slot_num,
-                },
-                blocking=True,
+            result = await cluster.clear_pin_code(slot_num)
+            _LOGGER.debug(
+                "[ZHAProvider] Lock %s slot %s clear_pin_code result: %s",
+                self.lock_entity_id,
+                slot_num,
+                result,
             )
+            status = getattr(result, "status", None)
+            if status is None and isinstance(result, list | tuple) and len(result) > 0:
+                status = result[0]
+            if status is not None and status != 0:
+                _LOGGER.error(
+                    "[ZHAProvider] Lock %s slot %s clear_pin_code rejected: status %s",
+                    self.lock_entity_id,
+                    slot_num,
+                    status,
+                )
+                return False
             # Update cache optimistically
             self._usercodes_cache[slot_num] = CodeSlot(
                 slot_num=slot_num,
                 code=None,
                 in_use=False,
             )
-        except HomeAssistantError as e:
-            _LOGGER.error(
-                "[ZHAProvider] Failed to clear user code on slot %s: %s: %s",
-                slot_num,
-                e.__class__.__qualname__,
-                e,
-            )
-            return False
         except Exception:
             _LOGGER.exception(
-                "[ZHAProvider] Unexpected error clearing user code on slot %s", slot_num
+                "[ZHAProvider] Error clearing user code on lock %s slot %s",
+                self.lock_entity_id,
+                slot_num,
             )
             return False
         else:
             return True
+
+    @staticmethod
+    def _parse_pin_response(result: Any) -> tuple[int, str]:
+        """Extract (user_status, pin_code) from a get_pin_code response."""
+        if hasattr(result, "user_status"):
+            pin = getattr(result, "code", "") or ""
+            if isinstance(pin, bytes):
+                pin = pin.decode("utf-8", errors="ignore")
+            return result.user_status, str(pin)
+        if isinstance(result, list | tuple) and len(result) >= 4:
+            pin = result[3]
+            if isinstance(pin, bytes):
+                pin = pin.decode("utf-8", errors="ignore")
+            return result[1], str(pin) if pin else ""
+        return DoorLock.UserStatus.Available, ""
 
     def subscribe_lock_events(
         self, kmlock: KeymasterLock, callback: LockEventCallback
@@ -249,6 +421,15 @@ class ZHALockProvider(BaseLockProvider):
                 return
 
             command = event.data.get("command")
+            if command == "programming_event_notification":
+                coordinator = self.hass.data.get(DOMAIN, {}).get(COORDINATOR)
+                if coordinator:
+                    self.hass.async_create_task(
+                        coordinator.async_refresh(),
+                        f"Refresh {self.lock_entity_id} after ZHA programming event",
+                    )
+                return
+
             if command != "operation_event_notification":
                 return
 
@@ -258,41 +439,67 @@ class ZHALockProvider(BaseLockProvider):
             source = None
 
             if isinstance(args, dict):
-                code_slot = args.get("code_slot")
-                operation = args.get("operation")
-                source = args.get("source")
+                # Real zha_event uses ZCL field names, not display labels.
+                code_slot = args.get("user_id")
+                operation = args.get("operation_event_code")
+                source = args.get("operation_event_source")
             elif isinstance(args, list | tuple):
                 if len(args) >= 3:
                     operation = args[0]
                     source = args[1]
                     code_slot = args[2]
 
-            if code_slot is None:
+            # user_id == 0 is a master/system event, not a slot operation
+            if code_slot is None or code_slot == 0:
                 return
 
-            # Normalize values for checking
-            op_lower = str(operation).lower() if operation else ""
-            src_lower = str(source).lower() if source else ""
+            # Parse ZCL enums for robust classification
+            op_val = None
+            src_val = None
+            if operation is not None:
+                try:
+                    op_val = DoorLock.OperationEvent(int(operation))
+                except (TypeError, ValueError):
+                    with contextlib.suppress(KeyError):
+                        op_val = DoorLock.OperationEvent[str(operation)]
 
-            # Standard Keymaster action codes:
-            # - Keypad unlock: action_code = 1, event_label = "Unlocked via Keypad"
-            # - Keypad lock: action_code = 5, event_label = "Keypad Lock"
-            # - Other unlock (RF): action_code = None, event_label = "Unlocked via RF"
-            # - Other lock (RF): action_code = None, event_label = "Locked via RF"
-            if "keypad" in src_lower:
-                if "unlock" in op_lower:
+            if source is not None:
+                try:
+                    src_val = DoorLock.OperationEventSource(int(source))
+                except (TypeError, ValueError):
+                    with contextlib.suppress(KeyError):
+                        src_val = DoorLock.OperationEventSource[str(source)]
+
+            is_keypad = src_val == DoorLock.OperationEventSource.Keypad
+            is_unlock = op_val in {
+                DoorLock.OperationEvent.Unlock,
+                DoorLock.OperationEvent.KeyUnlock,
+                DoorLock.OperationEvent.Manual_Unlock,
+                DoorLock.OperationEvent.ScheduleUnlock,
+            }
+            is_lock = op_val in {
+                DoorLock.OperationEvent.Lock,
+                DoorLock.OperationEvent.KeyLock,
+                DoorLock.OperationEvent.Manual_Lock,
+                DoorLock.OperationEvent.ScheduleLock,
+                DoorLock.OperationEvent.AutoLock,
+                DoorLock.OperationEvent.OnTouchLock,
+            }
+
+            if is_keypad:
+                if is_unlock:
                     event_label = "Unlocked via Keypad"
                     action_code = 1
-                elif "lock" in op_lower:
+                elif is_lock:
                     event_label = "Keypad Lock"
                     action_code = 5
                 else:
                     event_label = f"Keypad {operation}"
                     action_code = None
-            elif "unlock" in op_lower:
+            elif is_unlock:
                 event_label = "Unlocked via RF"
                 action_code = None
-            elif "lock" in op_lower:
+            elif is_lock:
                 event_label = "Locked via RF"
                 action_code = None
             else:
@@ -306,8 +513,20 @@ class ZHALockProvider(BaseLockProvider):
         return unsub
 
     def subscribe_connection_events(self, callback: ConnectionCallback) -> Callable[[], None]:
-        """Subscribe to availability events."""
-        return lambda: None
+        """Notify on lock entity availability transitions."""
+
+        @ha_callback
+        def _state_changed(event: Event) -> None:
+            new_state = event.data.get("new_state")
+            connected = bool(
+                new_state and new_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+            )
+            self._connected = connected
+            callback(connected)
+
+        unsub = async_track_state_change_event(self.hass, [self.lock_entity_id], _state_changed)
+        self._listeners.append(unsub)
+        return unsub
 
     def get_platform_data(self) -> dict[str, Any]:
         """Get ZHA-specific diagnostic data."""

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -14,12 +14,12 @@ try:
     from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
     from homeassistant.components.zha.helpers import get_zha_gateway_proxy
 except ImportError:
-    DoorLock = None  # type: ignore[assignment, unused-ignore]
+    DoorLock = None  # type: ignore[assignment, unused-ignore, misc]
     ZHA_DOMAIN = "zha"
     get_zha_gateway_proxy = None
 from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
-from homeassistant.core import Event, callback as ha_callback
+from homeassistant.core import Event, EventStateChangedData, callback as ha_callback
 from homeassistant.helpers.event import async_track_state_change_event
 
 from ._base import BaseLockProvider, CodeSlot, ConnectionCallback, LockEventCallback
@@ -65,14 +65,14 @@ class ZHALockProvider(BaseLockProvider):
         lock_entry = self.entity_registry.async_get(self.lock_entity_id)
         if not lock_entry:
             _LOGGER.error(
-                "[ZHAProvider] Can't find lock in entity registry: %s",
+                "Can't find lock in entity registry: %s",
                 self.lock_entity_id,
             )
             return False
 
         if lock_entry.platform != ZHA_DOMAIN:
             _LOGGER.error(
-                "[ZHAProvider] Lock platform is not zha: %s (%s)",
+                "Lock platform is not zha: %s (%s)",
                 self.lock_entity_id,
                 lock_entry.platform,
             )
@@ -84,7 +84,7 @@ class ZHALockProvider(BaseLockProvider):
         device_entry = self.get_device_entry()
         if not device_entry:
             _LOGGER.error(
-                "[ZHAProvider] Can't find lock device in Device Registry: %s",
+                "Can't find lock device in Device Registry: %s",
                 self.lock_entity_id,
             )
             return False
@@ -98,7 +98,7 @@ class ZHALockProvider(BaseLockProvider):
 
         if not device_ieee:
             _LOGGER.error(
-                "[ZHAProvider] Lock device has no ZHA IEEE identifier: %s",
+                "Lock device has no ZHA IEEE identifier: %s",
                 self.lock_entity_id,
             )
             return False
@@ -109,13 +109,13 @@ class ZHALockProvider(BaseLockProvider):
         cluster = self._get_door_lock_cluster()
         if not cluster:
             _LOGGER.warning(
-                "[ZHAProvider] DoorLock cluster not found on connect for lock %s",
+                "DoorLock cluster not found on connect for lock %s",
                 self.lock_entity_id,
             )
 
         self._connected = True
         _LOGGER.debug(
-            "[ZHAProvider] Connected to lock %s (device_ieee: %s)",
+            "Connected to lock %s (device_ieee: %s)",
             self.lock_entity_id,
             self._device_ieee,
         )
@@ -147,9 +147,7 @@ class ZHALockProvider(BaseLockProvider):
             entity_ref = None
 
         if not entity_ref:
-            _LOGGER.debug(
-                "[ZHAProvider] Could not find entity reference for %s", self.lock_entity_id
-            )
+            _LOGGER.debug("Could not find entity reference for %s", self.lock_entity_id)
             return None
 
         device_proxy = getattr(entity_ref, "device_proxy", None)
@@ -159,14 +157,12 @@ class ZHALockProvider(BaseLockProvider):
                 device_proxy = getattr(entity_data, "device_proxy", None)
 
         if not device_proxy:
-            _LOGGER.debug("[ZHAProvider] Could not find device proxy for %s", self.lock_entity_id)
+            _LOGGER.debug("Could not find device proxy for %s", self.lock_entity_id)
             return None
 
         device = getattr(device_proxy, "device", None)
         if not device:
-            _LOGGER.debug(
-                "[ZHAProvider] Could not find device on device proxy for %s", self.lock_entity_id
-            )
+            _LOGGER.debug("Could not find device on device proxy for %s", self.lock_entity_id)
             return None
 
         zigpy_device = getattr(device, "device", device)
@@ -179,13 +175,13 @@ class ZHALockProvider(BaseLockProvider):
                     self._door_lock_cluster = cluster
                     self._endpoint_id = endpoint_id
                     _LOGGER.debug(
-                        "[ZHAProvider] Found DoorLock cluster on endpoint %s for %s",
+                        "Found DoorLock cluster on endpoint %s for %s",
                         endpoint_id,
                         self.lock_entity_id,
                     )
                     return cluster
 
-        _LOGGER.warning("[ZHAProvider] Could not find DoorLock cluster for %s", self.lock_entity_id)
+        _LOGGER.warning("Could not find DoorLock cluster for %s", self.lock_entity_id)
         return None
 
     async def async_is_connected(self) -> bool:
@@ -212,12 +208,12 @@ class ZHALockProvider(BaseLockProvider):
     async def async_get_usercodes(self) -> list[CodeSlot]:
         """Get all user codes from ZHA lock."""
         if not self._connected:
-            _LOGGER.error("[ZHAProvider] Not connected to lock")
+            _LOGGER.error("Not connected to lock")
             return []
 
         cluster = self._get_door_lock_cluster()
         if not cluster:
-            _LOGGER.error("[ZHAProvider] DoorLock cluster not available")
+            _LOGGER.error("DoorLock cluster not available")
             return []
 
         slot_start = self.keymaster_config_entry.data.get(CONF_START, 1)
@@ -228,7 +224,7 @@ class ZHALockProvider(BaseLockProvider):
             try:
                 res = await cluster.get_pin_code(slot_num)
                 _LOGGER.debug(
-                    "[ZHAProvider] Lock %s slot %s get_pin_code: %s",
+                    "Lock %s slot %s get_pin_code: %s",
                     self.lock_entity_id,
                     slot_num,
                     res,
@@ -250,7 +246,7 @@ class ZHALockProvider(BaseLockProvider):
                 result.append(slot)
             except Exception as e:  # noqa: BLE001
                 _LOGGER.warning(
-                    "[ZHAProvider] Lock %s: failed to read slot %s: %s",
+                    "Lock %s: failed to read slot %s: %s",
                     self.lock_entity_id,
                     slot_num,
                     e,
@@ -297,7 +293,7 @@ class ZHALockProvider(BaseLockProvider):
             self._usercodes_cache[slot_num] = slot
         except Exception as e:  # noqa: BLE001
             _LOGGER.warning(
-                "[ZHAProvider] Lock %s: failed to refresh slot %s: %s",
+                "Lock %s: failed to refresh slot %s: %s",
                 self.lock_entity_id,
                 slot_num,
                 e,
@@ -310,7 +306,7 @@ class ZHALockProvider(BaseLockProvider):
         """Set user code on ZHA lock."""
         cluster = self._get_door_lock_cluster()
         if not cluster:
-            _LOGGER.error("[ZHAProvider] DoorLock cluster not available")
+            _LOGGER.error("DoorLock cluster not available")
             return False
 
         try:
@@ -321,7 +317,7 @@ class ZHALockProvider(BaseLockProvider):
                 code,
             )
             _LOGGER.debug(
-                "[ZHAProvider] Lock %s slot %s set_pin_code result: %s",
+                "Lock %s slot %s set_pin_code result: %s",
                 self.lock_entity_id,
                 slot_num,
                 result,
@@ -331,7 +327,7 @@ class ZHALockProvider(BaseLockProvider):
                 status = result[0]
             if status is not None and status != 0:
                 _LOGGER.error(
-                    "[ZHAProvider] Lock %s slot %s set_pin_code rejected: status %s",
+                    "Lock %s slot %s set_pin_code rejected: status %s",
                     self.lock_entity_id,
                     slot_num,
                     status,
@@ -345,7 +341,7 @@ class ZHALockProvider(BaseLockProvider):
             )
         except Exception:
             _LOGGER.exception(
-                "[ZHAProvider] Error setting user code on lock %s slot %s",
+                "Error setting user code on lock %s slot %s",
                 self.lock_entity_id,
                 slot_num,
             )
@@ -357,13 +353,13 @@ class ZHALockProvider(BaseLockProvider):
         """Clear user code from ZHA lock."""
         cluster = self._get_door_lock_cluster()
         if not cluster:
-            _LOGGER.error("[ZHAProvider] DoorLock cluster not available")
+            _LOGGER.error("DoorLock cluster not available")
             return False
 
         try:
             result = await cluster.clear_pin_code(slot_num)
             _LOGGER.debug(
-                "[ZHAProvider] Lock %s slot %s clear_pin_code result: %s",
+                "Lock %s slot %s clear_pin_code result: %s",
                 self.lock_entity_id,
                 slot_num,
                 result,
@@ -373,7 +369,7 @@ class ZHALockProvider(BaseLockProvider):
                 status = result[0]
             if status is not None and status != 0:
                 _LOGGER.error(
-                    "[ZHAProvider] Lock %s slot %s clear_pin_code rejected: status %s",
+                    "Lock %s slot %s clear_pin_code rejected: status %s",
                     self.lock_entity_id,
                     slot_num,
                     status,
@@ -387,7 +383,7 @@ class ZHALockProvider(BaseLockProvider):
             )
         except Exception:
             _LOGGER.exception(
-                "[ZHAProvider] Error clearing user code on lock %s slot %s",
+                "Error clearing user code on lock %s slot %s",
                 self.lock_entity_id,
                 slot_num,
             )
@@ -524,7 +520,7 @@ class ZHALockProvider(BaseLockProvider):
         """Notify on lock entity availability transitions."""
 
         @ha_callback
-        def _state_changed(event: Event) -> None:
+        def _state_changed(event: Event[EventStateChangedData]) -> None:
             new_state = event.data.get("new_state")
             connected = bool(
                 new_state and new_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -8,16 +8,11 @@ from dataclasses import dataclass, field
 import logging
 from typing import TYPE_CHECKING, Any
 
-try:
-    from zigpy.zcl.clusters.closures import DoorLock
+from zigpy.zcl.clusters.closures import DoorLock
 
-    from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
-    from homeassistant.components.zha.helpers import get_zha_gateway_proxy
-except ImportError:
-    DoorLock = None  # type: ignore[assignment, unused-ignore, misc]
-    ZHA_DOMAIN = "zha"
-    get_zha_gateway_proxy = None
 from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
+from homeassistant.components.zha.const import DOMAIN as ZHA_DOMAIN
+from homeassistant.components.zha.helpers import get_zha_gateway_proxy
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Event, EventStateChangedData, callback as ha_callback
 from homeassistant.helpers.event import async_track_state_change_event

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -127,7 +127,9 @@ class ZHALockProvider(BaseLockProvider):
             return None
         try:
             return get_zha_gateway_proxy(self.hass)
-        except (KeyError, ValueError):
+        except KeyError:
+            return None
+        except ValueError:
             return None
 
     def _get_door_lock_cluster(self) -> DoorLock | None:
@@ -459,14 +461,20 @@ class ZHALockProvider(BaseLockProvider):
             if operation is not None:
                 try:
                     op_val = DoorLock.OperationEvent(int(operation))
-                except (TypeError, ValueError):
+                except TypeError:
+                    with contextlib.suppress(KeyError):
+                        op_val = DoorLock.OperationEvent[str(operation)]
+                except ValueError:
                     with contextlib.suppress(KeyError):
                         op_val = DoorLock.OperationEvent[str(operation)]
 
             if source is not None:
                 try:
                     src_val = DoorLock.OperationEventSource(int(source))
-                except (TypeError, ValueError):
+                except TypeError:
+                    with contextlib.suppress(KeyError):
+                        src_val = DoorLock.OperationEventSource[str(source)]
+                except ValueError:
                     with contextlib.suppress(KeyError):
                         src_val = DoorLock.OperationEventSource[str(source)]
 

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -1,0 +1,318 @@
+"""ZHA lock provider for keymaster."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+import logging
+from typing import TYPE_CHECKING, Any
+
+from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN, Synced
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import Event, callback as ha_callback
+from homeassistant.exceptions import HomeAssistantError
+
+from ._base import BaseLockProvider, CodeSlot, ConnectionCallback, LockEventCallback
+
+if TYPE_CHECKING:
+    from custom_components.keymaster.lock import KeymasterLock
+
+_LOGGER = logging.getLogger(__name__)
+
+ZHA_DOMAIN = "zha"
+
+
+@dataclass
+class ZHALockProvider(BaseLockProvider):
+    """ZHA lock provider implementation."""
+
+    # Platform-specific state (non-init fields)
+    _device_ieee: str | None = field(default=None, init=False, repr=False)
+    _usercodes_cache: dict[int, CodeSlot] = field(default_factory=dict, init=False, repr=False)
+
+    @property
+    def domain(self) -> str:
+        """Return the integration domain."""
+        return ZHA_DOMAIN
+
+    @property
+    def supports_push_updates(self) -> bool:
+        """ZHA supports real-time events."""
+        return True
+
+    @property
+    def supports_connection_status(self) -> bool:
+        """ZHA can report connection status."""
+        return True
+
+    async def async_connect(self) -> bool:
+        """Connect to the ZHA lock."""
+        self._connected = False
+
+        # Get lock entity from registry
+        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
+        if not lock_entry:
+            _LOGGER.error(
+                "[ZHAProvider] Can't find lock in entity registry: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        if lock_entry.platform != ZHA_DOMAIN:
+            _LOGGER.error(
+                "[ZHAProvider] Lock platform is not zha: %s (%s)",
+                self.lock_entity_id,
+                lock_entry.platform,
+            )
+            return False
+
+        self.lock_config_entry_id = lock_entry.config_entry_id
+
+        # Get device/cluster info for ZHA
+        device_entry = self.get_device_entry()
+        if not device_entry:
+            _LOGGER.error(
+                "[ZHAProvider] Can't find lock device in Device Registry: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        # Find the ZHA IEEE address in identifiers
+        device_ieee = None
+        for domain, identifier in device_entry.identifiers:
+            if domain == ZHA_DOMAIN:
+                device_ieee = identifier
+                break
+
+        if not device_ieee:
+            _LOGGER.error(
+                "[ZHAProvider] Lock device has no ZHA IEEE identifier: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        self._device_ieee = device_ieee
+
+        # Pre-populate the cache from coordinator on connect to avoid pushing codes on startup
+        coordinator = self.hass.data.get(DOMAIN, {}).get(COORDINATOR)
+        if coordinator:
+            kmlock = coordinator.kmlocks.get(self.keymaster_config_entry.entry_id)
+            if kmlock and kmlock.code_slots:
+                for slot_num, kmslot in kmlock.code_slots.items():
+                    if kmslot.synced == Synced.SYNCED and kmslot.pin:
+                        self._usercodes_cache[slot_num] = CodeSlot(
+                            slot_num=slot_num,
+                            code=kmslot.pin,
+                            in_use=True,
+                        )
+
+        self._connected = True
+        _LOGGER.debug(
+            "[ZHAProvider] Connected to lock %s (device_ieee: %s)",
+            self.lock_entity_id,
+            self._device_ieee,
+        )
+        return True
+
+    async def async_is_connected(self) -> bool:
+        """Check if ZHA lock is connected."""
+        if not self._device_ieee:
+            self._connected = False
+            return False
+
+        # Verify entity exists and is still registered as ZHA domain
+        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
+        if not lock_entry or lock_entry.platform != ZHA_DOMAIN:
+            self._connected = False
+            return False
+
+        # Verify lock entity state is available
+        state = self.hass.states.get(self.lock_entity_id)
+        if not state or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            self._connected = False
+            return False
+
+        self._connected = True
+        return True
+
+    async def async_get_usercodes(self) -> list[CodeSlot]:
+        """Get all user codes from ZHA lock."""
+        if not self._connected:
+            _LOGGER.error("[ZHAProvider] Not connected to lock")
+            return []
+
+        slot_start = self.keymaster_config_entry.data.get(CONF_START, 1)
+        slot_count = self.keymaster_config_entry.data.get(CONF_SLOTS, 0)
+
+        result: list[CodeSlot] = []
+        for slot_num in range(slot_start, slot_start + slot_count):
+            if slot_num in self._usercodes_cache:
+                result.append(self._usercodes_cache[slot_num])
+            else:
+                # Return an empty slot by default
+                result.append(
+                    CodeSlot(
+                        slot_num=slot_num,
+                        code=None,
+                        in_use=False,
+                    )
+                )
+
+        return result
+
+    async def async_get_usercode(self, slot_num: int) -> CodeSlot | None:
+        """Get a specific user code from cache."""
+        return self._usercodes_cache.get(slot_num)
+
+    async def async_set_usercode(self, slot_num: int, code: str, name: str | None = None) -> bool:
+        """Set user code on ZHA lock."""
+        try:
+            await self.hass.services.async_call(
+                ZHA_DOMAIN,
+                "set_lock_user_code",
+                {
+                    "entity_id": self.lock_entity_id,
+                    "code_slot": slot_num,
+                    "user_code": code,
+                },
+                blocking=True,
+            )
+            # Update cache optimistically
+            self._usercodes_cache[slot_num] = CodeSlot(
+                slot_num=slot_num,
+                code=code,
+                in_use=True,
+            )
+        except HomeAssistantError as e:
+            _LOGGER.error(
+                "[ZHAProvider] Failed to set user code on slot %s: %s: %s",
+                slot_num,
+                e.__class__.__qualname__,
+                e,
+            )
+            return False
+        except Exception:
+            _LOGGER.exception(
+                "[ZHAProvider] Unexpected error setting user code on slot %s", slot_num
+            )
+            return False
+        else:
+            return True
+
+    async def async_clear_usercode(self, slot_num: int) -> bool:
+        """Clear user code from ZHA lock."""
+        try:
+            await self.hass.services.async_call(
+                ZHA_DOMAIN,
+                "clear_lock_user_code",
+                {
+                    "entity_id": self.lock_entity_id,
+                    "code_slot": slot_num,
+                },
+                blocking=True,
+            )
+            # Update cache optimistically
+            self._usercodes_cache[slot_num] = CodeSlot(
+                slot_num=slot_num,
+                code=None,
+                in_use=False,
+            )
+        except HomeAssistantError as e:
+            _LOGGER.error(
+                "[ZHAProvider] Failed to clear user code on slot %s: %s: %s",
+                slot_num,
+                e.__class__.__qualname__,
+                e,
+            )
+            return False
+        except Exception:
+            _LOGGER.exception(
+                "[ZHAProvider] Unexpected error clearing user code on slot %s", slot_num
+            )
+            return False
+        else:
+            return True
+
+    def subscribe_lock_events(
+        self, kmlock: KeymasterLock, callback: LockEventCallback
+    ) -> Callable[[], None]:
+        """Subscribe to ZHA lock events."""
+
+        @ha_callback
+        def handle_zha_event(event: Event) -> None:
+            """Handle incoming ZHA events."""
+            device_ieee = event.data.get("device_ieee")
+            if device_ieee != self._device_ieee:
+                return
+
+            command = event.data.get("command")
+            if command != "operation_event_notification":
+                return
+
+            args = event.data.get("args", {})
+            code_slot = None
+            operation = None
+            source = None
+
+            if isinstance(args, dict):
+                code_slot = args.get("code_slot")
+                operation = args.get("operation")
+                source = args.get("source")
+            elif isinstance(args, list | tuple):
+                if len(args) >= 3:
+                    operation = args[0]
+                    source = args[1]
+                    code_slot = args[2]
+
+            if code_slot is None:
+                return
+
+            # Normalize values for checking
+            op_lower = str(operation).lower() if operation else ""
+            src_lower = str(source).lower() if source else ""
+
+            # Standard Keymaster action codes:
+            # - Keypad unlock: action_code = 1, event_label = "Unlocked via Keypad"
+            # - Keypad lock: action_code = 5, event_label = "Keypad Lock"
+            # - Other unlock (RF): action_code = None, event_label = "Unlocked via RF"
+            # - Other lock (RF): action_code = None, event_label = "Locked via RF"
+            if "keypad" in src_lower:
+                if "unlock" in op_lower:
+                    event_label = "Unlocked via Keypad"
+                    action_code = 1
+                elif "lock" in op_lower:
+                    event_label = "Keypad Lock"
+                    action_code = 5
+                else:
+                    event_label = f"Keypad {operation}"
+                    action_code = None
+            elif "unlock" in op_lower:
+                event_label = "Unlocked via RF"
+                action_code = None
+            elif "lock" in op_lower:
+                event_label = "Locked via RF"
+                action_code = None
+            else:
+                event_label = f"Lock Event: {operation} via {source}"
+                action_code = None
+
+            self.hass.async_create_task(callback(code_slot, event_label, action_code))
+
+        unsub = self.hass.bus.async_listen("zha_event", handle_zha_event)
+        self._listeners.append(unsub)
+        return unsub
+
+    def subscribe_connection_events(self, callback: ConnectionCallback) -> Callable[[], None]:
+        """Subscribe to availability events."""
+        return lambda: None
+
+    def get_platform_data(self) -> dict[str, Any]:
+        """Get ZHA-specific diagnostic data."""
+        data = super().get_platform_data()
+        data.update(
+            {
+                "device_ieee": self._device_ieee,
+                "lock_config_entry_id": self.lock_config_entry_id,
+            }
+        )
+        return data

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,4 +13,5 @@ pytest-homeassistant-custom-component
 pyudev
 serialx
 zeroconf
+zigpy
 zwave-js-server-python

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,17 @@
+# ruff: noqa: E402
 """Fixtures for keymaster tests."""
+
+import sys
+from unittest.mock import MagicMock
+
+# Mock ZHA components before custom_components.keymaster is imported
+mock_zha_helpers = MagicMock()
+mock_zha_const = MagicMock()
+mock_zha_const.DOMAIN = "zha"
+
+sys.modules["homeassistant.components.zha"] = MagicMock()
+sys.modules["homeassistant.components.zha.helpers"] = mock_zha_helpers
+sys.modules["homeassistant.components.zha.const"] = mock_zha_const
 
 import asyncio
 import copy

--- a/tests/providers/test_zha.py
+++ b/tests/providers/test_zha.py
@@ -635,7 +635,14 @@ class TestLockEvents:
         mock_hass.async_create_task.assert_called_once()
         mock_coordinator.async_refresh.assert_called_once()
 
+        # 10. Test idempotency (subscribing twice returns the same unsub and doesn't double-listen)
+        mock_hass.bus.async_listen.reset_mock()
+        unsub_dup = provider.subscribe_lock_events(mock_kmlock, mock_callback)
+        assert unsub_dup is unsub
+        mock_hass.bus.async_listen.assert_not_called()
+
         unsub()
+        assert provider._event_unsub is None
 
     def test_get_platform_data(self, provider):
         """Test get_platform_data returns ZHA specific data."""

--- a/tests/providers/test_zha.py
+++ b/tests/providers/test_zha.py
@@ -1,0 +1,580 @@
+"""Tests for the ZHA lock provider."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN, Synced
+from custom_components.keymaster.providers._base import CodeSlot
+from custom_components.keymaster.providers.zha import ZHALockProvider
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    hass.data = {}
+    hass.states = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.bus = MagicMock()
+    hass.bus.async_listen = MagicMock()
+
+    def async_create_task(coro):
+        return asyncio.create_task(coro)
+
+    hass.async_create_task = MagicMock(side_effect=async_create_task)
+    return hass
+
+
+@pytest.fixture
+def mock_entity_registry():
+    """Create a mock entity registry."""
+    reg = MagicMock(spec=er.EntityRegistry)
+    reg.async_get.return_value = None
+    return reg
+
+
+@pytest.fixture
+def mock_device_registry():
+    """Create a mock device registry."""
+    reg = MagicMock(spec=dr.DeviceRegistry)
+    reg.async_get.return_value = None
+    return reg
+
+
+@pytest.fixture
+def mock_config_entry():
+    """Create a mock keymaster config entry."""
+    entry = MagicMock()
+    entry.entry_id = "keymaster_test_entry"
+    entry.data = {CONF_START: 1, CONF_SLOTS: 3}
+    return entry
+
+
+@pytest.fixture
+def provider(mock_hass, mock_entity_registry, mock_device_registry, mock_config_entry):
+    """Create a ZHALockProvider instance."""
+    return ZHALockProvider(
+        hass=mock_hass,
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry=mock_config_entry,
+        device_registry=mock_device_registry,
+        entity_registry=mock_entity_registry,
+    )
+
+
+def setup_successful_connect(provider, identifiers=None):
+    """Set up registry mocks for a successful connection."""
+    if identifiers is None:
+        identifiers = {("zha", "00:0d:6f:00:0b:90:57:f6")}
+
+    lock_entry = MagicMock()
+    lock_entry.config_entry_id = "zha_config_entry_id"
+    lock_entry.platform = "zha"
+    lock_entry.device_id = "test_lock_device_id"
+    provider.entity_registry.async_get.return_value = lock_entry
+
+    device_entry = MagicMock()
+    device_entry.identifiers = identifiers
+    provider.device_registry.async_get.return_value = device_entry
+
+
+class TestProperties:
+    """Test ZHALockProvider properties."""
+
+    def test_domain(self, provider):
+        """Test domain property."""
+        assert provider.domain == "zha"
+
+    def test_supports_push_updates(self, provider):
+        """Test supports_push_updates property."""
+        assert provider.supports_push_updates is True
+
+    def test_supports_connection_status(self, provider):
+        """Test supports_connection_status property."""
+        assert provider.supports_connection_status is True
+
+
+class TestConnect:
+    """Test ZHALockProvider async_connect."""
+
+    async def test_connect_success(self, provider):
+        """Test successful connection and IEEE lookup."""
+        setup_successful_connect(provider)
+        result = await provider.async_connect()
+        assert result is True
+        assert provider.connected is True
+        assert provider._device_ieee == "00:0d:6f:00:0b:90:57:f6"
+
+    async def test_connect_success_with_cache_populate(self, provider, mock_hass):
+        """Test that we pre-populate the cache from coordinator on connect."""
+        setup_successful_connect(provider)
+
+        # Setup mock coordinator
+        mock_kmlock = MagicMock()
+        mock_slot1 = MagicMock()
+        mock_slot1.synced = Synced.SYNCED
+        mock_slot1.pin = "1234"
+        mock_slot2 = MagicMock()
+        mock_slot2.synced = Synced.OUT_OF_SYNC
+        mock_slot2.pin = "5678"
+
+        mock_kmlock.code_slots = {1: mock_slot1, 2: mock_slot2}
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.kmlocks = {"keymaster_test_entry": mock_kmlock}
+
+        mock_hass.data = {DOMAIN: {COORDINATOR: mock_coordinator}}
+
+        result = await provider.async_connect()
+        assert result is True
+
+        # Slot 1 should be cached (synced and has pin)
+        assert provider._usercodes_cache[1] == CodeSlot(slot_num=1, code="1234", in_use=True)
+        # Slot 2 should not be cached (not synced)
+        assert 2 not in provider._usercodes_cache
+
+    async def test_connect_entity_not_found(self, provider):
+        """Test connection fails when lock entity is not found."""
+        provider.entity_registry.async_get.return_value = None
+        result = await provider.async_connect()
+        assert result is False
+        assert provider.connected is False
+
+    async def test_connect_platform_not_zha(self, provider):
+        """Test connection fails when lock entity platform is not zha."""
+        lock_entry = MagicMock()
+        lock_entry.platform = "zwave_js"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        result = await provider.async_connect()
+        assert result is False
+        assert provider.connected is False
+
+    async def test_connect_device_not_found(self, provider):
+        """Test connection fails when lock device is not found."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "zha_config_entry"
+        lock_entry.platform = "zha"
+        lock_entry.device_id = "missing_device"
+        provider.entity_registry.async_get.return_value = lock_entry
+        provider.device_registry.async_get.return_value = None
+
+        result = await provider.async_connect()
+        assert result is False
+        assert provider.connected is False
+
+    async def test_connect_no_zha_identifier(self, provider):
+        """Test connection fails when lock device has no ZHA IEEE identifier."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "zha_config_entry"
+        lock_entry.platform = "zha"
+        lock_entry.device_id = "test_device"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {("other_domain", "other_id")}
+        provider.device_registry.async_get.return_value = device_entry
+
+        result = await provider.async_connect()
+        assert result is False
+        assert provider.connected is False
+
+
+class TestIsConnected:
+    """Test ZHALockProvider async_is_connected."""
+
+    async def test_is_connected_not_connected_initially(self, provider):
+        """Test it returns False before connection."""
+        assert await provider.async_is_connected() is False
+
+    async def test_is_connected_success(self, provider, mock_hass):
+        """Test it returns True when connected and lock entity is available."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        mock_state = MagicMock()
+        mock_state.state = "locked"
+        mock_hass.states.get.return_value = mock_state
+
+        assert await provider.async_is_connected() is True
+
+    async def test_is_connected_state_unavailable(self, provider, mock_hass):
+        """Test it returns False when state is unavailable."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        mock_state = MagicMock()
+        mock_state.state = STATE_UNAVAILABLE
+        mock_hass.states.get.return_value = mock_state
+
+        assert await provider.async_is_connected() is False
+
+    async def test_is_connected_state_unknown(self, provider, mock_hass):
+        """Test it returns False when state is unknown."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        mock_state = MagicMock()
+        mock_state.state = STATE_UNKNOWN
+        mock_hass.states.get.return_value = mock_state
+
+        assert await provider.async_is_connected() is False
+
+    async def test_is_connected_state_none(self, provider, mock_hass):
+        """Test it returns False when state is None."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+        mock_hass.states.get.return_value = None
+
+        assert await provider.async_is_connected() is False
+
+    async def test_is_connected_registry_missing(self, provider, mock_hass):
+        """Test it returns False if entity is removed from registry."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+        provider.entity_registry.async_get.return_value = None
+
+        assert await provider.async_is_connected() is False
+
+    async def test_is_connected_platform_changed(self, provider, mock_hass):
+        """Test it returns False if entity platform changes."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        lock_entry = MagicMock()
+        lock_entry.platform = "other"
+        provider.entity_registry.async_get.return_value = lock_entry
+
+        assert await provider.async_is_connected() is False
+
+
+class TestUsercodeOperations:
+    """Test user code operations in ZHALockProvider."""
+
+    async def test_get_usercodes_not_connected(self, provider):
+        """Test get_usercodes returns empty list when not connected."""
+        result = await provider.async_get_usercodes()
+        assert result == []
+
+    async def test_get_usercodes_success(self, provider):
+        """Test get_usercodes returns cached slots and default slots."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        # Cache slot 2
+        provider._usercodes_cache[2] = CodeSlot(slot_num=2, code="5678", in_use=True)
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 3
+        # Slot 1 defaults to empty
+        assert result[0] == CodeSlot(slot_num=1, code=None, in_use=False)
+        # Slot 2 comes from cache
+        assert result[1] == CodeSlot(slot_num=2, code="5678", in_use=True)
+        # Slot 3 defaults to empty
+        assert result[2] == CodeSlot(slot_num=3, code=None, in_use=False)
+
+    async def test_get_usercode_cached(self, provider):
+        """Test get_usercode retrieves from cache."""
+        provider._usercodes_cache[1] = CodeSlot(slot_num=1, code="1234", in_use=True)
+        assert await provider.async_get_usercode(1) == CodeSlot(
+            slot_num=1, code="1234", in_use=True
+        )
+        assert await provider.async_get_usercode(2) is None
+
+    async def test_set_usercode_success(self, provider, mock_hass):
+        """Test set_usercode calls service and updates cache."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        mock_call = AsyncMock()
+        mock_hass.services.async_call = mock_call
+
+        result = await provider.async_set_usercode(2, "4321", "User 2")
+        assert result is True
+        mock_call.assert_called_once_with(
+            "zha",
+            "set_lock_user_code",
+            {
+                "entity_id": "lock.test_lock",
+                "code_slot": 2,
+                "user_code": "4321",
+            },
+            blocking=True,
+        )
+        assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code="4321", in_use=True)
+
+    async def test_set_usercode_haerror(self, provider, mock_hass):
+        """Test that set_usercode handles HomeAssistantError."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        mock_hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("Service failed"))
+
+        result = await provider.async_set_usercode(2, "4321")
+        assert result is False
+        assert 2 not in provider._usercodes_cache
+
+    async def test_set_usercode_generic_error(self, provider, mock_hass):
+        """Test that set_usercode handles unexpected exceptions."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        mock_hass.services.async_call = AsyncMock(side_effect=Exception("Crash"))
+
+        result = await provider.async_set_usercode(2, "4321")
+        assert result is False
+        assert 2 not in provider._usercodes_cache
+
+    async def test_clear_usercode_success(self, provider, mock_hass):
+        """Test clear_usercode calls service and updates cache."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        # Cache slot 2 initially
+        provider._usercodes_cache[2] = CodeSlot(slot_num=2, code="4321", in_use=True)
+
+        mock_call = AsyncMock()
+        mock_hass.services.async_call = mock_call
+
+        result = await provider.async_clear_usercode(2)
+        assert result is True
+        mock_call.assert_called_once_with(
+            "zha",
+            "clear_lock_user_code",
+            {
+                "entity_id": "lock.test_lock",
+                "code_slot": 2,
+            },
+            blocking=True,
+        )
+        assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code=None, in_use=False)
+
+    async def test_clear_usercode_haerror(self, provider, mock_hass):
+        """Test that clear_usercode handles HomeAssistantError."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        mock_hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("Service failed"))
+
+        result = await provider.async_clear_usercode(2)
+        assert result is False
+
+    async def test_clear_usercode_generic_error(self, provider, mock_hass):
+        """Test that clear_usercode handles unexpected exceptions."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        mock_hass.services.async_call = AsyncMock(side_effect=Exception("Crash"))
+
+        result = await provider.async_clear_usercode(2)
+        assert result is False
+
+
+class TestLockEvents:
+    """Test lock event subscription and parsing."""
+
+    async def test_subscribe_lock_events(self, provider, mock_hass):
+        """Test event subscription registers listener and parses event args."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        captured_callback = None
+
+        def mock_listen(event_type, callback_fn):
+            nonlocal captured_callback
+            captured_callback = callback_fn
+            return lambda: None
+
+        mock_hass.bus.async_listen = MagicMock(side_effect=mock_listen)
+
+        mock_callback = AsyncMock()
+        mock_kmlock = MagicMock()
+
+        unsub = provider.subscribe_lock_events(mock_kmlock, mock_callback)
+        assert captured_callback is not None
+
+        # Helper to invoke and wait
+        async def trigger_event(data):
+            event = Event("zha_event", data)
+            captured_callback(event)
+            await asyncio.sleep(0.01)
+
+        # 1. Unlocked via keypad (dict args)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "source": "Keypad",
+                    "operation": "Unlock",
+                    "code_slot": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Unlocked via Keypad", 1)
+        mock_callback.reset_mock()
+
+        # 2. Keypad Lock (dict args)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "source": "Keypad",
+                    "operation": "Lock",
+                    "code_slot": 3,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(3, "Keypad Lock", 5)
+        mock_callback.reset_mock()
+
+        # 3. Unlocked via keypad (list args)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": ["Unlock", "Keypad", 4],
+            }
+        )
+        mock_callback.assert_called_once_with(4, "Unlocked via Keypad", 1)
+        mock_callback.reset_mock()
+
+        # 4. Other operation (dict args)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "source": "RFID",
+                    "operation": "Unlock",
+                    "code_slot": 1,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(1, "Unlocked via RF", None)
+        mock_callback.reset_mock()
+
+        # 5. Non-matching ieee
+        await trigger_event(
+            {
+                "device_ieee": "other_ieee",
+                "command": "operation_event_notification",
+                "args": {
+                    "source": "Keypad",
+                    "operation": "Unlock",
+                    "code_slot": 2,
+                },
+            }
+        )
+        mock_callback.assert_not_called()
+
+        # 6. Non-matching command
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "other_command",
+                "args": {
+                    "source": "Keypad",
+                    "operation": "Unlock",
+                    "code_slot": 2,
+                },
+            }
+        )
+        mock_callback.assert_not_called()
+
+        # 7. Missing code_slot
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "source": "Keypad",
+                    "operation": "Unlock",
+                },
+            }
+        )
+        mock_callback.assert_not_called()
+
+        # 8. Invalid args format (neither dict nor list/tuple)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": "invalid",
+            }
+        )
+        mock_callback.assert_not_called()
+
+        # 9. Keypad other operation
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "source": "Keypad",
+                    "operation": "Other",
+                    "code_slot": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Keypad Other", None)
+        mock_callback.reset_mock()
+
+        # 10. Non-keypad lock
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "source": "RF",
+                    "operation": "Lock",
+                    "code_slot": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Locked via RF", None)
+        mock_callback.reset_mock()
+
+        # 11. Lock Event (other operation/source combination)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "source": "Manual",
+                    "operation": "Toggle",
+                    "code_slot": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Lock Event: Toggle via Manual", None)
+        mock_callback.reset_mock()
+
+        unsub()
+
+    def test_subscribe_connection_events(self, provider):
+        """Test subscribe_connection_events returns unsubscribe function."""
+        callback = MagicMock()
+        unsub = provider.subscribe_connection_events(callback)
+        assert callable(unsub)
+        unsub()
+
+    def test_get_platform_data(self, provider):
+        """Test get_platform_data returns ZHA specific data."""
+        provider._device_ieee = "00:0d:6f:00:0b:90:57:f6"
+        provider.lock_config_entry_id = "test_entry_id"
+        data = provider.get_platform_data()
+        assert data["domain"] == "zha"
+        assert data["device_ieee"] == "00:0d:6f:00:0b:90:57:f6"
+        assert data["lock_config_entry_id"] == "test_entry_id"

--- a/tests/providers/test_zha.py
+++ b/tests/providers/test_zha.py
@@ -867,6 +867,27 @@ class TestZHAAdditionalCoverage:
         mock_zha_gateway["cluster"].clear_pin_code.return_value = (1,)
         assert await provider.async_clear_usercode(2) is False
 
+    async def test_reconnect_clears_and_rediscovers_cluster(self, provider, mock_zha_gateway):
+        """Test that reconnect clears the cached cluster and discovers the new one."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        # Resolve cluster and check it is cached
+        cluster1 = provider._get_door_lock_cluster()
+        assert cluster1 is not None
+        assert provider._door_lock_cluster is cluster1
+
+        # Now mock a different cluster on the gateway
+        new_cluster = MagicMock()
+        new_cluster.cluster_id = 257  # Closures.DoorLock.cluster_id
+        mock_zha_gateway["zigpy_device"].endpoints[1].in_clusters[257] = new_cluster
+
+        # Call async_connect() again (reconnect)
+        await provider.async_connect()
+
+        # The cached cluster should now be updated to the new one
+        assert provider._door_lock_cluster is new_cluster
+
     def test_parse_pin_response_fallback(self):
         """Test _parse_pin_response fallback when response is invalid format."""
         status, pin = ZHALockProvider._parse_pin_response("invalid_response_format")

--- a/tests/providers/test_zha.py
+++ b/tests/providers/test_zha.py
@@ -335,6 +335,27 @@ class TestUsercodeOperations:
         assert result[1] == CodeSlot(slot_num=2, code="5678", in_use=True)
         assert result[2] == CodeSlot(slot_num=3, code=None, in_use=False)
 
+    async def test_get_usercodes_list_tuple_response(self, provider, mock_zha_gateway):
+        """Test get_usercodes with list/tuple format cluster responses."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        # Mock list/tuple responses
+        # Slot 1: list response with string PIN
+        res1 = [1, DoorLock.UserStatus.Enabled, 1, "4321"]
+        # Slot 2: tuple response with bytes PIN
+        res2 = (1, DoorLock.UserStatus.Enabled, 1, b"8765")
+        # Slot 3: list response indicating available (empty PIN)
+        res3 = [1, DoorLock.UserStatus.Available, 1, None]
+
+        mock_zha_gateway["cluster"].get_pin_code.side_effect = [res1, res2, res3]
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 3
+        assert result[0] == CodeSlot(slot_num=1, code="4321", in_use=True)
+        assert result[1] == CodeSlot(slot_num=2, code="8765", in_use=True)
+        assert result[2] == CodeSlot(slot_num=3, code=None, in_use=False)
+
     async def test_get_usercodes_fallback_to_cache_on_error(self, provider, mock_zha_gateway):
         """Test that get_usercodes falls back to cached values on query exception."""
         setup_successful_connect(provider)

--- a/tests/providers/test_zha.py
+++ b/tests/providers/test_zha.py
@@ -697,3 +697,332 @@ class TestConnectionEvents:
             assert provider.connected is True
 
             unsub()
+
+
+class TestZHAAdditionalCoverage:
+    """Test cases to cover remaining paths in ZHA provider."""
+
+    async def test_connect_cluster_not_found(self, provider, mock_zha_gateway):
+        """Test connect warns but succeeds when cluster is not found."""
+        setup_successful_connect(provider)
+        mock_zha_gateway["zigpy_device"].endpoints = {}
+        assert await provider.async_connect() is True
+
+    def test_get_gateway_errors(self, provider):
+        """Test _get_gateway under various fallback scenarios."""
+        # 1. get_zha_gateway_proxy is None
+        with patch("custom_components.keymaster.providers.zha.get_zha_gateway_proxy", None):
+            assert provider._get_gateway() is None
+
+        # 2. get_zha_gateway_proxy raises KeyError
+        with patch(
+            "custom_components.keymaster.providers.zha.get_zha_gateway_proxy",
+            side_effect=KeyError,
+        ):
+            assert provider._get_gateway() is None
+
+        # 3. get_zha_gateway_proxy raises ValueError
+        with patch(
+            "custom_components.keymaster.providers.zha.get_zha_gateway_proxy",
+            side_effect=ValueError,
+        ):
+            assert provider._get_gateway() is None
+
+    def test_get_door_lock_cluster_fallbacks(self, provider, mock_zha_gateway):
+        """Test _get_door_lock_cluster fallback paths."""
+        # Reset cache first
+        provider._door_lock_cluster = None
+
+        # 1. No gateway
+        with patch.object(provider, "_get_gateway", return_value=None):
+            assert provider._get_door_lock_cluster() is None
+
+        # 2. gateway.get_entity_reference raises AttributeError
+        mock_zha_gateway["gateway"].get_entity_reference.side_effect = AttributeError
+        assert provider._get_door_lock_cluster() is None
+        mock_zha_gateway["gateway"].get_entity_reference.side_effect = None
+
+        # 3. entity_ref is None
+        mock_zha_gateway["gateway"].get_entity_reference.return_value = None
+        assert provider._get_door_lock_cluster() is None
+        mock_zha_gateway["gateway"].get_entity_reference.return_value = mock_zha_gateway[
+            "entity_ref"
+        ]
+
+        # 4. device_proxy on entity_data fallback + endpoint 0 continue
+        endpoint_one = mock_zha_gateway["zigpy_device"].endpoints[1]
+        endpoint_zero = MagicMock()
+        mock_zha_gateway["zigpy_device"].endpoints = {0: endpoint_zero, 1: endpoint_one}
+
+        mock_zha_gateway["entity_ref"].device_proxy = None
+        mock_zha_gateway["entity_ref"].entity_data = MagicMock()
+        mock_zha_gateway["entity_ref"].entity_data.device_proxy = mock_zha_gateway["device_proxy"]
+        assert provider._get_door_lock_cluster() is not None
+
+        # Reset back
+        mock_zha_gateway["entity_ref"].device_proxy = mock_zha_gateway["device_proxy"]
+        provider._door_lock_cluster = None
+
+        # 5. device_proxy is None completely
+        mock_zha_gateway["entity_ref"].device_proxy = None
+        mock_zha_gateway["entity_ref"].entity_data = None
+        assert provider._get_door_lock_cluster() is None
+        mock_zha_gateway["entity_ref"].device_proxy = mock_zha_gateway["device_proxy"]
+        provider._door_lock_cluster = None
+
+        # 6. device is None
+        mock_zha_gateway["device_proxy"].device = None
+        assert provider._get_door_lock_cluster() is None
+        mock_zha_gateway["device_proxy"].device = MagicMock()
+        provider._door_lock_cluster = None
+
+        # 7. DoorLock cluster not found in endpoint
+        setup_successful_connect(provider)
+        endpoint_zero = MagicMock()
+        endpoint_zero.in_clusters = {}
+        mock_zha_gateway["zigpy_device"].endpoints = {0: endpoint_zero}
+        assert provider._get_door_lock_cluster() is None
+
+    async def test_async_is_connected_no_device_ieee(self, provider):
+        """Test async_is_connected returns False if device_ieee is missing."""
+        provider._device_ieee = None
+        assert await provider.async_is_connected() is False
+        assert provider.connected is False
+
+    async def test_get_usercodes_missing_config_slots(self, provider, mock_zha_gateway):
+        """Test get_usercodes defaults start/slots when missing from config entry."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+        provider.keymaster_config_entry.data = {}
+        result = await provider.async_get_usercodes()
+        assert result == []
+
+    async def test_get_usercodes_cluster_unavailable(self, provider):
+        """Test get_usercodes logs error and returns empty if cluster is not found."""
+        provider._connected = True
+        with patch.object(provider, "_get_door_lock_cluster", return_value=None):
+            assert await provider.async_get_usercodes() == []
+
+    async def test_refresh_usercode_not_connected(self, provider):
+        """Test refresh_usercode returns None if not connected."""
+        provider._connected = False
+        assert await provider.async_refresh_usercode(2) is None
+
+    async def test_refresh_usercode_cluster_unavailable(self, provider):
+        """Test refresh_usercode returns None if cluster is not found."""
+        provider._connected = True
+        with patch.object(provider, "_get_door_lock_cluster", return_value=None):
+            assert await provider.async_refresh_usercode(2) is None
+
+    async def test_refresh_usercode_error_paths(self, provider, mock_zha_gateway):
+        """Test async_refresh_usercode handles exceptions and non-enabled codes."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        # 1. Exception path
+        mock_zha_gateway["cluster"].get_pin_code.side_effect = Exception("Read Timeout")
+        provider._usercodes_cache[2] = CodeSlot(slot_num=2, code="1234", in_use=True)
+        res = await provider.async_refresh_usercode(2)
+        assert res.code == "1234"
+
+        # 2. UserStatus.Available path (not Enabled)
+        mock_zha_gateway["cluster"].get_pin_code.side_effect = None
+        mock_zha_gateway["cluster"].get_pin_code.return_value = [
+            1,
+            DoorLock.UserStatus.Available,
+            1,
+            None,
+        ]
+        res = await provider.async_refresh_usercode(2)
+        assert res.in_use is False
+        assert res.code is None
+
+    async def test_set_usercode_cluster_unavailable(self, provider):
+        """Test set_usercode returns False if cluster is not found."""
+        with patch.object(provider, "_get_door_lock_cluster", return_value=None):
+            assert await provider.async_set_usercode(2, "1234") is False
+
+    async def test_clear_usercode_cluster_unavailable(self, provider):
+        """Test clear_usercode returns False if cluster is not found."""
+        with patch.object(provider, "_get_door_lock_cluster", return_value=None):
+            assert await provider.async_clear_usercode(2) is False
+
+    async def test_set_clear_usercode_list_tuple_rejections(self, provider, mock_zha_gateway):
+        """Test set_usercode and clear_usercode list/tuple status rejection format."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        # 1. set_usercode status rejection in list
+        mock_zha_gateway["cluster"].set_pin_code.return_value = [1]
+        assert await provider.async_set_usercode(2, "4321") is False
+
+        # 2. clear_usercode status rejection in tuple
+        mock_zha_gateway["cluster"].clear_pin_code.return_value = (1,)
+        assert await provider.async_clear_usercode(2) is False
+
+    def test_parse_pin_response_fallback(self):
+        """Test _parse_pin_response fallback when response is invalid format."""
+        status, pin = ZHALockProvider._parse_pin_response("invalid_response_format")
+        assert status == DoorLock.UserStatus.Available
+        assert pin == ""
+
+    async def test_subscribe_lock_events_edge_cases(self, provider, mock_hass, mock_zha_gateway):
+        """Test ZHA events parsing with edge cases (errors, unknown enums, etc.)."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        captured_callback = None
+
+        def mock_listen(event_type, callback_fn):
+            nonlocal captured_callback
+            captured_callback = callback_fn
+            return lambda: None
+
+        mock_hass.bus.async_listen = MagicMock(side_effect=mock_listen)
+        mock_callback = AsyncMock()
+        mock_kmlock = MagicMock()
+
+        unsub = provider.subscribe_lock_events(mock_kmlock, mock_callback)
+        assert captured_callback is not None
+
+        async def trigger_event(data):
+            event = Event("zha_event", data)
+            captured_callback(event)
+            await asyncio.sleep(0.01)
+
+        # 1. operation as enum member name string (causes ValueError in int(operation) -> fallback ok)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "operation_event_source": 0,
+                    "operation_event_code": "Unlock",
+                    "user_id": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Unlocked via Keypad", 1)
+        mock_callback.reset_mock()
+
+        # 2. source as enum member name string
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "operation_event_source": "Keypad",
+                    "operation_event_code": 1,
+                    "user_id": 3,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(3, "Keypad Lock", 5)
+        mock_callback.reset_mock()
+
+        # 3. Invalid operation string (KeyError suppressed)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "operation_event_source": 0,
+                    "operation_event_code": "InvalidOp",
+                    "user_id": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Keypad InvalidOp", None)
+        mock_callback.reset_mock()
+
+        # 4. Invalid source string (KeyError suppressed)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "operation_event_source": "InvalidSrc",
+                    "operation_event_code": 2,
+                    "user_id": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Unlocked via RF", None)
+        mock_callback.reset_mock()
+
+        # 5. Keypad event that is neither lock nor unlock (operation code 3)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "operation_event_source": 0,
+                    "operation_event_code": 3,
+                    "user_id": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Keypad 3", None)
+        mock_callback.reset_mock()
+
+        # 6. Event that is neither keypad, nor lock, nor unlock (source 2, operation 5)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "operation_event_source": 2,
+                    "operation_event_code": 5,
+                    "user_id": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Lock Event: 5 via 2", None)
+        mock_callback.reset_mock()
+
+        # 7. TypeError block during operation parsing (causes TypeError in int(operation) -> fallback ok)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "operation_event_source": 0,
+                    "operation_event_code": [],
+                    "user_id": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Keypad []", None)
+        mock_callback.reset_mock()
+
+        # 8. TypeError block during source parsing
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "operation_event_source": [],
+                    "operation_event_code": 2,
+                    "user_id": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Unlocked via RF", None)
+        mock_callback.reset_mock()
+
+        # 9. Locked via RF (source 1, operation 1)
+        await trigger_event(
+            {
+                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                "command": "operation_event_notification",
+                "args": {
+                    "operation_event_source": 1,
+                    "operation_event_code": 1,
+                    "user_id": 2,
+                },
+            }
+        )
+        mock_callback.assert_called_once_with(2, "Locked via RF", None)
+        mock_callback.reset_mock()
+
+        unsub()

--- a/tests/providers/test_zha.py
+++ b/tests/providers/test_zha.py
@@ -1,18 +1,29 @@
+# ruff: noqa: E402
 """Tests for the ZHA lock provider."""
 
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from zigpy.zcl.clusters.closures import DoorLock
 
-from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN, Synced
+# Mock homeassistant.components.zha before imports run
+mock_zha_helpers = MagicMock()
+mock_zha_const = MagicMock()
+mock_zha_const.DOMAIN = "zha"
+
+sys.modules["homeassistant.components.zha"] = MagicMock()
+sys.modules["homeassistant.components.zha.helpers"] = mock_zha_helpers
+sys.modules["homeassistant.components.zha.const"] = mock_zha_const
+
+from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
 from custom_components.keymaster.providers._base import CodeSlot
 from custom_components.keymaster.providers.zha import ZHALockProvider
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Event, HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 
@@ -28,7 +39,7 @@ def mock_hass():
     hass.bus = MagicMock()
     hass.bus.async_listen = MagicMock()
 
-    def async_create_task(coro):
+    def async_create_task(coro, name=None):
         return asyncio.create_task(coro)
 
     hass.async_create_task = MagicMock(side_effect=async_create_task)
@@ -72,6 +83,48 @@ def provider(mock_hass, mock_entity_registry, mock_device_registry, mock_config_
     )
 
 
+@pytest.fixture
+def mock_zha_cluster():
+    """Create a mock DoorLock cluster."""
+    cluster = AsyncMock()
+    cluster.cluster_id = DoorLock.cluster_id
+    return cluster
+
+
+@pytest.fixture
+def mock_zha_gateway(mock_hass, mock_zha_cluster):
+    """Create a mock ZHA gateway proxy."""
+    gateway = MagicMock()
+    entity_ref = MagicMock()
+    gateway.get_entity_reference.return_value = entity_ref
+
+    device_proxy = MagicMock()
+    entity_ref.device_proxy = device_proxy
+    entity_ref.entity_data.device_proxy = device_proxy
+
+    device = MagicMock()
+    device_proxy.device = device
+    device.available = True
+
+    zigpy_device = MagicMock()
+    device.device = zigpy_device
+
+    endpoint = MagicMock()
+    endpoint.in_clusters = {DoorLock.cluster_id: mock_zha_cluster}
+    zigpy_device.endpoints = {1: endpoint}
+
+    mock_zha_helpers.get_zha_gateway_proxy.return_value = gateway
+
+    return {
+        "gateway": gateway,
+        "entity_ref": entity_ref,
+        "device_proxy": device_proxy,
+        "zigpy_device": zigpy_device,
+        "cluster": mock_zha_cluster,
+        "get_gateway_proxy": mock_zha_helpers.get_zha_gateway_proxy,
+    }
+
+
 def setup_successful_connect(provider, identifiers=None):
     """Set up registry mocks for a successful connection."""
     if identifiers is None:
@@ -107,41 +160,14 @@ class TestProperties:
 class TestConnect:
     """Test ZHALockProvider async_connect."""
 
-    async def test_connect_success(self, provider):
-        """Test successful connection and IEEE lookup."""
+    async def test_connect_success(self, provider, mock_zha_gateway):
+        """Test successful connection, IEEE lookup, and cluster caching."""
         setup_successful_connect(provider)
         result = await provider.async_connect()
         assert result is True
         assert provider.connected is True
         assert provider._device_ieee == "00:0d:6f:00:0b:90:57:f6"
-
-    async def test_connect_success_with_cache_populate(self, provider, mock_hass):
-        """Test that we pre-populate the cache from coordinator on connect."""
-        setup_successful_connect(provider)
-
-        # Setup mock coordinator
-        mock_kmlock = MagicMock()
-        mock_slot1 = MagicMock()
-        mock_slot1.synced = Synced.SYNCED
-        mock_slot1.pin = "1234"
-        mock_slot2 = MagicMock()
-        mock_slot2.synced = Synced.OUT_OF_SYNC
-        mock_slot2.pin = "5678"
-
-        mock_kmlock.code_slots = {1: mock_slot1, 2: mock_slot2}
-
-        mock_coordinator = MagicMock()
-        mock_coordinator.kmlocks = {"keymaster_test_entry": mock_kmlock}
-
-        mock_hass.data = {DOMAIN: {COORDINATOR: mock_coordinator}}
-
-        result = await provider.async_connect()
-        assert result is True
-
-        # Slot 1 should be cached (synced and has pin)
-        assert provider._usercodes_cache[1] == CodeSlot(slot_num=1, code="1234", in_use=True)
-        # Slot 2 should not be cached (not synced)
-        assert 2 not in provider._usercodes_cache
+        assert provider._door_lock_cluster == mock_zha_gateway["cluster"]
 
     async def test_connect_entity_not_found(self, provider):
         """Test connection fails when lock entity is not found."""
@@ -197,7 +223,7 @@ class TestIsConnected:
         """Test it returns False before connection."""
         assert await provider.async_is_connected() is False
 
-    async def test_is_connected_success(self, provider, mock_hass):
+    async def test_is_connected_success(self, provider, mock_hass, mock_zha_gateway):
         """Test it returns True when connected and lock entity is available."""
         setup_successful_connect(provider)
         await provider.async_connect()
@@ -208,7 +234,7 @@ class TestIsConnected:
 
         assert await provider.async_is_connected() is True
 
-    async def test_is_connected_state_unavailable(self, provider, mock_hass):
+    async def test_is_connected_state_unavailable(self, provider, mock_hass, mock_zha_gateway):
         """Test it returns False when state is unavailable."""
         setup_successful_connect(provider)
         await provider.async_connect()
@@ -219,7 +245,7 @@ class TestIsConnected:
 
         assert await provider.async_is_connected() is False
 
-    async def test_is_connected_state_unknown(self, provider, mock_hass):
+    async def test_is_connected_state_unknown(self, provider, mock_hass, mock_zha_gateway):
         """Test it returns False when state is unknown."""
         setup_successful_connect(provider)
         await provider.async_connect()
@@ -230,7 +256,7 @@ class TestIsConnected:
 
         assert await provider.async_is_connected() is False
 
-    async def test_is_connected_state_none(self, provider, mock_hass):
+    async def test_is_connected_state_none(self, provider, mock_hass, mock_zha_gateway):
         """Test it returns False when state is None."""
         setup_successful_connect(provider)
         await provider.async_connect()
@@ -238,7 +264,7 @@ class TestIsConnected:
 
         assert await provider.async_is_connected() is False
 
-    async def test_is_connected_registry_missing(self, provider, mock_hass):
+    async def test_is_connected_registry_missing(self, provider, mock_hass, mock_zha_gateway):
         """Test it returns False if entity is removed from registry."""
         setup_successful_connect(provider)
         await provider.async_connect()
@@ -246,7 +272,7 @@ class TestIsConnected:
 
         assert await provider.async_is_connected() is False
 
-    async def test_is_connected_platform_changed(self, provider, mock_hass):
+    async def test_is_connected_platform_changed(self, provider, mock_hass, mock_zha_gateway):
         """Test it returns False if entity platform changes."""
         setup_successful_connect(provider)
         await provider.async_connect()
@@ -266,21 +292,60 @@ class TestUsercodeOperations:
         result = await provider.async_get_usercodes()
         assert result == []
 
-    async def test_get_usercodes_success(self, provider):
-        """Test get_usercodes returns cached slots and default slots."""
+    async def test_get_usercodes_success(self, provider, mock_zha_gateway):
+        """Test get_usercodes queries cluster directly for each slot."""
         setup_successful_connect(provider)
         await provider.async_connect()
 
-        # Cache slot 2
-        provider._usercodes_cache[2] = CodeSlot(slot_num=2, code="5678", in_use=True)
+        # Mock cluster responses
+        # Slot 1: Enabled with string code "1234"
+        res1 = MagicMock()
+        res1.user_status = DoorLock.UserStatus.Enabled
+        res1.code = "1234"
+
+        # Slot 2: Enabled with bytes code b"5678"
+        res2 = MagicMock()
+        res2.user_status = DoorLock.UserStatus.Enabled
+        res2.code = b"5678"
+
+        # Slot 3: Disabled/Available
+        res3 = MagicMock()
+        res3.user_status = DoorLock.UserStatus.Available
+        res3.code = ""
+
+        # Setup side effect
+        mock_zha_gateway["cluster"].get_pin_code.side_effect = [res1, res2, res3]
 
         result = await provider.async_get_usercodes()
         assert len(result) == 3
-        # Slot 1 defaults to empty
-        assert result[0] == CodeSlot(slot_num=1, code=None, in_use=False)
-        # Slot 2 comes from cache
+
+        # Verify cluster was called for slots 1, 2, and 3
+        assert mock_zha_gateway["cluster"].get_pin_code.call_count == 3
+        mock_zha_gateway["cluster"].get_pin_code.assert_any_call(1)
+        mock_zha_gateway["cluster"].get_pin_code.assert_any_call(2)
+        mock_zha_gateway["cluster"].get_pin_code.assert_any_call(3)
+
+        assert result[0] == CodeSlot(slot_num=1, code="1234", in_use=True)
         assert result[1] == CodeSlot(slot_num=2, code="5678", in_use=True)
-        # Slot 3 defaults to empty
+        assert result[2] == CodeSlot(slot_num=3, code=None, in_use=False)
+
+    async def test_get_usercodes_fallback_to_cache_on_error(self, provider, mock_zha_gateway):
+        """Test that get_usercodes falls back to cached values on query exception."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        # Populate cache initially
+        provider._usercodes_cache[1] = CodeSlot(slot_num=1, code="9999", in_use=True)
+
+        # Force query to raise an exception
+        mock_zha_gateway["cluster"].get_pin_code.side_effect = Exception("Communication error")
+
+        result = await provider.async_get_usercodes()
+        assert len(result) == 3
+        # Slot 1 retrieved from cache
+        assert result[0] == CodeSlot(slot_num=1, code="9999", in_use=True)
+        # Slots 2 & 3 return default empty
+        assert result[1] == CodeSlot(slot_num=2, code=None, in_use=False)
         assert result[2] == CodeSlot(slot_num=3, code=None, in_use=False)
 
     async def test_get_usercode_cached(self, provider):
@@ -291,90 +356,104 @@ class TestUsercodeOperations:
         )
         assert await provider.async_get_usercode(2) is None
 
-    async def test_set_usercode_success(self, provider, mock_hass):
-        """Test set_usercode calls service and updates cache."""
+    async def test_refresh_usercode_success(self, provider, mock_zha_gateway):
+        """Test refresh_usercode bypasses cache, queries device, and updates cache."""
         setup_successful_connect(provider)
         await provider.async_connect()
 
-        mock_call = AsyncMock()
-        mock_hass.services.async_call = mock_call
+        res = MagicMock()
+        res.user_status = DoorLock.UserStatus.Enabled
+        res.code = "4321"
+        mock_zha_gateway["cluster"].get_pin_code.return_value = res
+
+        result = await provider.async_refresh_usercode(2)
+        assert result == CodeSlot(slot_num=2, code="4321", in_use=True)
+        mock_zha_gateway["cluster"].get_pin_code.assert_called_once_with(2)
+        assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code="4321", in_use=True)
+
+    async def test_set_usercode_success(self, provider, mock_zha_gateway):
+        """Test set_usercode calls cluster directly and updates cache on success."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        # Mock set_pin_code command returning status 0
+        cmd_result = MagicMock()
+        cmd_result.status = 0
+        mock_zha_gateway["cluster"].set_pin_code.return_value = cmd_result
 
         result = await provider.async_set_usercode(2, "4321", "User 2")
         assert result is True
-        mock_call.assert_called_once_with(
-            "zha",
-            "set_lock_user_code",
-            {
-                "entity_id": "lock.test_lock",
-                "code_slot": 2,
-                "user_code": "4321",
-            },
-            blocking=True,
+        mock_zha_gateway["cluster"].set_pin_code.assert_called_once_with(
+            2,
+            DoorLock.UserStatus.Enabled,
+            DoorLock.UserType.Unrestricted,
+            "4321",
         )
         assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code="4321", in_use=True)
 
-    async def test_set_usercode_haerror(self, provider, mock_hass):
-        """Test that set_usercode handles HomeAssistantError."""
+    async def test_set_usercode_status_rejection(self, provider, mock_zha_gateway):
+        """Test that set_usercode returns False and does not cache when ZCL status != 0."""
         setup_successful_connect(provider)
         await provider.async_connect()
 
-        mock_hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("Service failed"))
+        # Mock set_pin_code returning status 1 (rejection/duplicate PIN)
+        cmd_result = MagicMock()
+        cmd_result.status = 1
+        mock_zha_gateway["cluster"].set_pin_code.return_value = cmd_result
 
         result = await provider.async_set_usercode(2, "4321")
         assert result is False
         assert 2 not in provider._usercodes_cache
 
-    async def test_set_usercode_generic_error(self, provider, mock_hass):
-        """Test that set_usercode handles unexpected exceptions."""
+    async def test_set_usercode_exception(self, provider, mock_zha_gateway):
+        """Test that set_usercode handles exceptions gracefully and does not cache."""
         setup_successful_connect(provider)
         await provider.async_connect()
 
-        mock_hass.services.async_call = AsyncMock(side_effect=Exception("Crash"))
+        mock_zha_gateway["cluster"].set_pin_code.side_effect = Exception("Write Timeout")
 
         result = await provider.async_set_usercode(2, "4321")
         assert result is False
         assert 2 not in provider._usercodes_cache
 
-    async def test_clear_usercode_success(self, provider, mock_hass):
-        """Test clear_usercode calls service and updates cache."""
+    async def test_clear_usercode_success(self, provider, mock_zha_gateway):
+        """Test clear_usercode calls cluster directly and updates cache on success."""
         setup_successful_connect(provider)
         await provider.async_connect()
 
         # Cache slot 2 initially
         provider._usercodes_cache[2] = CodeSlot(slot_num=2, code="4321", in_use=True)
 
-        mock_call = AsyncMock()
-        mock_hass.services.async_call = mock_call
+        cmd_result = MagicMock()
+        cmd_result.status = 0
+        mock_zha_gateway["cluster"].clear_pin_code.return_value = cmd_result
 
         result = await provider.async_clear_usercode(2)
         assert result is True
-        mock_call.assert_called_once_with(
-            "zha",
-            "clear_lock_user_code",
-            {
-                "entity_id": "lock.test_lock",
-                "code_slot": 2,
-            },
-            blocking=True,
-        )
+        mock_zha_gateway["cluster"].clear_pin_code.assert_called_once_with(2)
         assert provider._usercodes_cache[2] == CodeSlot(slot_num=2, code=None, in_use=False)
 
-    async def test_clear_usercode_haerror(self, provider, mock_hass):
-        """Test that clear_usercode handles HomeAssistantError."""
+    async def test_clear_usercode_status_rejection(self, provider, mock_zha_gateway):
+        """Test that clear_usercode returns False and does not modify cache when ZCL status != 0."""
         setup_successful_connect(provider)
         await provider.async_connect()
 
-        mock_hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("Service failed"))
+        provider._usercodes_cache[2] = CodeSlot(slot_num=2, code="4321", in_use=True)
+
+        cmd_result = MagicMock()
+        cmd_result.status = 1
+        mock_zha_gateway["cluster"].clear_pin_code.return_value = cmd_result
 
         result = await provider.async_clear_usercode(2)
         assert result is False
+        assert provider._usercodes_cache[2].in_use is True
 
-    async def test_clear_usercode_generic_error(self, provider, mock_hass):
-        """Test that clear_usercode handles unexpected exceptions."""
+    async def test_clear_usercode_exception(self, provider, mock_zha_gateway):
+        """Test that clear_usercode handles exceptions gracefully."""
         setup_successful_connect(provider)
         await provider.async_connect()
 
-        mock_hass.services.async_call = AsyncMock(side_effect=Exception("Crash"))
+        mock_zha_gateway["cluster"].clear_pin_code.side_effect = Exception("Write Timeout")
 
         result = await provider.async_clear_usercode(2)
         assert result is False
@@ -383,8 +462,8 @@ class TestUsercodeOperations:
 class TestLockEvents:
     """Test lock event subscription and parsing."""
 
-    async def test_subscribe_lock_events(self, provider, mock_hass):
-        """Test event subscription registers listener and parses event args."""
+    async def test_subscribe_lock_events(self, provider, mock_hass, mock_zha_gateway):
+        """Test event subscription registers listener and parses event args using ZCL names."""
         setup_successful_connect(provider)
         await provider.async_connect()
 
@@ -409,56 +488,62 @@ class TestLockEvents:
             captured_callback(event)
             await asyncio.sleep(0.01)
 
-        # 1. Unlocked via keypad (dict args)
+        # 1. Unlocked via keypad (dict args with ZCL names)
+        # DoorLock.OperationEventSource.Keypad = 0
+        # DoorLock.OperationEvent.Unlock = 2
         await trigger_event(
             {
                 "device_ieee": "00:0d:6f:00:0b:90:57:f6",
                 "command": "operation_event_notification",
                 "args": {
-                    "source": "Keypad",
-                    "operation": "Unlock",
-                    "code_slot": 2,
+                    "operation_event_source": 0,
+                    "operation_event_code": 2,
+                    "user_id": 2,
                 },
             }
         )
         mock_callback.assert_called_once_with(2, "Unlocked via Keypad", 1)
         mock_callback.reset_mock()
 
-        # 2. Keypad Lock (dict args)
+        # 2. Keypad Lock (dict args with ZCL names)
+        # DoorLock.OperationEventSource.Keypad = 0
+        # DoorLock.OperationEvent.Lock = 1
         await trigger_event(
             {
                 "device_ieee": "00:0d:6f:00:0b:90:57:f6",
                 "command": "operation_event_notification",
                 "args": {
-                    "source": "Keypad",
-                    "operation": "Lock",
-                    "code_slot": 3,
+                    "operation_event_source": 0,
+                    "operation_event_code": 1,
+                    "user_id": 3,
                 },
             }
         )
         mock_callback.assert_called_once_with(3, "Keypad Lock", 5)
         mock_callback.reset_mock()
 
-        # 3. Unlocked via keypad (list args)
+        # 3. Unlocked via keypad (list args fallback)
         await trigger_event(
             {
                 "device_ieee": "00:0d:6f:00:0b:90:57:f6",
                 "command": "operation_event_notification",
-                "args": ["Unlock", "Keypad", 4],
+                "args": [2, 0, 4],  # Unlock (2), Keypad (0), Slot 4
             }
         )
         mock_callback.assert_called_once_with(4, "Unlocked via Keypad", 1)
         mock_callback.reset_mock()
 
-        # 4. Other operation (dict args)
+        # 4. Other operation (dict args with RF source)
+        # DoorLock.OperationEventSource.RF = 1
+        # DoorLock.OperationEvent.Unlock = 2
         await trigger_event(
             {
                 "device_ieee": "00:0d:6f:00:0b:90:57:f6",
                 "command": "operation_event_notification",
                 "args": {
-                    "source": "RFID",
-                    "operation": "Unlock",
-                    "code_slot": 1,
+                    "operation_event_source": 1,
+                    "operation_event_code": 2,
+                    "user_id": 1,
                 },
             }
         )
@@ -471,9 +556,9 @@ class TestLockEvents:
                 "device_ieee": "other_ieee",
                 "command": "operation_event_notification",
                 "args": {
-                    "source": "Keypad",
-                    "operation": "Unlock",
-                    "code_slot": 2,
+                    "operation_event_source": 0,
+                    "operation_event_code": 1,
+                    "user_id": 2,
                 },
             }
         )
@@ -485,89 +570,44 @@ class TestLockEvents:
                 "device_ieee": "00:0d:6f:00:0b:90:57:f6",
                 "command": "other_command",
                 "args": {
-                    "source": "Keypad",
-                    "operation": "Unlock",
-                    "code_slot": 2,
+                    "operation_event_source": 0,
+                    "operation_event_code": 1,
+                    "user_id": 2,
                 },
             }
         )
         mock_callback.assert_not_called()
 
-        # 7. Missing code_slot
+        # 7. user_id == 0 (Master / System Event, filtered out)
         await trigger_event(
             {
                 "device_ieee": "00:0d:6f:00:0b:90:57:f6",
                 "command": "operation_event_notification",
                 "args": {
-                    "source": "Keypad",
-                    "operation": "Unlock",
+                    "operation_event_source": 0,
+                    "operation_event_code": 1,
+                    "user_id": 0,
                 },
             }
         )
         mock_callback.assert_not_called()
 
-        # 8. Invalid args format (neither dict nor list/tuple)
+        # 8. programming_event_notification (triggers coordinator refresh)
+        mock_hass.async_create_task.reset_mock()
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_refresh = AsyncMock()
+        mock_hass.data = {DOMAIN: {COORDINATOR: mock_coordinator}}
+
         await trigger_event(
             {
                 "device_ieee": "00:0d:6f:00:0b:90:57:f6",
-                "command": "operation_event_notification",
-                "args": "invalid",
+                "command": "programming_event_notification",
             }
         )
-        mock_callback.assert_not_called()
+        # Verify coordinator refresh was scheduled
+        mock_hass.async_create_task.assert_called_once()
+        mock_coordinator.async_refresh.assert_called_once()
 
-        # 9. Keypad other operation
-        await trigger_event(
-            {
-                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
-                "command": "operation_event_notification",
-                "args": {
-                    "source": "Keypad",
-                    "operation": "Other",
-                    "code_slot": 2,
-                },
-            }
-        )
-        mock_callback.assert_called_once_with(2, "Keypad Other", None)
-        mock_callback.reset_mock()
-
-        # 10. Non-keypad lock
-        await trigger_event(
-            {
-                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
-                "command": "operation_event_notification",
-                "args": {
-                    "source": "RF",
-                    "operation": "Lock",
-                    "code_slot": 2,
-                },
-            }
-        )
-        mock_callback.assert_called_once_with(2, "Locked via RF", None)
-        mock_callback.reset_mock()
-
-        # 11. Lock Event (other operation/source combination)
-        await trigger_event(
-            {
-                "device_ieee": "00:0d:6f:00:0b:90:57:f6",
-                "command": "operation_event_notification",
-                "args": {
-                    "source": "Manual",
-                    "operation": "Toggle",
-                    "code_slot": 2,
-                },
-            }
-        )
-        mock_callback.assert_called_once_with(2, "Lock Event: Toggle via Manual", None)
-        mock_callback.reset_mock()
-
-        unsub()
-
-    def test_subscribe_connection_events(self, provider):
-        """Test subscribe_connection_events returns unsubscribe function."""
-        callback = MagicMock()
-        unsub = provider.subscribe_connection_events(callback)
-        assert callable(unsub)
         unsub()
 
     def test_get_platform_data(self, provider):
@@ -578,3 +618,55 @@ class TestLockEvents:
         assert data["domain"] == "zha"
         assert data["device_ieee"] == "00:0d:6f:00:0b:90:57:f6"
         assert data["lock_config_entry_id"] == "test_entry_id"
+
+
+class TestConnectionEvents:
+    """Test connection availability event tracking."""
+
+    async def test_subscribe_connection_events(self, provider, mock_hass, mock_zha_gateway):
+        """Test that subscribe_connection_events correctly monitors entity state changes."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        captured_callback = None
+
+        def mock_track(hass, entity_ids, callback_fn):
+            nonlocal captured_callback
+            captured_callback = callback_fn
+            return lambda: None
+
+        mock_callback = MagicMock()
+
+        with patch(
+            "homeassistant.helpers.event.async_track_state_change_event",
+            side_effect=mock_track,
+        ) as mock_track_state:
+            unsub = provider.subscribe_connection_events(mock_callback)
+
+            assert mock_track_state.call_count == 1
+            assert captured_callback is not None
+
+            # Trigger state change to unavailable
+            event_unavailable = Event(
+                "state_changed",
+                {
+                    "new_state": MagicMock(state=STATE_UNAVAILABLE),
+                },
+            )
+            captured_callback(event_unavailable)
+            mock_callback.assert_called_once_with(False)
+            assert provider.connected is False
+            mock_callback.reset_mock()
+
+            # Trigger state change to online/locked
+            event_locked = Event(
+                "state_changed",
+                {
+                    "new_state": MagicMock(state="locked"),
+                },
+            )
+            captured_callback(event_locked)
+            mock_callback.assert_called_once_with(True)
+            assert provider.connected is True
+
+            unsub()

--- a/tests/providers/test_zha.py
+++ b/tests/providers/test_zha.py
@@ -1,23 +1,14 @@
-# ruff: noqa: E402
 """Tests for the ZHA lock provider."""
 
 from __future__ import annotations
 
 import asyncio
 import sys
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from zigpy.zcl.clusters.closures import DoorLock
-
-# Mock homeassistant.components.zha before imports run
-mock_zha_helpers = MagicMock()
-mock_zha_const = MagicMock()
-mock_zha_const.DOMAIN = "zha"
-
-sys.modules["homeassistant.components.zha"] = MagicMock()
-sys.modules["homeassistant.components.zha.helpers"] = mock_zha_helpers
-sys.modules["homeassistant.components.zha.const"] = mock_zha_const
 
 from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
 from custom_components.keymaster.providers._base import CodeSlot
@@ -25,6 +16,21 @@ from custom_components.keymaster.providers.zha import ZHALockProvider
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+# Retrieve pre-existing mock or create if not present
+mock_zha_helpers: Any = sys.modules.get("homeassistant.components.zha.helpers")
+if mock_zha_helpers is None:
+    mock_zha_helpers = MagicMock()
+    sys.modules["homeassistant.components.zha.helpers"] = mock_zha_helpers
+
+mock_zha_const: Any = sys.modules.get("homeassistant.components.zha.const")
+if mock_zha_const is None:
+    mock_zha_const = MagicMock()
+    mock_zha_const.DOMAIN = "zha"
+    sys.modules["homeassistant.components.zha.const"] = mock_zha_const
+
+if "homeassistant.components.zha" not in sys.modules:
+    sys.modules["homeassistant.components.zha"] = MagicMock()
 
 
 @pytest.fixture
@@ -638,7 +644,7 @@ class TestConnectionEvents:
         mock_callback = MagicMock()
 
         with patch(
-            "homeassistant.helpers.event.async_track_state_change_event",
+            "custom_components.keymaster.providers.zha.async_track_state_change_event",
             side_effect=mock_track,
         ) as mock_track_state:
             unsub = provider.subscribe_connection_events(mock_callback)


### PR DESCRIPTION
# Summary

This PR adds a ZHA (Zigbee Home Automation) lock provider implementation for Keymaster, enabling PIN code management and real-time keypad lock/unlock event handling for Zigbee locks integrated via native ZHA.

## Proposed change

A new `ZHALockProvider` is introduced in `custom_components/keymaster/providers/zha.py` following the `BaseLockProvider` design.
- Uses `zha.set_lock_user_code` and `zha.clear_lock_user_code` services for code management.
- Implements an optimistic cache (`_usercodes_cache`) for lock codes, since ZHA does not support retrieving PIN codes from locks.
- Pre-populates the provider's optimistic cache from the coordinator's stored state on startup, preventing redundant service calls/battery drain.
- Subscribes to the Home Assistant `zha_event` bus to process keypad lock/unlock notifications (`operation_event_notification`), robustly parsing both positional (list) and keyword (dict) event arguments.
- Declares `zha` under `after_dependencies` in `manifest.json`.
- Registers the new provider in `custom_components/keymaster/providers/__init__.py`.
- Includes a complete unit test suite in `tests/providers/test_zha.py` with mock fixtures ensuring 100% code coverage.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #163 
