### PR TITLE
fix(coordinator): unsubscribe stale event listeners on lock reload

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -725,10 +725,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 "[update_listeners] %s: Setting create_listeners to run when HA starts",
                 kmlock.lock_name,
             )
-            self.hass.bus.async_listen_once(
+            unsub = self.hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_STARTED,
                 functools.partial(self._create_listeners, kmlock),
             )
+            kmlock.listeners.append(unsub)
 
     def _fire_unlock_state_changed(
         self,

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -169,3 +169,66 @@ async def test_delete_lock_not_pending(hass, mock_coordinator, mock_lock):
 
         mock_delete_lovelace.assert_not_called()
         assert "test_entry" in mock_coordinator.kmlocks
+
+
+async def test_update_listeners_startup_cleanup(hass, mock_lock):
+    """Test that startup listeners are correctly tracked and cleaned up."""
+    coordinator = KeymasterCoordinator(hass)
+
+    # Force HA to starting state (not running)
+    with patch.object(hass, "state", "starting"):
+        # Setup real or mock listeners on mock_lock
+        mock_unsub = MagicMock()
+        with patch(
+            "homeassistant.core.EventBus.async_listen_once", return_value=mock_unsub
+        ) as mock_listen:
+            await coordinator._update_listeners(mock_lock)
+            mock_listen.assert_called_once()
+            # The unsub callback should be stored in listeners
+            assert mock_unsub in mock_lock.listeners
+
+    # Unsubscribe should trigger the mock unsub callback
+    await KeymasterCoordinator._unsubscribe_listeners(mock_lock)
+    mock_unsub.assert_called_once()
+    assert len(mock_lock.listeners) == 0
+
+
+async def test_update_lock_unsubscribes_old_listeners(hass):
+    """Test that _update_lock unsubscribes the old lock's listeners."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator._rebuild_lock_relationships = AsyncMock()
+    coordinator._update_door_and_lock_state = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+
+    old_lock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_id",
+        code_slots={},
+    )
+    old_lock.number_of_code_slots = 1
+    old_lock.starting_code_slot = 1
+    old_lock.code_slots = {1: MagicMock()}
+
+    new_lock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_id",
+        code_slots={},
+    )
+    new_lock.number_of_code_slots = 1
+    new_lock.starting_code_slot = 1
+    new_lock.code_slots = {1: MagicMock()}
+
+    coordinator.kmlocks["entry_id"] = old_lock
+
+    mock_unsub = MagicMock()
+    old_lock.listeners = [mock_unsub]
+
+    with patch.object(coordinator, "_update_listeners", new=AsyncMock()):
+        await coordinator._update_lock(new_lock)
+
+    # The old lock's listeners should be unsubscribed
+    mock_unsub.assert_called_once()
+    assert len(old_lock.listeners) == 0


### PR DESCRIPTION
# Summary

This pull request resolves the bug where the autolock timer fails to start after a configuration reload or Home Assistant restart (Issue #632). It fixes a resource leak where event listeners remained attached to stale `KeymasterLock` instances on reload, causing duplicate events that blocked the live instance's listener due to lock-unlocked command throttling.

## Proposed change

1. **Startup Listener Tracking**:
   In `coordinator.py`, `_update_listeners` now properly tracks the unsubscribe callback returned by `self.hass.bus.async_listen_once` when HA is starting up, storing it in the lock's `listeners` list.
2. **Stale Listener Cleanup**:
   In `_update_lock`, before replacing the old lock instance in `self.kmlocks`, we call `KeymasterCoordinator._unsubscribe_listeners(kmlock=old)`. This cancels any active state trackers and startup listeners registered for the old instance.
3. **Unit Tests Added**:
   Added unit tests in `tests/test_coordinator_lifecycle.py` verifying that startup listeners are correctly tracked and cleaned up, and that `_update_lock` unsubscribes the old lock's listeners.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #632
- This PR is related to issue:
