### PR TITLE
chore: Add ZHA and Zigbee2MQTT to bug report template lock providers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,6 +47,8 @@ body:
       options:
         - local_akuvox
         - schlage
+        - zha
+        - zigbee2mqtt
         - zwave_js
     validations:
       required: true

--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -1,0 +1,41 @@
+name: 'Issue Autolabeler'
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  issues: write
+
+jobs:
+  autolabel:
+    name: 'Label Issue by Provider'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: 🔍 Parse Issue Form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/bug_report.yml
+
+      - name: 🏷️ Apply Provider Label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueData = JSON.parse(`${{ steps.issue-parser.outputs.jsonString }}`);
+            const provider = issueData['lock-provider'];
+
+            if (provider) {
+              const labelName = `provider: ${provider}`;
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [labelName]
+              });
+            }


### PR DESCRIPTION
# Summary

This PR adds the newly implemented lock providers (`zha` and `zigbee2mqtt`) to the lock provider options list in the GitHub bug report template (`bug_report.yml`). Additionally, it introduces a new GitHub Actions workflow to parse the template selection and automatically apply the corresponding provider label to issues.

## Proposed change

- Added `zha` and `zigbee2mqtt` to the dropdown options for the `lock-provider` field in `.github/ISSUE_TEMPLATE/bug_report.yml`.
- Created `.github/workflows/issue_labeler.yml` to automatically parse and label incoming issues (e.g. applying `provider: zha` or `provider: zigbee2mqtt`) when opened.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
