### PR TITLE
fix(coordinator): correct notification routing

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -84,6 +84,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 # dismiss-on-success loop in _lock_locked. Single source of truth so
 # new ids can't be added in one place and silently missed in the other.
 AUTOLOCK_NOTIFICATION_SUFFIXES: tuple[str, ...] = ("door_open", "door_closed", "failed")
+KEYPAD_UNLOCK_NOTIFICATION_DELAY_SECONDS = 1
 
 STORAGE_VERSION = 1
 STORAGE_KEY = f"{DOMAIN}.locks"
@@ -117,6 +118,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._quick_refresh: bool = False
         self._cancel_quick_refresh: Callable | None = None
         self._cancel_debounced_refresh: Callable | None = None
+        self._pending_keypad_unlock_notifications: dict[str, Callable[[], None]] = {}
+        self._state_change_autolock_started: set[str] = set()
         self._consecutive_failures: dict[str, int] = {}
         self._next_retry_time: dict[str, dt] = {}
 
@@ -601,20 +604,42 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             new_state,
         )
 
+        uses_provider_lock_events = bool(kmlock.provider and kmlock.provider.supports_push_updates)
+        # For push providers this listener is autolock-only; notifications
+        # come from the richer provider lock-event path.
         if new_state == LockState.UNLOCKED:
-            if kmlock.lock_state != LockState.UNLOCKED:
-                await self._lock_unlocked(
-                    kmlock=kmlock,
-                    source="state_change",
-                    event_label="State Change Update Unlock",
-                )
+            if old_state != LockState.UNLOCKED:
+                if not uses_provider_lock_events:
+                    await self._lock_unlocked(
+                        kmlock=kmlock,
+                        source="state_change",
+                        event_label="Manual Unlock",
+                    )
+                elif (
+                    kmlock.lock_state != LockState.UNLOCKED
+                    and kmlock.autolock_enabled
+                    and kmlock.autolock_timer
+                ):
+                    await kmlock.autolock_timer.start(
+                        duration=self.autolock_duration_seconds(kmlock),
+                    )
+                    self._state_change_autolock_started.add(kmlock.keymaster_config_entry_id)
+                    self.async_set_updated_data(dict(self.kmlocks))
         elif new_state == LockState.LOCKED:
-            if kmlock.lock_state != LockState.LOCKED:
-                await self._lock_locked(
-                    kmlock=kmlock,
-                    source="state_change",
-                    event_label="State Change Update Lock",
-                )
+            if old_state != LockState.LOCKED:
+                if not uses_provider_lock_events:
+                    await self._lock_locked(
+                        kmlock=kmlock,
+                        source="state_change",
+                        event_label="Manual Lock",
+                    )
+                elif (
+                    kmlock.keymaster_config_entry_id in self._state_change_autolock_started
+                    or kmlock.lock_state != LockState.LOCKED
+                ) and kmlock.autolock_timer:
+                    await kmlock.autolock_timer.cancel()
+                    self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
+                    self.async_set_updated_data(dict(self.kmlocks))
 
     async def _handle_door_state_change(
         self,
@@ -760,11 +785,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         kmlock: KeymasterLock,
         code_slot_num: int,
         event_label: str | None,
-    ) -> None:
+    ) -> bool:
         """Send a per-code-slot unlock notification when enabled."""
         slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
-        if not slot or not slot.notifications or kmlock.lock_notifications:
-            return
+        if not slot or not slot.notifications:
+            return False
 
         if slot.name:
             message = f"{event_label} by {slot.name} [{code_slot_num}]"
@@ -776,6 +801,101 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             title=kmlock.lock_name,
             message=message,
         )
+        return True
+
+    async def _send_global_unlock_notification(
+        self,
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+        event_label: str | None,
+    ) -> None:
+        """Send a global unlock notification."""
+        message = event_label
+        if code_slot_num > 0:
+            if (
+                kmlock.code_slots
+                and kmlock.code_slots.get(code_slot_num)
+                and kmlock.code_slots[code_slot_num].name
+            ):
+                message = f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
+            else:
+                message = f"{message} by Code Slot {code_slot_num}"
+        await send_manual_notification(
+            hass=self.hass,
+            script_name=kmlock.notify_script_name,
+            title=kmlock.lock_name,
+            message=message,
+        )
+
+    async def _send_deferred_keypad_unlock_notification(
+        self,
+        kmlock: KeymasterLock,
+        event_label: str | None,
+        _: dt,
+    ) -> None:
+        """Send a deferred global keypad unlock notification."""
+        self._pending_keypad_unlock_notifications.pop(kmlock.keymaster_config_entry_id, None)
+        if kmlock.lock_notifications:
+            await self._send_global_unlock_notification(kmlock, 0, event_label)
+        if self._last_unlock_code_slot.get(kmlock.keymaster_config_entry_id) == 0:
+            self._last_unlock_code_slot[kmlock.keymaster_config_entry_id] = None
+
+    def _cancel_pending_keypad_unlock_notification(self, kmlock: KeymasterLock) -> bool:
+        """Cancel pending keypad unlock notification if one exists."""
+        cancel = self._pending_keypad_unlock_notifications.pop(
+            kmlock.keymaster_config_entry_id,
+            None,
+        )
+        if not cancel:
+            return False
+        cancel()
+        return True
+
+    def _defer_keypad_unlock_notification(
+        self,
+        kmlock: KeymasterLock,
+        event_label: str | None,
+    ) -> None:
+        """Defer a provisional global keypad unlock notification."""
+        self._cancel_pending_keypad_unlock_notification(kmlock)
+        self._pending_keypad_unlock_notifications[kmlock.keymaster_config_entry_id] = (
+            async_call_later(
+                hass=self.hass,
+                delay=KEYPAD_UNLOCK_NOTIFICATION_DELAY_SECONDS,
+                action=functools.partial(
+                    self._send_deferred_keypad_unlock_notification,
+                    kmlock,
+                    event_label,
+                ),
+            )
+        )
+
+    @staticmethod
+    def _global_unlock_notification_superseded(
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+    ) -> bool:
+        """Return whether per-slot notification should replace global unlock text."""
+        if not kmlock.code_slots:
+            return False
+
+        if code_slot_num > 0:
+            slot = kmlock.code_slots.get(code_slot_num)
+            return bool(slot and slot.notifications)
+
+        return False
+
+    @staticmethod
+    def _should_defer_keypad_unlock_notification(
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+        event_label: str | None,
+    ) -> bool:
+        """Return whether a slot=0 keypad unlock may be superseded by slot details."""
+        if code_slot_num != 0 or event_label != "Keypad Unlock" or not kmlock.code_slots:
+            return False
+
+        return any(slot.notifications for slot in kmlock.code_slots.values())
 
     async def _lock_unlocked(
         self,
@@ -807,7 +927,18 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 self._fire_unlock_state_changed(
                     kmlock, code_slot_num, source, event_label, action_code
                 )
-                await self._send_code_slot_unlock_notification(kmlock, code_slot_num, event_label)
+                had_pending_notification = self._cancel_pending_keypad_unlock_notification(kmlock)
+                sent_slot_notification = await self._send_code_slot_unlock_notification(
+                    kmlock,
+                    code_slot_num,
+                    event_label,
+                )
+                if (
+                    had_pending_notification
+                    and not sent_slot_notification
+                    and kmlock.lock_notifications
+                ):
+                    await self._send_global_unlock_notification(kmlock, 0, event_label)
             return
 
         if not self._throttle.is_allowed(
@@ -834,29 +965,18 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         self._last_unlock_code_slot[kmlock.keymaster_config_entry_id] = code_slot_num
 
-        if kmlock.autolock_enabled and kmlock.autolock_timer:
+        if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
+            self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
+            self.async_set_updated_data(dict(self.kmlocks))
+        elif kmlock.autolock_enabled and kmlock.autolock_timer:
             await kmlock.autolock_timer.start(duration=self.autolock_duration_seconds(kmlock))
             self.async_set_updated_data(dict(self.kmlocks))
 
         if kmlock.lock_notifications:
-            message = event_label
-            if code_slot_num > 0:
-                if (
-                    kmlock.code_slots
-                    and kmlock.code_slots.get(code_slot_num)
-                    and kmlock.code_slots[code_slot_num].name
-                ):
-                    message = (
-                        f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
-                    )
-                else:
-                    message = f"{message} by Code Slot {code_slot_num}"
-            await send_manual_notification(
-                hass=self.hass,
-                script_name=kmlock.notify_script_name,
-                title=kmlock.lock_name,
-                message=message,
-            )
+            if self._should_defer_keypad_unlock_notification(kmlock, code_slot_num, event_label):
+                self._defer_keypad_unlock_notification(kmlock, event_label)
+            elif not self._global_unlock_notification_superseded(kmlock, code_slot_num):
+                await self._send_global_unlock_notification(kmlock, code_slot_num, event_label)
 
         if code_slot_num > 0 and kmlock.code_slots and code_slot_num in kmlock.code_slots:
             if (
@@ -919,12 +1039,20 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             return
 
         if kmlock.lock_state == LockState.LOCKED and not kmlock.pending_retry_lock:
+            if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
+                if kmlock.autolock_timer:
+                    await kmlock.autolock_timer.cancel()
+                    self.async_set_updated_data(dict(self.kmlocks))
+                self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
+            self._cancel_pending_keypad_unlock_notification(kmlock)
             return
 
         kmlock.lock_state = LockState.LOCKED
         kmlock.pending_retry_lock = False
         self._throttle.reset("lock_unlocked", kmlock.keymaster_config_entry_id)
         self._last_unlock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
+        self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
+        self._cancel_pending_keypad_unlock_notification(kmlock)
         _LOGGER.debug(
             "[lock_locked] %s: Running. source: %s, event_label: %s, action_code: %s",
             kmlock.lock_name,
@@ -1318,6 +1446,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         self.kmlocks.pop(kmlock.keymaster_config_entry_id, None)
         self._last_unlock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
+        self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
+        self._cancel_pending_keypad_unlock_notification(kmlock)
         await self._rebuild_lock_relationships()
         await self._async_save_data()
         await self.async_refresh()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -108,6 +108,8 @@ def mock_coordinator(mock_hass) -> Any:
         coordinator.hass = mock_hass
         coordinator.kmlocks = {}
         coordinator._last_unlock_code_slot = {}
+        coordinator._pending_keypad_unlock_notifications = {}
+        coordinator._state_change_autolock_started = set()
         # Use setattr to safely add the mock method
         setattr(coordinator, "delete_lock_by_config_entry_id", AsyncMock())
         setattr(coordinator, "async_set_updated_data", Mock())
@@ -1030,6 +1032,8 @@ class TestLockStateEventHandlers:
         lock.lock_notifications = False
         lock.door_notifications = False
         lock.notify_script_name = None
+        lock.provider = Mock()
+        lock.provider.supports_push_updates = True
         return lock
 
     async def test_lock_locked_basic_state_change(self, mock_coordinator, mock_kmlock):
@@ -1391,8 +1395,78 @@ class TestLockStateEventHandlers:
             assert mock_kmlock.door_state == STATE_OPEN
 
     async def test_handle_lock_state_change_unlocked(self, mock_coordinator, mock_kmlock):
-        """Test _handle_lock_state_change triggers _lock_unlocked when lock transitions to UNLOCKED."""
+        """Test _handle_lock_state_change starts autolock without notifications."""
         mock_kmlock.lock_state = LockState.LOCKED
+        mock_kmlock.autolock_enabled = True
+        mock_kmlock.autolock_timer = AsyncMock()
+        mock_kmlock.autolock_timer.start = AsyncMock()
+        mock_kmlock.lock_notifications = True
+        mock_coordinator._lock_unlocked = AsyncMock()
+        mock_coordinator._lock_locked = AsyncMock()
+        mock_coordinator.autolock_duration_seconds = Mock(return_value=300)
+
+        mock_old = Mock()
+        mock_old.state = LockState.LOCKED
+        mock_new = Mock()
+        mock_new.state = LockState.UNLOCKED
+        event = Mock()
+        event.data = {
+            "entity_id": "lock.front_door",
+            "old_state": mock_old,
+            "new_state": mock_new,
+        }
+
+        with patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify:
+            await mock_coordinator._handle_lock_state_change(mock_kmlock, event)
+
+        assert mock_kmlock.lock_state == LockState.LOCKED
+        mock_kmlock.autolock_timer.start.assert_called_once_with(duration=300)
+        mock_coordinator.async_set_updated_data.assert_called_once()
+        mock_notify.assert_not_called()
+        mock_coordinator._lock_unlocked.assert_not_called()
+        mock_coordinator._lock_locked.assert_not_called()
+
+    async def test_handle_lock_state_change_locked(self, mock_coordinator, mock_kmlock):
+        """Test _handle_lock_state_change cancels autolock without notifications."""
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_kmlock.autolock_timer = AsyncMock()
+        mock_kmlock.autolock_timer.cancel = AsyncMock()
+        mock_kmlock.lock_notifications = True
+        mock_coordinator._lock_unlocked = AsyncMock()
+        mock_coordinator._lock_locked = AsyncMock()
+
+        mock_old = Mock()
+        mock_old.state = LockState.UNLOCKED
+        mock_new = Mock()
+        mock_new.state = LockState.LOCKED
+        event = Mock()
+        event.data = {
+            "entity_id": "lock.front_door",
+            "old_state": mock_old,
+            "new_state": mock_new,
+        }
+
+        with patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify:
+            await mock_coordinator._handle_lock_state_change(mock_kmlock, event)
+
+        assert mock_kmlock.lock_state == LockState.UNLOCKED
+        mock_kmlock.autolock_timer.cancel.assert_called_once()
+        mock_coordinator.async_set_updated_data.assert_called_once()
+        mock_notify.assert_not_called()
+        mock_coordinator._lock_locked.assert_not_called()
+        mock_coordinator._lock_unlocked.assert_not_called()
+
+    async def test_handle_lock_state_change_unlocked_without_push_provider(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test state-change unlock path remains active without push provider events."""
+        mock_kmlock.provider = None
         mock_coordinator._lock_unlocked = AsyncMock()
         mock_coordinator._lock_locked = AsyncMock()
 
@@ -1412,13 +1486,15 @@ class TestLockStateEventHandlers:
         mock_coordinator._lock_unlocked.assert_called_once_with(
             kmlock=mock_kmlock,
             source="state_change",
-            event_label="State Change Update Unlock",
+            event_label="Manual Unlock",
         )
         mock_coordinator._lock_locked.assert_not_called()
 
-    async def test_handle_lock_state_change_locked(self, mock_coordinator, mock_kmlock):
-        """Test _handle_lock_state_change triggers _lock_locked when lock transitions to LOCKED."""
-        mock_kmlock.lock_state = LockState.UNLOCKED
+    async def test_handle_lock_state_change_locked_without_push_provider(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test state-change lock path remains active without push provider events."""
+        mock_kmlock.provider = None
         mock_coordinator._lock_unlocked = AsyncMock()
         mock_coordinator._lock_locked = AsyncMock()
 
@@ -1438,7 +1514,7 @@ class TestLockStateEventHandlers:
         mock_coordinator._lock_locked.assert_called_once_with(
             kmlock=mock_kmlock,
             source="state_change",
-            event_label="State Change Update Lock",
+            event_label="Manual Lock",
         )
         mock_coordinator._lock_unlocked.assert_not_called()
 

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -15,6 +15,7 @@ from custom_components.keymaster.helpers import Throttle
 from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
 from homeassistant.components.lock.const import LockState
 from homeassistant.const import ATTR_STATE
+from tests.common import async_fire_time_changed
 
 
 @pytest.fixture
@@ -376,6 +377,638 @@ async def test_lock_unlocked_decrements_parent_lock_accesslimit_count(
         assert parent_kmlock.code_slots[1].accesslimit_count == 9
 
 
+@pytest.mark.parametrize(
+    ("action", "global_notifications", "expected_message"),
+    [
+        ("lock", False, None),
+        ("lock", True, "Manual Lock"),
+        ("unlock", False, None),
+        ("unlock", True, "Manual Unlock"),
+    ],
+)
+async def test_manual_notifications_respect_global_setting(
+    hass,
+    coordinator_for_unlock_test,
+    action,
+    global_notifications,
+    expected_message,
+):
+    """Test manual lock/unlock notifications for both global states."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id=f"test_entry_{action}_{global_notifications}",
+    )
+    kmlock.lock_state = LockState.UNLOCKED if action == "lock" else LockState.LOCKED
+    kmlock.lock_notifications = global_notifications
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = (
+        {1: KeymasterCodeSlot(number=1, notifications=True)} if action == "unlock" else {}
+    )
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with (
+        patch(
+            "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+            new=AsyncMock(),
+        ),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        if action == "lock":
+            await coordinator._lock_locked(
+                kmlock=kmlock,
+                source="event",
+                event_label="Manual Lock",
+            )
+        else:
+            await coordinator._lock_unlocked(
+                kmlock=kmlock,
+                code_slot_num=0,
+                source="event",
+                event_label="Manual Unlock",
+            )
+        await hass.async_block_till_done()
+
+    if expected_message is None:
+        mock_notify.assert_not_called()
+    else:
+        mock_notify.assert_called_once_with(
+            hass=hass,
+            script_name="notify_front_door",
+            title="Front Door",
+            message=expected_message,
+        )
+
+
+@pytest.mark.parametrize(
+    ("slot_notifications", "global_notifications", "expected_message"),
+    [
+        (True, False, "Keypad Unlock by Rich [1]"),
+        (True, True, "Keypad Unlock by Rich [1]"),
+        (False, True, "Keypad Unlock"),
+        (False, False, None),
+    ],
+)
+async def test_keypad_unlock_notifications_follow_slot_and_global_settings(
+    hass,
+    coordinator_for_unlock_test,
+    slot_notifications,
+    global_notifications,
+    expected_message,
+):
+    """Test Z-Wave JS slot=0 then slot=N keypad unlock notification behavior."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id=f"test_entry_{slot_notifications}_{global_notifications}",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.lock_notifications = global_notifications
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(
+            number=1,
+            name="Rich",
+            enabled=True,
+            notifications=slot_notifications,
+        )
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=1,
+            source="valid_code_entered",
+            event_label="Keypad Unlock",
+            action_code=6,
+        )
+        await hass.async_block_till_done()
+
+    if expected_message is None:
+        mock_notify.assert_not_called()
+    else:
+        mock_notify.assert_called_once_with(
+            hass=hass,
+            script_name="notify_front_door",
+            title="Front Door",
+            message=expected_message,
+        )
+
+
+async def test_keypad_unlock_mixed_slots_falls_back_to_global_notification(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test deferred global text is sent when actual slot notifications are off."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_mixed_slots",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Rich", enabled=True, notifications=False),
+        2: KeymasterCodeSlot(number=2, name="Guest", enabled=True, notifications=True),
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=1,
+            source="valid_code_entered",
+            event_label="Keypad Unlock",
+            action_code=6,
+        )
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Keypad Unlock",
+    )
+
+
+async def test_keypad_unlock_deferred_global_notification_fires_without_slot_event(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test deferred global keypad text fires if no slot detail arrives."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_deferred_keypad",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Rich", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new=AsyncMock(),
+    ) as mock_notify:
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+        mock_notify.assert_not_called()
+
+        async_fire_time_changed(hass, fire_all=True)
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Keypad Unlock",
+    )
+
+
+async def test_late_slot_event_after_deferred_global_does_not_duplicate_notification(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test a slot event after deferred global text does not send a second notification."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_late_slot",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Rich", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        async_fire_time_changed(hass, fire_all=True)
+        await hass.async_block_till_done()
+
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=1,
+            source="valid_code_entered",
+            event_label="Keypad Unlock",
+            action_code=6,
+        )
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Keypad Unlock",
+    )
+
+
+async def test_state_change_before_slot_event_does_not_swallow_slot_notification(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test coordinator state-change autolock path does not consume provider slot event."""
+    coordinator = coordinator_for_unlock_test
+    coordinator.autolock_duration_seconds = MagicMock(return_value=300)
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_state_then_slot",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.provider = MagicMock()
+    kmlock.provider.supports_push_updates = True
+    kmlock.autolock_enabled = True
+    kmlock.autolock_timer = MagicMock()
+    kmlock.autolock_timer.start = AsyncMock()
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Rich", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    old_state = MagicMock()
+    old_state.state = LockState.LOCKED
+    new_state = MagicMock()
+    new_state.state = LockState.UNLOCKED
+    event = MagicMock()
+    event.data = {
+        "entity_id": "lock.front_door",
+        "old_state": old_state,
+        "new_state": new_state,
+    }
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._handle_lock_state_change(kmlock, event)
+        await hass.async_block_till_done()
+        mock_notify.assert_not_called()
+        kmlock.autolock_timer.start.assert_called_once_with(duration=300)
+
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=1,
+            source="valid_code_entered",
+            event_label="Keypad Unlock",
+            action_code=6,
+        )
+        await hass.async_block_till_done()
+
+    assert kmlock.autolock_timer.start.call_count == 1
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Keypad Unlock by Rich [1]",
+    )
+
+
+async def test_provider_unlock_before_state_change_does_not_restart_autolock(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test provider-first unlock ordering does not re-arm autolock on state change."""
+    coordinator = coordinator_for_unlock_test
+    coordinator.autolock_duration_seconds = MagicMock(return_value=300)
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_provider_then_state",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.autolock_enabled = True
+    kmlock.autolock_timer = MagicMock()
+    kmlock.autolock_timer.start = AsyncMock()
+    kmlock.provider = MagicMock()
+    kmlock.provider.supports_push_updates = True
+    kmlock.code_slots = {}
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    old_state = MagicMock()
+    old_state.state = LockState.LOCKED
+    new_state = MagicMock()
+    new_state.state = LockState.UNLOCKED
+    event = MagicMock()
+    event.data = {
+        "entity_id": "lock.front_door",
+        "old_state": old_state,
+        "new_state": new_state,
+    }
+
+    await coordinator._lock_unlocked(
+        kmlock=kmlock,
+        code_slot_num=0,
+        source="event",
+        event_label="Manual Unlock",
+    )
+    await hass.async_block_till_done()
+
+    await coordinator._handle_lock_state_change(kmlock, event)
+    await hass.async_block_till_done()
+
+    kmlock.autolock_timer.start.assert_called_once_with(duration=300)
+
+
+async def test_state_change_relock_clears_autolock_marker_before_next_unlock(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test relock after state-change-only unlock does not suppress next autolock."""
+    coordinator = coordinator_for_unlock_test
+    coordinator.autolock_duration_seconds = MagicMock(return_value=300)
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_state_relock",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.autolock_enabled = True
+    kmlock.autolock_timer = MagicMock()
+    kmlock.autolock_timer.start = AsyncMock()
+    kmlock.autolock_timer.cancel = AsyncMock()
+    kmlock.provider = MagicMock()
+    kmlock.provider.supports_push_updates = True
+    kmlock.code_slots = {}
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    unlock_old = MagicMock()
+    unlock_old.state = LockState.LOCKED
+    unlock_new = MagicMock()
+    unlock_new.state = LockState.UNLOCKED
+    unlock_event = MagicMock()
+    unlock_event.data = {
+        "entity_id": "lock.front_door",
+        "old_state": unlock_old,
+        "new_state": unlock_new,
+    }
+    lock_old = MagicMock()
+    lock_old.state = LockState.UNLOCKED
+    lock_new = MagicMock()
+    lock_new.state = LockState.LOCKED
+    lock_event = MagicMock()
+    lock_event.data = {
+        "entity_id": "lock.front_door",
+        "old_state": lock_old,
+        "new_state": lock_new,
+    }
+
+    await coordinator._handle_lock_state_change(kmlock, unlock_event)
+    await hass.async_block_till_done()
+    kmlock.autolock_timer.start.assert_called_once_with(duration=300)
+
+    await coordinator._handle_lock_state_change(kmlock, lock_event)
+    await hass.async_block_till_done()
+    kmlock.autolock_timer.cancel.assert_called_once()
+
+    await coordinator._lock_unlocked(
+        kmlock=kmlock,
+        code_slot_num=0,
+        source="event",
+        event_label="Manual Unlock",
+    )
+    await hass.async_block_till_done()
+
+    assert kmlock.autolock_timer.start.call_count == 2
+
+
+async def test_already_locked_event_clears_state_change_autolock_marker(
+    coordinator_for_unlock_test,
+):
+    """Test already-locked event clears stale state-change autolock marker."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_locked_marker",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.pending_retry_lock = False
+    kmlock.autolock_timer = MagicMock()
+    kmlock.autolock_timer.cancel = AsyncMock()
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+    coordinator._state_change_autolock_started.add(kmlock.keymaster_config_entry_id)
+
+    await coordinator._lock_locked(kmlock=kmlock, source="event", event_label="Manual Lock")
+
+    kmlock.autolock_timer.cancel.assert_called_once()
+    assert kmlock.keymaster_config_entry_id not in coordinator._state_change_autolock_started
+
+
+async def test_manual_unlock_global_notification_without_code_slots(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test global manual unlock notification when no slots are configured."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_manual_no_slots",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {}
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new=AsyncMock(),
+    ) as mock_notify:
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="event",
+            event_label="Manual Unlock",
+        )
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Manual Unlock",
+    )
+
+
+async def test_keypad_unlock_with_initial_slot_sends_single_slot_notification(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test per-slot text replaces global text when the first event has a slot."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_initial_slot",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Rich", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=1,
+            source="valid_code_entered",
+            event_label="Keypad Unlock",
+            action_code=6,
+        )
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Keypad Unlock by Rich [1]",
+    )
+
+
+@pytest.mark.parametrize(
+    ("slot_name", "expected_message"),
+    [
+        ("Rich", "Keypad Unlock by Rich [1]"),
+        (None, "Keypad Unlock by Code Slot 1"),
+    ],
+)
+async def test_global_keypad_unlock_with_initial_slot_uses_slot_details(
+    hass,
+    coordinator_for_unlock_test,
+    slot_name,
+    expected_message,
+):
+    """Test global unlock text includes slot details when per-slot notification is off."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id=f"test_entry_global_slot_{slot_name}",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name=slot_name, enabled=True, notifications=False)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with (
+        patch.object(coordinator, "async_refresh", new=AsyncMock()),
+        patch.object(coordinator, "update_slot_active_state", new=AsyncMock()),
+        patch.object(coordinator, "clear_pin_from_lock", new=AsyncMock()),
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify,
+    ):
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=1,
+            source="valid_code_entered",
+            event_label="Keypad Unlock",
+            action_code=6,
+        )
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message=expected_message,
+    )
+
+
 async def test_lock_unlocked_does_not_decrement_when_count_zero(hass, coordinator_for_unlock_test):
     """Test that accesslimit_count is not decremented when already at 0."""
     coordinator = coordinator_for_unlock_test
@@ -532,10 +1165,10 @@ async def test_lock_unlocked_supersede_sends_per_slot_notification(
     )
 
 
-async def test_lock_unlocked_supersede_skips_per_slot_when_global_enabled(
+async def test_lock_unlocked_supersede_sends_slot_notification_when_global_enabled(
     hass, coordinator_for_unlock_test
 ):
-    """Test that global notifications suppress per-slot notification on supersede."""
+    """Test that per-slot notification supersedes global text when both are enabled."""
     coordinator = coordinator_for_unlock_test
 
     kmlock = KeymasterLock(
@@ -564,7 +1197,7 @@ async def test_lock_unlocked_supersede_skips_per_slot_when_global_enabled(
             kmlock=kmlock,
             code_slot_num=0,
             source="relay_a_triggered",
-            event_label="Unlock",
+            event_label="Keypad Unlock",
             action_code=1,
         )
         await hass.async_block_till_done()
@@ -573,7 +1206,7 @@ async def test_lock_unlocked_supersede_skips_per_slot_when_global_enabled(
             kmlock=kmlock,
             code_slot_num=2,
             source="valid_code_entered",
-            event_label="Unlock",
+            event_label="Keypad Unlock",
             action_code=2,
         )
         await hass.async_block_till_done()
@@ -582,7 +1215,7 @@ async def test_lock_unlocked_supersede_skips_per_slot_when_global_enabled(
         hass=hass,
         script_name="notify_test",
         title="test_lock",
-        message="Unlock",
+        message="Keypad Unlock by Charlie [2]",
     )
 
 
@@ -789,7 +1422,7 @@ async def test_lock_unlocked_side_effects_not_duplicated(hass, coordinator_for_u
 
     When a slot>0 event supersedes a prior slot=0 unlock, autolock timer
     should NOT be restarted, access limits should NOT be decremented, and
-    notifications should NOT be re-sent.
+    global notifications should NOT be re-sent.
     """
     coordinator = coordinator_for_unlock_test
 
@@ -825,12 +1458,12 @@ async def test_lock_unlocked_side_effects_not_duplicated(hass, coordinator_for_u
             new=AsyncMock(),
         ) as mock_notify,
     ):
-        # First event: slot=0 — triggers autolock and notification
+        # First event: slot=0 — triggers autolock but defers to per-slot notification
         await coordinator._lock_unlocked(
             kmlock=kmlock,
             code_slot_num=0,
             source="relay_a_triggered",
-            event_label="Unlock",
+            event_label="Keypad Unlock",
             action_code=1,
         )
         await hass.async_block_till_done()
@@ -839,20 +1472,26 @@ async def test_lock_unlocked_side_effects_not_duplicated(hass, coordinator_for_u
         notify_call_count = mock_notify.call_count
         access_count_after_first = kmlock.code_slots[2].accesslimit_count
 
-        # Second event: slot=2 — supersedes, but should NOT re-run side effects
+        # Second event: slot=2 — supersedes, but should NOT re-run global side effects
         await coordinator._lock_unlocked(
             kmlock=kmlock,
             code_slot_num=2,
             source="valid_code_entered",
-            event_label="Unlock",
+            event_label="Keypad Unlock",
             action_code=2,
         )
         await hass.async_block_till_done()
 
     # Autolock timer should not be started again
     assert kmlock.autolock_timer.start.call_count == autolock_call_count
-    # Notification should not be sent again
-    assert mock_notify.call_count == notify_call_count
+    # Only the per-slot notification should be sent
+    assert notify_call_count == 0
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="script.notify_test",
+        title="test_lock",
+        message="Keypad Unlock by Charlie [2]",
+    )
     # Access limit should not be decremented
     assert kmlock.code_slots[2].accesslimit_count == access_count_after_first == 5
 


### PR DESCRIPTION
## Summary

Fixes two notification regressions behind #646:

- `custom_components/keymaster/coordinator.py:607` now keeps the coordinator
  lock state-change listener autolock-only when a push provider supplies
  richer events, so Z-Wave JS notifications come from the provider event path
  with source/slot context instead of hardcoded `State Change Update ...`
  text. Non-push providers keep a Manual Lock/Unlock state-change fallback.
- `custom_components/keymaster/coordinator.py:789` removes the global
  `lock_notifications` mutual-exclusion gate from per-slot unlock
  notifications, allowing slot-aware text to win when both settings are on.
- `custom_components/keymaster/coordinator.py:830` defers provisional
  slot=0 global keypad unlock text briefly so a following slot=N event can
  supersede it, while still falling back to global text if no slot detail
  arrives or the actual slot has per-slot notifications disabled.

The user's clarification means lock-direction events are intentionally
slot-less on many lock models, so per-slot notifications remain unlock-only.

## Expected behavior covered

- Manual lock, global off: no notification
- Manual lock, global on: `Manual Lock`
- Manual unlock, global off: no notification
- Manual unlock, global on: `Manual Unlock`
- Keypad unlock slot N, per-slot on/global off: `Keypad Unlock by Rich [N]`
- Keypad unlock slot N, per-slot on/global on: `Keypad Unlock by Rich [N]`
- Keypad unlock slot N, per-slot off/global on: `Keypad Unlock`
- State-change listener for push providers produces no user notification

Release-note worthy: users with both `lock_notifications=True` and per-slot
notifications enabled now get the slot-aware keypad unlock text instead of
only the generic global text.

## Validation

- `pytest -q` (894 passed, 11 existing warnings)
- `python -m diff_cover.diff_cover_tool coverage.xml --compare-branch=upstream/main --fail-under=100`
- `prek run --all-files`
- local code-review rubber-duck loop clean

Fixes #646
