### PR TITLE
docs: add supported lock providers matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ single line of YAML, or add individual lock views to existing dashboards. See
 the [Lovelace Configuration](https://github.com/FutureTense/keymaster/wiki/Lovelace-Configuration-Automatic)
 wiki page for setup instructions and configuration options.
 
+## Supported Lock Providers
+
+Keymaster supports multiple lock integrations and communication protocols via a
+provider abstraction model. Below is the support matrix of features for each
+provider:
+
+<!-- markdownlint-disable MD013 -->
+| Integration / Platform | Domain | Protocol | Push Updates | Connection Status | Description / Notes |
+| :--- | :--- | :--- | :---: | :---: | :--- |
+| **[Z-Wave JS](https://www.home-assistant.io/integrations/zwave_js/)** | `zwave_js` | Z-Wave | ✅ | ✅ | Direct node-based lock control with full pin/metadata querying. |
+| **[Zigbee2MQTT](https://www.zigbee2mqtt.io/)** | `mqtt` | Zigbee | ✅ | ✅ | MQTT-based control (requires `expose_pin: true` in Z2M config). |
+| **[ZHA](https://www.home-assistant.io/integrations/zha/)** | `zha` | Zigbee | ✅ | ✅ | Native HA Zigbee Home Automation integration. |
+| **[Schlage WiFi](https://www.home-assistant.io/integrations/schlage/)** | `schlage` | Wi-Fi | ❌ | ✅ | Virtual slot mapping by prefixing tags to code names. |
+| **[Local Akuvox](https://github.com/firstof9/ha-local-akuvox)** | `local_akuvox` | LAN | ✅ | ✅ | Virtual slot mapping by tagging door controller user names. |
+| **[Matter](https://www.home-assistant.io/integrations/matter/)** | `matter` | Matter | ⏳ | ⏳ | Standardized Matter Lock Cluster PIN credential management. |
+| **[Nuki](https://www.home-assistant.io/integrations/nuki/)** | `nuki` | Local API | ⏳ | ⏳ | Nuki Keypad PIN management. |
+| **[Tedee](https://www.home-assistant.io/integrations/tedee/)** | `tedee` | Cloud/Local | ⏳ | ⏳ | Tedee Keypad PIN management. |
+<!-- markdownlint-enable MD013 -->
+
 ## Installation
 
 Please visit this project's


### PR DESCRIPTION
# Summary

This PR adds a comprehensive **Supported Lock Providers** support matrix to the `README.md` to help users and maintainers understand at a glance which integrations (Z-Wave JS, Zigbee2MQTT, ZHA, Schlage WiFi, Local Akuvox, Matter, Nuki, and Tedee) are supported, their respective domains and protocols, and whether they support push updates and connection status tracking.

## Proposed change

Introduces a structured Markdown table under a new `## Supported Lock Providers` section in the project README mapping:
- Integration/Platform names (linked to official integration/docs)
- Domains and communication protocols
- Feature support (Push Updates and Connection Status)
- Short descriptions and usage requirements (such as `expose_pin: true` for Zigbee2MQTT)

The description text was also wrapped and the table placed inside markdownlint bypass tags to ensure all pre-commit formatting checks pass cleanly.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests (Documentation update)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
