### PR TITLE
fix(lock): persist lock and door notification settings across restarts

### DIFF
--- a/custom_components/keymaster/lock.py
+++ b/custom_components/keymaster/lock.py
@@ -246,6 +246,8 @@ class KeymasterLock:
         self.autolock_enabled = old.autolock_enabled
         self.autolock_min_day = old.autolock_min_day
         self.autolock_min_night = old.autolock_min_night
+        self.lock_notifications = old.lock_notifications
+        self.door_notifications = old.door_notifications
         self.retry_lock = old.retry_lock
         self.pending_retry_lock = old.pending_retry_lock
         if not self.code_slots or not old.code_slots:

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -304,3 +304,44 @@ async def test_update_lock_unsubscribes_old_listeners(hass):
     # The old lock's listeners should be unsubscribed
     mock_unsub.assert_called_once()
     assert len(old_lock.listeners) == 0
+
+
+async def test_update_lock_inherits_notifications(hass):
+    """Test that _update_lock inherits notifications settings from the old lock."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator._rebuild_lock_relationships = AsyncMock()
+    coordinator._update_door_and_lock_state = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+
+    old_lock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_id",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+    )
+    old_lock.number_of_code_slots = 1
+    old_lock.starting_code_slot = 1
+    old_lock.lock_notifications = True
+    old_lock.door_notifications = True
+
+    new_lock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_id",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+    )
+    new_lock.number_of_code_slots = 1
+    new_lock.starting_code_slot = 1
+    # New lock defaults to False
+    assert new_lock.lock_notifications is False
+    assert new_lock.door_notifications is False
+
+    coordinator.kmlocks["entry_id"] = old_lock
+
+    with patch.object(coordinator, "_update_listeners", new=AsyncMock()):
+        await coordinator._update_lock(new_lock)
+
+    # Verify new_lock inherits the values from old_lock
+    assert coordinator.kmlocks["entry_id"].lock_notifications is True
+    assert coordinator.kmlocks["entry_id"].door_notifications is True


### PR DESCRIPTION
# Summary

Fixes the issue where global lock and door notification toggle settings are lost and reset to `False` on Home Assistant restarts or config-entry reloads.

## Proposed change

`KeymasterLock` instances constructed during config-entry setup or restart initialize `lock_notifications` and `door_notifications` to `False` by default. When the coordinator updates the lock via `_update_lock()`, it copies state from the old instance to the new instance using `new.inherit_state_from(old)`. Since `lock_notifications` and `door_notifications` were not included in `inherit_state_from()`, they were reset to `False` and subsequently persisted back to disk as `False`.

This PR copies `lock_notifications` and `door_notifications` from the old to the new instance in `KeymasterLock.inherit_state_from`.

We also added a new test `test_update_lock_inherits_notifications` in `tests/test_coordinator_lifecycle.py` to assert that both notification settings are correctly inherited during lock updates.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #659
- This PR is related to issue:
