### PR TITLE
fix(autolock): honor cancel() during pre-run and cleared-entry races

### DIFF
--- a/custom_components/keymaster/autolock/scheduler.py
+++ b/custom_components/keymaster/autolock/scheduler.py
@@ -46,6 +46,16 @@ class ScheduledFire:
         self._done = False
 
         async def _run(now: dt) -> None:
+            # cancel() may have set `_cancelled` between the underlying
+            # HA TimerHandle being dispatched and this coroutine getting
+            # its first slice of execution. In that window, the unsub
+            # returned by async_call_later is a no-op and `cancel()` sees
+            # `_task is None`, so nothing prevents `_action` from running
+            # unless we check the flag here. Honor the cancel and bail
+            # cleanly instead of invoking the (now stale) action.
+            if self._cancelled:
+                self._done = True
+                return
             self._task = asyncio.current_task()
             try:
                 await self._action(now)

--- a/custom_components/keymaster/autolock/timer.py
+++ b/custom_components/keymaster/autolock/timer.py
@@ -182,8 +182,21 @@ class AutolockTimer:
         delay = (self._entry.end_time - dt_util.utcnow()).total_seconds()
 
         async def fire(now: dt) -> None:
-            assert self._entry is not None
-            await self._fire(now=now, entry=self._entry)
+            # `_entry` can legitimately be None here if cancel() (or a
+            # subsequent start() that awaited store I/O and yielded to a
+            # racing cancel()) cleared it after `_schedule_remaining`
+            # captured `self` but before this callback ran. Bail cleanly
+            # instead of asserting; the cancel path has already handled
+            # store state and lifecycle transitions.
+            entry = self._entry
+            if entry is None:
+                _LOGGER.debug(
+                    "[AutolockTimer] %s: fire callback observed cleared entry;"
+                    " cancel() won the race",
+                    self._timer_id,
+                )
+                return
+            await self._fire(now=now, entry=entry)
 
         self._scheduled = ScheduledFire(self._hass, delay, fire)
 

--- a/tests/autolock/test_scheduler.py
+++ b/tests/autolock/test_scheduler.py
@@ -163,3 +163,42 @@ async def test_negative_delay_clamped_to_zero(hass):
     ) as mock_call_later:
         ScheduledFire(hass, delay=-5, action=action)
         assert mock_call_later.call_args.kwargs["delay"] == 0
+
+
+async def test_cancel_wins_race_when_run_not_yet_started(hass):
+    """Regression for FutureTense/keymaster#671.
+
+    If `cancel()` lands after the underlying HA `TimerHandle` has been
+    dispatched but before `_run` has run its first statement, the
+    returned unsub is a no-op and `cancel()` sees `_task is None` — so
+    nothing on the cancel path prevents `_run` from later invoking the
+    action. `_run` itself must observe `_cancelled` and short-circuit
+    to honor `cancel()`'s contract ("no further action firing can
+    happen after cancel() returns").
+    """
+    fired = False
+
+    async def action(now: dt) -> None:
+        nonlocal fired
+        fired = True
+
+    with patch(
+        "custom_components.keymaster.autolock.scheduler.async_call_later"
+    ) as mock_call_later:
+        # Model the "TimerHandle already fired" state: unsub is a no-op
+        # because the handle has already been picked up for execution.
+        mock_call_later.return_value = lambda: None
+        scheduled = ScheduledFire(hass, delay=10, action=action)
+        captured_run = mock_call_later.call_args.kwargs["action"]
+
+    # cancel() runs first; `_task` is still None because `_run` hasn't
+    # executed yet. The pre-fix code would return here with no other
+    # guard in place, letting the stale `_run` fire the action next.
+    await scheduled.cancel()
+    assert scheduled.cancelled
+
+    # Now `_run` finally gets its turn. It must observe `_cancelled`
+    # and skip `_action`.
+    await captured_run(dt_util.utcnow())
+    assert not fired, "action must not fire after cancel() has returned"
+    assert scheduled.done

--- a/tests/autolock/test_timer.py
+++ b/tests/autolock/test_timer.py
@@ -268,6 +268,41 @@ async def test_cancel_awaits_in_flight_action(hass, store, kmlock):
     await cleanup()
 
 
+async def test_fire_closure_bails_when_entry_cleared_race(hass, store, kmlock):
+    """Regression for FutureTense/keymaster#671.
+
+    Belt-and-suspenders companion to the scheduler-level short-circuit:
+    if `_entry` is None by the time the `fire` closure runs (because
+    cancel() won a race and cleared it), the closure must return
+    cleanly instead of raising AssertionError.
+
+    Directly exercises the closure so the guard is covered even in
+    scenarios where the scheduler-level `_cancelled` check hasn't been
+    reached (e.g. reload/replace paths that null `_entry` without going
+    through `ScheduledFire.cancel`).
+    """
+    timer, action, _, cleanup = make_timer(hass, store, kmlock=kmlock)
+    await timer.recover()
+
+    with patch(
+        "custom_components.keymaster.autolock.scheduler.async_call_later"
+    ) as mock_call_later:
+        await timer.start(duration=300)
+        fire_closure = mock_call_later.call_args.kwargs["action"]
+
+    # Simulate a racing cancel(): clear the entry the closure captured
+    # `self` for, without also flipping `_cancelled` on the scheduler
+    # (so the scheduler-level guard cannot help).
+    timer._entry = None
+
+    # Invoking the raw `_run` wrapper (which is what async_call_later
+    # would eventually schedule) must not raise AssertionError.
+    await fire_closure(dt_util.utcnow())
+    action.assert_not_called()
+
+    await cleanup()
+
+
 async def test_action_failure_preserves_entry_for_replay(hass, store, kmlock):
     """Preserve store entry on action failure for replay on next restart.
 


### PR DESCRIPTION
Fixes #671

## Summary

`AutolockTimer` raises `AssertionError` at `timer.py:185` when `cancel()` interleaves with an `async_call_later` dispatch. The module docstring in `timer.py` declares:

> cancel() awaits any in-flight callback before returning. After cancel() returns, no further action firing can happen.

...but the implementation had two windows where that invariant could be violated in practice, producing repeated tracebacks (192 occurrences over ~2 weeks on the reporter's install) plus follow-up "Task exception was never retrieved" warnings at task GC.

## Root cause

**Window 1 — scheduler-level.** `ScheduledFire.cancel()` sets `_cancelled=True` and calls `_unsub()`, but if the underlying HA `TimerHandle` has already fired at the loop level, that unsub is a no-op. If `cancel()` arrives before `_run` executes its first line (`self._task = asyncio.current_task()`), `cancel()` reads `_task` as `None`, returns without awaiting anything, and `_run` still invokes `_action` after `cancel()` has returned.

**Window 2 — timer-level.** Even when the scheduler cancel is observed correctly, the `fire` closure in `_schedule_remaining` hard-asserts `self._entry is not None`. `_entry` can legitimately be `None` by the time `fire` runs — e.g. a `start()` that awaited `store.write()` yielded to a racing `cancel()` that cleared `_entry`, or a reload path that swapped state without going through `ScheduledFire.cancel`. The assert then crashes the task.

## Fix

Two minimal defensive guards that restore the documented invariant:

- **`scheduler.py::_run`** — short-circuit if `_cancelled` is already set before running the action. Closes window 1 directly.
- **`timer.py::_schedule_remaining.fire`** — replace the assert with a debug-logged bail. `_fire` (with the store cleanup + state transitions) does not need to run if `_entry` has already been cleared; the cancel path has already handled those transitions. Belt-and-suspenders defense against any future code path that clears `_entry` without going through `ScheduledFire.cancel`.

## Regression tests

- `tests/autolock/test_scheduler.py::test_cancel_wins_race_when_run_not_yet_started` — models the "`TimerHandle` already fired, unsub is a no-op" state, cancels, then invokes the captured `_run`; asserts the action never fires and `scheduled.done` is set.
- `tests/autolock/test_timer.py::test_fire_closure_bails_when_entry_cleared_race` — clears `_entry` without touching `_cancelled` on the scheduler (bypassing the scheduler-level guard) and directly invokes the captured callback; asserts no `AssertionError` and no action call.

Both existing tests (`test_cancel_before_fire_prevents_action`, `test_cancel_awaits_in_flight_action`, `test_cancel_is_idempotent`, `test_cancel_swallows_action_exception`, `test_cancel_swallows_in_flight_cancelled_error`) exercise paths where `_task` gets set before `cancel()` reads it, so their behavior is unchanged by the `_cancelled` short-circuit — they still pass through `_run`'s existing flow.

## Notes

- Diff is 99 lines total across 4 files (+2 changes to production code, +2 new tests).
- No public API changes; no behavior change on any path that was previously succeeding.
- I don't have a Windows-ARM64 build toolchain to run the HA test suite locally (numpy/grpcio/cryptography have no ARM64 wheels for Python 3.14 on Windows and would need MSVC to build). CI should confirm.
