### PR TITLE
fix(providers/zwave_js): fix stale sensor check attributing RF events to previous slot

### DIFF
--- a/custom_components/keymaster/providers/zwave_js.py
+++ b/custom_components/keymaster/providers/zwave_js.py
@@ -1036,6 +1036,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
             sensor_is_stale = (
                 alarm_level_state is not None
                 and alarm_type_state is not None
+                and alarm_type_state.last_changed is not None
                 and new_state
                 and dt_util.utcnow() - dt_util.as_utc(alarm_type_state.last_changed)
                 > timedelta(seconds=5)

--- a/custom_components/keymaster/providers/zwave_js.py
+++ b/custom_components/keymaster/providers/zwave_js.py
@@ -1037,7 +1037,6 @@ class ZWaveJSLockProvider(BaseLockProvider):
                 alarm_level_state is not None
                 and alarm_type_state is not None
                 and new_state
-                and int(alarm_level_state.state) == 0
                 and dt_util.utcnow() - dt_util.as_utc(alarm_type_state.last_changed)
                 > timedelta(seconds=5)
             )


### PR DESCRIPTION
# Summary

When a user locks or unlocks their lock via Home Assistant (which triggers an RF lock/unlock operation), the "last used code slot" sensor for a previously used keypad user code slot (such as Slot 2) was getting incorrectly updated.

This was caused by the `sensor_is_stale` check in the fallback Z-Wave JS `handle_lock_state_change` method checking for `int(alarm_level_state.state) == 0`. When a non-zero code slot was the last keypad code used (so the alarm level sensor state remained non-zero), this check would always evaluate to `False` even if the sensor values had not updated in hours or days. This resulted in the integration attributing the new RF event to that previous slot number. Additionally, it could cause casting crashes if the sensor state was `unknown` or `unavailable`.

Removing `and int(alarm_level_state.state) == 0` ensures that when sensors have not changed in >5 seconds, they are correctly marked as stale, and the event is correctly classified as a generic/RF Lock/Unlock (slot `0`) instead of being credited to a stale slot.

## Proposed change

This PR removes the `and int(alarm_level_state.state) == 0` clause from `sensor_is_stale` in `custom_components/keymaster/providers/zwave_js.py`. When a lock state change occurs, if the sensors are older than 5 seconds, they will be considered stale and overridden with the expected values matching the lock's new state.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #673
- This PR is related to issue:
