### PR TITLE
Chore: Raise Home Assistant minimum version to 2026.7.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
   "name": "keymaster",
   "zip_release": true,
   "filename": "keymaster.zip",
-  "homeassistant": "2026.4.0",
+  "homeassistant": "2026.7.0",
   "persistent_directory": "json_kmlocks"
 }


### PR DESCRIPTION
Part of #670
Closes #678

## What

Raises the declared minimum Home Assistant version to **2026.7.0** in `hacs.json` (was 2026.4.0). 2026.7.0 introduced the event-bus nested-dispatch guard (`_MAX_QUEUED_EVENT_DISPATCHES`) that the #670 fix set targets; pinning the floor there keeps the guard-regression tests and behavior aligned with one HA baseline.

## Notes

- Metadata only; no code/behavior change.
- `hacs.json` is the only place the floor is declared (manifest/requirements/docs carry no HA floor).
- The `homeassistant` test requirement stays intentionally unpinned (CI uses latest, which is >= 2026.7).
