### PR TITLE
Fix: Warn about very large Keymaster lock configurations

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -47,12 +47,19 @@ from .const import (
     DEFAULT_REDACT_PIN_CODES,
     DEFAULT_REDACT_SLOT_NAMES,
     DOMAIN,
-    NONE_TEXT,
+    NORMALIZED_TO_NONE_SENTINELS,
     PLATFORMS,
     STRATEGY_FILENAME,
     STRATEGY_PATH,
 )
 from .coordinator import KeymasterCoordinator
+from .helpers import (
+    async_clear_large_lock_ack,
+    async_delete_large_lock_repair_issue,
+    async_load_large_lock_ack_store,
+    async_update_all_large_lock_repair_issues,
+    async_update_large_lock_repair_issue,
+)
 from .lock import KeymasterCodeSlot, KeymasterCodeSlotDayOfWeek, KeymasterLock
 from .lovelace import async_generate_lovelace
 from .migrate import migrate_2to3
@@ -62,6 +69,7 @@ from .websocket import async_setup as async_websocket_setup
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+_LARGE_LOCK_REPAIR_SWEEP_DONE = "large_lock_repair_sweep_done"
 
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
@@ -99,11 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
         CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
     ):
-        if config_entry.data.get(prop) in {
-            NONE_TEXT,
-            "sensor.fake",
-            "binary_sensor.fake",
-        }:
+        if config_entry.data.get(prop) in NORMALIZED_TO_NONE_SENTINELS:
             updated_config[prop] = None
 
     if config_entry.data.get(CONF_PARENT_ENTRY_ID) == config_entry.entry_id:
@@ -221,6 +225,29 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     except asyncio.exceptions.CancelledError as e:
         _LOGGER.error("Timeout on add_lock. %s: %s", e.__class__.__qualname__, e)
 
+    try:
+        await async_load_large_lock_ack_store(hass)
+        supports_connection_status = True
+        if kmlock.provider:
+            supports_connection_status = kmlock.provider.supports_connection_status
+        await async_update_large_lock_repair_issue(
+            hass,
+            config_entry,
+            supports_connection_status=supports_connection_status,
+        )
+    except Exception:
+        _LOGGER.exception(
+            "Failed to update large-lock repair issue for %s",
+            config_entry.entry_id,
+        )
+
+    if not hass.data[DOMAIN].get(_LARGE_LOCK_REPAIR_SWEEP_DONE):
+        hass.data[DOMAIN][_LARGE_LOCK_REPAIR_SWEEP_DONE] = True
+        try:
+            await async_update_all_large_lock_repair_issues(hass)
+        except Exception:
+            _LOGGER.exception("Failed to update large-lock repair issues during setup sweep")
+
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     await async_generate_lovelace(
         hass=hass,
@@ -267,6 +294,15 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
             if kmlock.provider:
                 await kmlock.provider.async_unload()
 
+    if config_entry.disabled_by is not None:
+        try:
+            async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
+        except Exception:
+            _LOGGER.exception(
+                "Failed to delete large-lock repair issue for disabled entry %s",
+                config_entry.entry_id,
+            )
+
     # Clean up strategy resource if no other keymaster entries need it
     remaining_entries = [
         entry
@@ -285,6 +321,15 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
 async def async_remove_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Handle removal of an entry."""
+    try:
+        async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
+        await async_clear_large_lock_ack(hass, config_entry.entry_id)
+    except Exception:
+        _LOGGER.exception(
+            "Failed to clean up large-lock repair state for %s",
+            config_entry.entry_id,
+        )
+
     if DOMAIN in hass.data and COORDINATOR in hass.data[DOMAIN]:
         coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
         await coordinator.delete_lock_by_config_entry_id(config_entry.entry_id, immediate=True)

--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -43,6 +43,7 @@ from .const import (
     NONE_TEXT,
 )
 from .coordinator import KeymasterCoordinator
+from .helpers import async_update_large_lock_repair_issue
 from .providers import is_platform_supported
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -408,6 +409,13 @@ async def _start_config_flow(
                 return cls.async_create_entry(title=title, data=user_input)
             if cls._entry is not None:
                 cls.hass.config_entries.async_update_entry(cls._entry, data=user_input)
+                try:
+                    await async_update_large_lock_repair_issue(cls.hass, cls._entry, user_input)
+                except Exception:
+                    _LOGGER.exception(
+                        "Failed to update large-lock repair issue for %s",
+                        cls._entry.entry_id,
+                    )
                 return cls.async_abort(reason="reconfigure_successful")
 
     data_schema = _get_schema(

--- a/custom_components/keymaster/const.py
+++ b/custom_components/keymaster/const.py
@@ -31,6 +31,11 @@ ENTITY_DEBOUNCE_SECONDS: int = 5
 BACKOFF_INITIAL_SECONDS: int = 60
 BACKOFF_MAX_SECONDS: int = 1800  # 30 minutes
 BACKOFF_FAILURE_THRESHOLD: int = 3  # consecutive failures before backoff
+LARGE_LOCK_WARNING_THRESHOLD = 8000
+LARGE_LOCK_CRITICAL_THRESHOLD = 9500
+LARGE_LOCK_EVENT_GUARD_LIMIT = 10000
+LARGE_LOCK_ACK_STORE_KEY = "keymaster_large_lock_ack"
+LARGE_LOCK_ACK_STORE_VERSION = 1
 
 # hass.data attributes
 CHILD_LOCKS = "child_locks"
@@ -90,6 +95,10 @@ DEFAULT_AUTOLOCK_MIN_DAY: int = 120
 DEFAULT_AUTOLOCK_MIN_NIGHT: int = 15
 
 NONE_TEXT = "(none)"
+# Placeholder sentinel values keymaster stores for optional entity fields.
+# async_setup_entry normalizes these to None before platforms load, so projection
+# treats them as unset to match generated entities.
+NORMALIZED_TO_NONE_SENTINELS = (NONE_TEXT, "sensor.fake", "binary_sensor.fake")
 
 SERVICE_UPDATE_PIN = "update_pin"
 SERVICE_CLEAR_PIN = "clear_pin"

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -2,25 +2,51 @@
 
 from __future__ import annotations
 
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 import logging
 import time
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import persistent_notification
 from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
+from homeassistant.config_entries import SOURCE_IGNORE, ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceNotFound
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers.storage import Store
 from homeassistant.util import slugify
 
-from .const import DOMAIN
+from .const import (
+    CONF_ADVANCED_DATE_RANGE,
+    CONF_ADVANCED_DAY_OF_WEEK,
+    CONF_DOOR_SENSOR_ENTITY_ID,
+    CONF_LOCK_NAME,
+    CONF_PARENT,
+    CONF_PARENT_ENTRY_ID,
+    CONF_SLOTS,
+    COORDINATOR,
+    DAY_NAMES,
+    DOMAIN,
+    LARGE_LOCK_ACK_STORE_KEY,
+    LARGE_LOCK_ACK_STORE_VERSION,
+    LARGE_LOCK_CRITICAL_THRESHOLD,
+    LARGE_LOCK_EVENT_GUARD_LIMIT,
+    LARGE_LOCK_WARNING_THRESHOLD,
+    NONE_TEXT,
+    NORMALIZED_TO_NONE_SENTINELS,
+)
 from .providers import is_platform_supported
 
 if TYPE_CHECKING:
     from .lock import KeymasterLock
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+LARGE_LOCK_ENTITY_WARNING_THRESHOLD = LARGE_LOCK_WARNING_THRESHOLD
+LARGE_LOCK_REPAIR_TRANSLATION_KEY = "large_lock_configuration"
+LARGE_LOCK_ACK_STORE = "large_lock_ack_store"
+LARGE_LOCK_ACK_DATA = "large_lock_ack_data"
+_LARGE_LOCK_REPAIR_ISSUE_ID_PREFIX = "large_lock_configuration"
 
 
 class Throttle:
@@ -46,6 +72,222 @@ class Throttle:
         """Clear the cooldown for a function/key so the next call is allowed."""
         if func_name in self._cooldowns:
             self._cooldowns[func_name].pop(key, None)
+
+
+def large_lock_repair_issue_id(config_entry_id: str) -> str:
+    """Return the repair issue ID for a config entry."""
+    return f"{_LARGE_LOCK_REPAIR_ISSUE_ID_PREFIX}_{config_entry_id}"
+
+
+def projected_lock_entity_count(
+    config: Mapping[str, Any],
+    *,
+    is_child: bool | None = None,
+    has_door_sensor: bool | None = None,
+    supports_connection_status: bool = True,
+) -> int:
+    """Return the projected number of entities generated for one Keymaster lock."""
+    slots = int(config.get(CONF_SLOTS, 0))
+    if slots < 1:
+        return 0
+
+    if is_child is None:
+        is_child = _has_value(config.get(CONF_PARENT)) or _has_value(
+            config.get(CONF_PARENT_ENTRY_ID)
+        )
+    if has_door_sensor is None:
+        # async_setup_entry normalizes these door-sensor sentinel values to
+        # None before platforms load, so switch.py does not create door switches
+        # for them. Mirror that post-normalization behavior here.
+        has_door_sensor = config.get(CONF_DOOR_SENSOR_ENTITY_ID) not in (
+            None,
+            *NORMALIZED_TO_NONE_SENTINELS,
+        )
+
+    advanced_date_range = bool(config.get(CONF_ADVANCED_DATE_RANGE, True))
+    advanced_day_of_week = bool(config.get(CONF_ADVANCED_DAY_OF_WEEK, True))
+    days = len(DAY_NAMES)
+
+    binary_sensor_count = slots + (1 if supports_connection_status else 0)
+    button_count = slots + 1
+    datetime_count = 2 * slots if advanced_date_range else 0
+    event_count = slots
+    number_count = slots + 2
+    sensor_count = slots + 2 + (1 if is_child else 0)
+    switch_count = 2 + (2 if has_door_sensor else 0)
+    switch_count += slots * (3 + (1 if is_child else 0))
+    if advanced_date_range:
+        switch_count += slots
+    if advanced_day_of_week:
+        switch_count += slots * (1 + (3 * days))
+    text_count = 2 * slots
+    time_count = 2 * slots * days if advanced_day_of_week else 0
+
+    return (
+        binary_sensor_count
+        + button_count
+        + datetime_count
+        + event_count
+        + number_count
+        + sensor_count
+        + switch_count
+        + text_count
+        + time_count
+    )
+
+
+async def async_update_large_lock_repair_issue(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    config: Mapping[str, Any] | None = None,
+    *,
+    supports_connection_status: bool | None = None,
+) -> int:
+    """Create or clear the large-lock repair issue for one config entry."""
+    entry_config = config_entry.data if config is None else config
+    if supports_connection_status is None:
+        supports_connection_status = _supports_connection_status(hass, config_entry.entry_id)
+    entity_count = projected_lock_entity_count(
+        entry_config,
+        supports_connection_status=supports_connection_status,
+    )
+    issue_id = large_lock_repair_issue_id(config_entry.entry_id)
+
+    if entity_count < LARGE_LOCK_WARNING_THRESHOLD:
+        async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
+        await async_clear_large_lock_ack(hass, config_entry.entry_id)
+        return entity_count
+
+    ack_count = await async_get_large_lock_ack(hass, config_entry.entry_id)
+    if entity_count < LARGE_LOCK_CRITICAL_THRESHOLD and ack_count is not None:
+        # Acknowledged warning-band locks stay dismissed; ensure no active issue remains.
+        async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
+        return entity_count
+
+    if entity_count >= LARGE_LOCK_CRITICAL_THRESHOLD and ack_count is not None:
+        await async_clear_large_lock_ack(hass, config_entry.entry_id)
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=LARGE_LOCK_REPAIR_TRANSLATION_KEY,
+        translation_placeholders={
+            "lock_name": str(entry_config.get(CONF_LOCK_NAME, config_entry.title)),
+            "entity_count": str(entity_count),
+            "threshold": str(LARGE_LOCK_WARNING_THRESHOLD),
+            "guard_limit": str(LARGE_LOCK_EVENT_GUARD_LIMIT),
+        },
+        data={
+            "entry_id": config_entry.entry_id,
+            "projected": entity_count,
+        },
+    )
+    return entity_count
+
+
+async def async_update_all_large_lock_repair_issues(hass: HomeAssistant) -> None:
+    """Create or clear large-lock repair issues for all Keymaster config entries."""
+    for config_entry in hass.config_entries.async_entries(DOMAIN):
+        try:
+            if not _entry_is_generating_entities(config_entry):
+                async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
+                continue
+            await async_update_large_lock_repair_issue(
+                hass,
+                config_entry,
+                supports_connection_status=_supports_connection_status(hass, config_entry.entry_id),
+            )
+        except Exception:
+            _LOGGER.exception(
+                "Failed to update large-lock repair issue for %s",
+                config_entry.entry_id,
+            )
+
+
+@callback
+def async_delete_large_lock_repair_issue(hass: HomeAssistant, config_entry_id: str) -> None:
+    """Delete the large-lock repair issue for a removed config entry."""
+    issue_id = large_lock_repair_issue_id(config_entry_id)
+    issue_registry = ir.async_get(hass)
+    if issue_registry.async_get_issue(DOMAIN, issue_id):
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+
+async def async_load_large_lock_ack_store(hass: HomeAssistant) -> dict[str, int]:
+    """Load the large-lock acknowledgement store."""
+    hass_data = hass.data.setdefault(DOMAIN, {})
+    if LARGE_LOCK_ACK_DATA in hass_data:
+        return hass_data[LARGE_LOCK_ACK_DATA]
+
+    store: Store[dict[str, int]] = Store(
+        hass,
+        LARGE_LOCK_ACK_STORE_VERSION,
+        LARGE_LOCK_ACK_STORE_KEY,
+    )
+    stored_data = await store.async_load()
+    ack_data = {
+        str(entry_id): int(projected) for entry_id, projected in (stored_data or {}).items()
+    }
+    hass_data[LARGE_LOCK_ACK_STORE] = store
+    hass_data[LARGE_LOCK_ACK_DATA] = ack_data
+    return ack_data
+
+
+async def async_get_large_lock_ack(hass: HomeAssistant, entry_id: str) -> int | None:
+    """Return the acknowledged projected count for an entry."""
+    ack_data = await async_load_large_lock_ack_store(hass)
+    return ack_data.get(entry_id)
+
+
+async def async_set_large_lock_ack(hass: HomeAssistant, entry_id: str, count: int) -> None:
+    """Store a large-lock acknowledgement for an entry."""
+    ack_data = await async_load_large_lock_ack_store(hass)
+    ack_data[entry_id] = count
+    store: Store[dict[str, int]] = hass.data[DOMAIN][LARGE_LOCK_ACK_STORE]
+    await store.async_save(ack_data)
+
+
+async def async_clear_large_lock_ack(hass: HomeAssistant, entry_id: str) -> None:
+    """Clear the large-lock acknowledgement for an entry."""
+    ack_data = await async_load_large_lock_ack_store(hass)
+    if entry_id not in ack_data:
+        return
+    ack_data.pop(entry_id)
+    store: Store[dict[str, int]] = hass.data[DOMAIN][LARGE_LOCK_ACK_STORE]
+    await store.async_save(ack_data)
+
+
+def _has_value(value: Any) -> bool:
+    """Return whether a config value represents a selected entity or parent."""
+    return value not in (None, "", NONE_TEXT)
+
+
+def _get_kmlock_for_entry(hass: HomeAssistant, entry_id: str) -> KeymasterLock | None:
+    """Return the loaded lock for a config entry if the coordinator exists."""
+    coordinator = hass.data.get(DOMAIN, {}).get(COORDINATOR)
+    if coordinator is None:
+        return None
+    return coordinator.sync_get_lock_by_config_entry_id(entry_id)
+
+
+def _entry_is_generating_entities(config_entry: ConfigEntry) -> bool:
+    """Return whether an entry is active and expected to generate Keymaster entities."""
+    return (
+        config_entry.disabled_by is None
+        and config_entry.source != SOURCE_IGNORE
+        and config_entry.state in {ConfigEntryState.LOADED, ConfigEntryState.SETUP_IN_PROGRESS}
+    )
+
+
+def _supports_connection_status(hass: HomeAssistant, entry_id: str) -> bool:
+    """Return whether the loaded provider will create a connection-status binary sensor."""
+    kmlock = _get_kmlock_for_entry(hass, entry_id)
+    if kmlock and kmlock.provider:
+        return kmlock.provider.supports_connection_status
+    return True
 
 
 @callback

--- a/custom_components/keymaster/repairs.py
+++ b/custom_components/keymaster/repairs.py
@@ -1,0 +1,81 @@
+"""Repairs flows for keymaster."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+
+from .const import DOMAIN, LARGE_LOCK_WARNING_THRESHOLD
+from .helpers import (
+    _supports_connection_status,
+    async_set_large_lock_ack,
+    projected_lock_entity_count,
+)
+
+
+class LargeLockConfigurationRepairFlow(RepairsFlow):
+    """Acknowledge a very large Keymaster lock configuration."""
+
+    def __init__(self, issue_id: str, data: dict[str, Any]) -> None:
+        """Initialize the repair flow."""
+        self._issue_id = issue_id
+        self._data = data
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the initial step."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the acknowledgement confirmation."""
+        if user_input is not None:
+            entry_id = self._data.get("entry_id")
+            if entry_id is None:
+                ir.async_delete_issue(self.hass, DOMAIN, self._issue_id)
+                return self.async_abort(reason="missing_issue_data")
+
+            entry_id = str(entry_id)
+            config_entry = self.hass.config_entries.async_get_entry(entry_id)
+            if config_entry is None:
+                ir.async_delete_issue(self.hass, DOMAIN, self._issue_id)
+                return self.async_abort(reason="entry_not_found")
+
+            projected = projected_lock_entity_count(
+                config_entry.data,
+                supports_connection_status=_supports_connection_status(self.hass, entry_id),
+            )
+            if projected >= LARGE_LOCK_WARNING_THRESHOLD:
+                await async_set_large_lock_ack(self.hass, entry_id, projected)
+            return self.async_create_entry(title="", data={})
+
+        issue_registry = ir.async_get(self.hass)
+        description_placeholders = None
+        if issue := issue_registry.async_get_issue(DOMAIN, self._issue_id):
+            description_placeholders = issue.translation_placeholders
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders=description_placeholders,
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create a repairs flow for a Keymaster issue."""
+    del hass
+    if data is None:
+        data = {}
+    return LargeLockConfigurationRepairFlow(issue_id, data)

--- a/custom_components/keymaster/strings.json
+++ b/custom_components/keymaster/strings.json
@@ -60,5 +60,18 @@
         }
       }
     }
+  },
+  "issues": {
+    "large_lock_configuration": {
+      "title": "Very large Keymaster lock configuration",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Acknowledge very large Keymaster lock: {lock_name}",
+            "description": "The Keymaster lock \"{lock_name}\" is projected to create about {entity_count} entities, approaching Home Assistant's per-dispatch event limit of {guard_limit} (warning threshold {threshold}). Reducing slots or splitting this configuration can help now; planned per-lock improvements tracked in issue #670 will reduce this dispatch risk. Acknowledging confirms you understand the risk of instability and want to dismiss this warning for the current projected size. It will reappear if the configuration grows materially larger."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/keymaster/translations/en.json
+++ b/custom_components/keymaster/translations/en.json
@@ -61,5 +61,18 @@
         }
       }
     }
+  },
+  "issues": {
+    "large_lock_configuration": {
+      "title": "Very large Keymaster lock configuration",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Acknowledge very large Keymaster lock: {lock_name}",
+            "description": "The Keymaster lock \"{lock_name}\" is projected to create about {entity_count} entities, approaching Home Assistant's per-dispatch event limit of {guard_limit} (warning threshold {threshold}). Reducing slots or splitting this configuration can help now; planned per-lock improvements tracked in issue #670 will reduce this dispatch risk. Acknowledging confirms you understand the risk of instability and want to dismiss this warning for the current projected size. It will reappear if the configuration grows materially larger."
+          }
+        }
+      }
+    }
   }
 }

--- a/tests/test_large_lock_repairs.py
+++ b/tests/test_large_lock_repairs.py
@@ -1,0 +1,1093 @@
+"""Test large lock repair helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+import logging
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.keymaster import async_remove_entry, async_setup_entry, async_unload_entry
+from custom_components.keymaster.const import (
+    CONF_ADVANCED_DATE_RANGE,
+    CONF_ADVANCED_DAY_OF_WEEK,
+    CONF_DOOR_SENSOR_ENTITY_ID,
+    CONF_LOCK_ENTITY_ID,
+    CONF_LOCK_NAME,
+    CONF_PARENT,
+    CONF_SLOTS,
+    COORDINATOR,
+    DOMAIN,
+    LARGE_LOCK_CRITICAL_THRESHOLD,
+    LARGE_LOCK_WARNING_THRESHOLD,
+    NONE_TEXT,
+)
+from custom_components.keymaster.helpers import (
+    LARGE_LOCK_ENTITY_WARNING_THRESHOLD,
+    _supports_connection_status,
+    async_clear_large_lock_ack,
+    async_get_large_lock_ack,
+    async_set_large_lock_ack,
+    async_update_all_large_lock_repair_issues,
+    async_update_large_lock_repair_issue,
+    large_lock_repair_issue_id,
+    projected_lock_entity_count,
+)
+from custom_components.keymaster.lock import KeymasterLock
+from custom_components.keymaster.repairs import (
+    LargeLockConfigurationRepairFlow,
+    async_create_fix_flow,
+)
+from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import issue_registry as ir
+
+from .const import CONFIG_DATA
+
+pytestmark = pytest.mark.asyncio
+
+
+def _config(slots: int, **overrides: Any) -> dict[str, Any]:
+    """Return test config data with a configurable slot count."""
+    config = CONFIG_DATA.copy()
+    config.update(
+        {
+            CONF_ADVANCED_DATE_RANGE: True,
+            CONF_ADVANCED_DAY_OF_WEEK: False,
+            CONF_SLOTS: slots,
+        }
+    )
+    config.update(overrides)
+    return config
+
+
+def _issue(hass: Any, entry_id: str) -> ir.IssueEntry | None:
+    """Return a large-lock issue registry entry."""
+    return ir.async_get(hass).async_get_issue(DOMAIN, large_lock_repair_issue_id(entry_id))
+
+
+def _create_test_issue(hass: Any, issue_id: str) -> None:
+    """Create a large-lock issue for direct repair flow tests."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="large_lock_configuration",
+    )
+
+
+async def _manual_fix_flow(
+    hass: Any,
+    data: dict[str, Any] | None,
+    issue_id: str = "large_lock_configuration_entry",
+) -> LargeLockConfigurationRepairFlow:
+    """Return a manually initialized large-lock repairs flow."""
+    flow = LargeLockConfigurationRepairFlow(issue_id, data or {})
+    flow.hass = hass
+    flow.handler = DOMAIN
+    flow.flow_id = "large-lock-test-flow"
+    flow.context = {}
+    return flow
+
+
+@contextmanager
+def _setup_patches() -> Iterator[None]:
+    """Patch coordinator calls that would otherwise require a real lock provider."""
+    with (
+        patch(
+            "custom_components.keymaster.KeymasterCoordinator._connect_and_update_lock",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.keymaster.KeymasterCoordinator._update_lock_data",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.keymaster.KeymasterCoordinator._sync_child_locks",
+            return_value=True,
+        ),
+    ):
+        yield
+
+
+async def test_projected_lock_entity_count_representative_configs() -> None:
+    """Test projected entity counts match the platform setup loops."""
+    parent_dow_off = _config(70, **{CONF_ADVANCED_DAY_OF_WEEK: False})
+    parent_dow_on = _config(70, **{CONF_ADVANCED_DAY_OF_WEEK: True})
+    child_dow_off = _config(
+        70,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: False,
+            CONF_PARENT: "frontdoor",
+        },
+    )
+    child_dow_on = _config(
+        70,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: True,
+            CONF_PARENT: "frontdoor",
+        },
+    )
+
+    assert projected_lock_entity_count(parent_dow_off) == 920
+    assert projected_lock_entity_count(parent_dow_on) == 3440
+    assert projected_lock_entity_count(child_dow_off) == 991
+    assert projected_lock_entity_count(child_dow_on) == 3511
+    assert projected_lock_entity_count(_config(0)) == 0
+    assert (
+        projected_lock_entity_count(
+            parent_dow_off,
+            has_door_sensor=False,
+            supports_connection_status=False,
+        )
+        == 917
+    )
+
+
+async def test_projected_lock_entity_count_matches_normalized_door_sensor_values() -> None:
+    """Test door switch projection matches values normalized before switch.py loads."""
+    real_door_sensor = _config(
+        70,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: False,
+            CONF_DOOR_SENSOR_ENTITY_ID: "binary_sensor.front_door",
+        },
+    )
+    none_text_door_sensor = _config(
+        70,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: False,
+            CONF_DOOR_SENSOR_ENTITY_ID: NONE_TEXT,
+        },
+    )
+    no_door_sensor = _config(
+        70,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: False,
+            CONF_DOOR_SENSOR_ENTITY_ID: None,
+        },
+    )
+    fake_door_sensor = _config(
+        70,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: False,
+            CONF_DOOR_SENSOR_ENTITY_ID: "binary_sensor.fake",
+        },
+    )
+    fake_sensor_door_sensor = _config(
+        70,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: False,
+            CONF_DOOR_SENSOR_ENTITY_ID: "sensor.fake",
+        },
+    )
+    missing_door_sensor = _config(70, **{CONF_ADVANCED_DAY_OF_WEEK: False})
+    missing_door_sensor.pop(CONF_DOOR_SENSOR_ENTITY_ID)
+
+    assert projected_lock_entity_count(real_door_sensor) == 920
+    assert projected_lock_entity_count(none_text_door_sensor) == 918
+    assert projected_lock_entity_count(no_door_sensor) == 918
+    assert projected_lock_entity_count(fake_door_sensor) == 918
+    assert projected_lock_entity_count(fake_sensor_door_sensor) == 918
+    assert projected_lock_entity_count(missing_door_sensor) == 918
+
+
+async def test_large_lock_repair_issue_created_and_deleted(hass: Any) -> None:
+    """Test large-lock repair issues are created and auto-cleared."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+
+    entity_count = await async_update_large_lock_repair_issue(hass, config_entry)
+
+    assert entity_count >= LARGE_LOCK_ENTITY_WARNING_THRESHOLD
+    issue = _issue(hass, config_entry.entry_id)
+    assert issue is not None
+    assert issue.translation_key == "large_lock_configuration"
+    assert issue.severity is ir.IssueSeverity.WARNING
+    assert issue.is_fixable is True
+
+    entity_count = await async_update_large_lock_repair_issue(
+        hass,
+        config_entry,
+        _config(70, **{CONF_ADVANCED_DAY_OF_WEEK: False}),
+    )
+
+    assert entity_count < LARGE_LOCK_ENTITY_WARNING_THRESHOLD
+    assert _issue(hass, config_entry.entry_id) is None
+
+
+async def test_large_lock_ack_store_helpers(hass: Any) -> None:
+    """Test large-lock acknowledgement store helpers."""
+    assert await async_get_large_lock_ack(hass, "entry") is None
+
+    await async_clear_large_lock_ack(hass, "entry")
+    assert await async_get_large_lock_ack(hass, "entry") is None
+
+    await async_set_large_lock_ack(hass, "entry", 8123)
+
+    assert await async_get_large_lock_ack(hass, "entry") == 8123
+
+    await async_clear_large_lock_ack(hass, "entry")
+
+    assert await async_get_large_lock_ack(hass, "entry") is None
+
+
+async def test_large_lock_fix_flow_factory_handles_missing_data(hass: Any) -> None:
+    """Test the repairs fix-flow factory handles missing issue data."""
+    flow = await async_create_fix_flow(hass, "large_lock_configuration_entry", None)
+
+    assert isinstance(flow, LargeLockConfigurationRepairFlow)
+
+
+async def test_large_lock_fix_flow_form_includes_issue_placeholders(hass: Any) -> None:
+    """Test the repairs fix flow forwards issue translation placeholders."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    projected = await async_update_large_lock_repair_issue(hass, config_entry)
+    issue = _issue(hass, config_entry.entry_id)
+    assert issue is not None
+
+    flow = await _manual_fix_flow(hass, issue.data, issue.issue_id)
+    result = await flow.async_step_init()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["description_placeholders"] == {
+        "lock_name": "frontdoor",
+        "entity_count": str(projected),
+        "threshold": "8000",
+        "guard_limit": "10000",
+    }
+
+
+async def test_large_lock_fix_flow_acknowledges_current_projected_count(hass: Any) -> None:
+    """Test the repairs fix flow records current acknowledgement."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    projected = await async_update_large_lock_repair_issue(hass, config_entry)
+    issue = _issue(hass, config_entry.entry_id)
+    assert issue is not None
+    current_config = _config(171, **{CONF_ADVANCED_DAY_OF_WEEK: True})
+    current_projected = projected_lock_entity_count(current_config)
+    assert current_projected != projected
+    hass.config_entries.async_update_entry(config_entry, data=current_config)
+
+    flow = await _manual_fix_flow(hass, issue.data, issue.issue_id)
+    result = await flow.async_step_init()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    # In production HA's repairs flow manager resolves the issue on CREATE_ENTRY.
+    assert await async_get_large_lock_ack(hass, config_entry.entry_id) == current_projected
+
+
+@pytest.mark.parametrize("data", [None, {}, {"entry_id": None}, {"projected": 9000}])
+async def test_large_lock_fix_flow_aborts_without_entry_id(
+    hass: Any,
+    data: dict[str, Any] | None,
+) -> None:
+    """Test fix flow confirm gracefully aborts when issue data lacks an entry id."""
+    issue_id = "large_lock_configuration_entry"
+    _create_test_issue(hass, issue_id)
+    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is not None
+    flow = await _manual_fix_flow(hass, data, issue_id)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "missing_issue_data"
+    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None
+    assert await async_get_large_lock_ack(hass, "None") is None
+    assert await async_get_large_lock_ack(hass, "missing") is None
+
+
+async def test_large_lock_fix_flow_aborts_for_removed_config_entry(hass: Any) -> None:
+    """Test fix flow confirm gracefully aborts when the config entry was removed."""
+    issue_id = "large_lock_configuration_removed_entry"
+    _create_test_issue(hass, issue_id)
+    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is not None
+    flow = await _manual_fix_flow(
+        hass,
+        {
+            "entry_id": "removed-entry",
+            "projected": LARGE_LOCK_WARNING_THRESHOLD,
+        },
+        issue_id,
+    )
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_not_found"
+    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None
+    assert await async_get_large_lock_ack(hass, "removed-entry") is None
+
+
+async def test_large_lock_fix_flow_does_not_ack_stale_below_warning_flow(
+    hass: Any,
+) -> None:
+    """Test a stale open fix flow cannot resurrect an ack below the warning threshold."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    await async_update_large_lock_repair_issue(hass, config_entry)
+    issue = _issue(hass, config_entry.entry_id)
+    assert issue is not None
+    flow = await _manual_fix_flow(hass, issue.data, issue.issue_id)
+    result = await flow.async_step_init()
+    assert result["type"] is FlowResultType.FORM
+
+    small_config = _config(70, **{CONF_ADVANCED_DAY_OF_WEEK: False})
+    hass.config_entries.async_update_entry(config_entry, data=small_config)
+    await async_set_large_lock_ack(hass, config_entry.entry_id, LARGE_LOCK_WARNING_THRESHOLD)
+    await async_update_large_lock_repair_issue(hass, config_entry)
+    assert _issue(hass, config_entry.entry_id) is None
+    assert await async_get_large_lock_ack(hass, config_entry.entry_id) is None
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert await async_get_large_lock_ack(hass, config_entry.entry_id) is None
+
+
+async def test_acknowledged_warning_stays_dismissed_until_critical(hass: Any) -> None:
+    """Test acknowledged warning reappears only when projected count reaches critical."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    projected = projected_lock_entity_count(config_entry.data)
+    assert LARGE_LOCK_WARNING_THRESHOLD <= projected < LARGE_LOCK_CRITICAL_THRESHOLD
+    await async_set_large_lock_ack(hass, config_entry.entry_id, projected)
+
+    entity_count = await async_update_large_lock_repair_issue(hass, config_entry)
+
+    assert entity_count == projected
+    assert _issue(hass, config_entry.entry_id) is None
+    assert await async_get_large_lock_ack(hass, config_entry.entry_id) == projected
+
+    critical_config = _config(194, **{CONF_ADVANCED_DAY_OF_WEEK: True})
+    critical_count = projected_lock_entity_count(critical_config)
+    assert critical_count >= LARGE_LOCK_CRITICAL_THRESHOLD
+
+    entity_count = await async_update_large_lock_repair_issue(
+        hass,
+        config_entry,
+        critical_config,
+    )
+
+    assert entity_count == critical_count
+    assert await async_get_large_lock_ack(hass, config_entry.entry_id) is None
+    issue = _issue(hass, config_entry.entry_id)
+    assert issue is not None
+    assert issue.is_fixable is True
+
+
+async def test_large_lock_drop_below_warning_clears_ack_and_future_recross_warns(
+    hass: Any,
+) -> None:
+    """Test dropping below warning clears acknowledgement so recrossing warns again."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    await async_set_large_lock_ack(hass, config_entry.entry_id, 8330)
+    await async_update_large_lock_repair_issue(
+        hass,
+        config_entry,
+        _config(70, **{CONF_ADVANCED_DAY_OF_WEEK: False}),
+    )
+
+    assert _issue(hass, config_entry.entry_id) is None
+    assert await async_get_large_lock_ack(hass, config_entry.entry_id) is None
+
+    await async_update_large_lock_repair_issue(hass, config_entry)
+
+    issue = _issue(hass, config_entry.entry_id)
+    assert issue is not None
+    assert issue.is_fixable is True
+
+
+async def test_large_lock_repair_issue_created_at_exact_threshold(hass: Any) -> None:
+    """Test exactly the warning threshold creates the large-lock repair issue."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(
+            799,
+            **{
+                CONF_ADVANCED_DATE_RANGE: False,
+                CONF_ADVANCED_DAY_OF_WEEK: False,
+            },
+        ),
+        state=ConfigEntryState.LOADED,
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+
+    entity_count = await async_update_large_lock_repair_issue(hass, config_entry)
+
+    assert entity_count == LARGE_LOCK_ENTITY_WARNING_THRESHOLD
+    issue = _issue(hass, config_entry.entry_id)
+    assert issue is not None
+    assert issue.is_fixable is True
+
+
+async def test_remove_entry_clears_large_lock_repair_issue(hass: Any) -> None:
+    """Test entry removal clears its large-lock repair issue."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    await async_update_large_lock_repair_issue(hass, config_entry)
+    await async_set_large_lock_ack(hass, config_entry.entry_id, LARGE_LOCK_WARNING_THRESHOLD)
+
+    await async_remove_entry(hass, config_entry)
+
+    assert _issue(hass, config_entry.entry_id) is None
+    assert await async_get_large_lock_ack(hass, config_entry.entry_id) is None
+
+
+async def test_remove_entry_cleanup_failure_does_not_skip_coordinator_teardown(
+    hass: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test entry removal still tears down coordinator if repair cleanup fails."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    delete_lock = AsyncMock()
+    hass.data.setdefault(DOMAIN, {})[COORDINATOR] = SimpleNamespace(
+        delete_lock_by_config_entry_id=delete_lock,
+        count_locks_not_pending_delete=1,
+    )
+    caplog.set_level(logging.ERROR)
+
+    with patch(
+        "custom_components.keymaster.async_clear_large_lock_ack",
+        new_callable=AsyncMock,
+        side_effect=Exception("ack cleanup failed"),
+    ):
+        await async_remove_entry(hass, config_entry)
+
+    delete_lock.assert_awaited_once_with(config_entry.entry_id, immediate=True)
+    assert "Failed to clean up large-lock repair state" in caplog.text
+
+
+async def test_setup_repair_update_failure_does_not_block_setup(
+    hass: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test setup still succeeds if updating the entry repair issue fails."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(6, **{CONF_ADVANCED_DAY_OF_WEEK: False}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    caplog.set_level(logging.ERROR)
+
+    with (
+        _setup_patches(),
+        patch(
+            "custom_components.keymaster.async_update_large_lock_repair_issue",
+            new_callable=AsyncMock,
+            side_effect=Exception("repair update failed"),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id) is True
+        await hass.async_block_till_done()
+
+    assert "Failed to update large-lock repair issue" in caplog.text
+
+
+async def test_setup_sweep_failure_does_not_block_setup(
+    hass: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test setup still succeeds if the once-per-startup repair sweep fails."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(6, **{CONF_ADVANCED_DAY_OF_WEEK: False}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    caplog.set_level(logging.ERROR)
+
+    with (
+        _setup_patches(),
+        patch(
+            "custom_components.keymaster.async_update_all_large_lock_repair_issues",
+            new_callable=AsyncMock,
+            side_effect=Exception("repair sweep failed"),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id) is True
+        await hass.async_block_till_done()
+
+    assert "Failed to update large-lock repair issues during setup sweep" in caplog.text
+
+
+async def test_setup_uses_loaded_provider_connection_status(hass: Any) -> None:
+    """Test setup repair projection uses a provider already attached to the lock."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(6, **{CONF_ADVANCED_DAY_OF_WEEK: False}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})
+
+    async def add_lock_with_provider(kmlock: KeymasterLock, update: bool = False) -> None:
+        """Attach a provider before setup updates the repair issue."""
+        del update
+        kmlock.provider = cast(Any, SimpleNamespace(supports_connection_status=False))
+
+    fake_coordinator = SimpleNamespace(
+        kmlocks={},
+        add_lock=AsyncMock(side_effect=add_lock_with_provider),
+    )
+    hass.data[DOMAIN][COORDINATOR] = fake_coordinator
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch("custom_components.keymaster.async_update_large_lock_repair_issue") as mock_update,
+        patch(
+            "custom_components.keymaster.async_update_all_large_lock_repair_issues",
+            new_callable=AsyncMock,
+        ),
+        patch.object(hass.config_entries, "async_forward_entry_setups", new_callable=AsyncMock),
+        patch("custom_components.keymaster.async_generate_lovelace", new_callable=AsyncMock),
+    ):
+        assert await async_setup_entry(hass, config_entry) is True
+
+    mock_update.assert_awaited_once()
+    assert mock_update.await_args is not None
+    assert mock_update.await_args.kwargs["supports_connection_status"] is False
+
+
+async def test_setup_continues_when_add_lock_times_out(
+    hass: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test setup still succeeds when adding a lock is cancelled."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(6, **{CONF_ADVANCED_DAY_OF_WEEK: False}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})[COORDINATOR] = SimpleNamespace(
+        kmlocks={},
+        add_lock=AsyncMock(side_effect=asyncio.CancelledError()),
+    )
+    caplog.set_level(logging.ERROR)
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch(
+            "custom_components.keymaster.async_update_large_lock_repair_issue",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.keymaster.async_update_all_large_lock_repair_issues",
+            new_callable=AsyncMock,
+        ),
+        patch.object(hass.config_entries, "async_forward_entry_setups", new_callable=AsyncMock),
+        patch("custom_components.keymaster.async_generate_lovelace", new_callable=AsyncMock),
+    ):
+        assert await async_setup_entry(hass, config_entry) is True
+
+    assert "Timeout on add_lock" in caplog.text
+
+
+async def test_unload_disabled_entry_clears_issue_but_preserves_ack(hass: Any) -> None:
+    """Test unloading a disabled large entry clears its issue but preserves its ack."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+        disabled_by=ConfigEntryDisabler.USER,
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    await async_update_large_lock_repair_issue(hass, config_entry)
+    projected = projected_lock_entity_count(config_entry.data)
+    await async_set_large_lock_ack(hass, config_entry.entry_id, projected)
+
+    with patch.object(hass.config_entries, "async_forward_entry_unload", return_value=True):
+        assert await async_unload_entry(hass, config_entry) is True
+
+    assert _issue(hass, config_entry.entry_id) is None
+    assert await async_get_large_lock_ack(hass, config_entry.entry_id) == projected
+
+    object.__setattr__(config_entry, "disabled_by", None)
+    await async_update_large_lock_repair_issue(hass, config_entry)
+
+    assert _issue(hass, config_entry.entry_id) is None
+    assert await async_get_large_lock_ack(hass, config_entry.entry_id) == projected
+
+
+async def test_unload_disabled_entry_delete_failure_does_not_block_unload(
+    hass: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test disabled entry unload still succeeds if repair issue deletion fails."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+        disabled_by=ConfigEntryDisabler.USER,
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+    caplog.set_level(logging.ERROR)
+
+    with (
+        patch.object(hass.config_entries, "async_forward_entry_unload", return_value=True),
+        patch(
+            "custom_components.keymaster.async_delete_large_lock_repair_issue",
+            side_effect=Exception("repair delete failed"),
+        ),
+    ):
+        assert await async_unload_entry(hass, config_entry) is True
+
+    assert "Failed to delete large-lock repair issue for disabled entry" in caplog.text
+
+
+async def test_setup_sweep_clears_stale_and_inactive_large_lock_issues(hass: Any) -> None:
+    """Test setup sweep clears stale below-threshold and inactive-entry repairs."""
+    stale_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="stale",
+        data=_config(
+            70,
+            **{
+                CONF_ADVANCED_DAY_OF_WEEK: False,
+                CONF_LOCK_ENTITY_ID: "lock.stale",
+                CONF_LOCK_NAME: "stale",
+            },
+        ),
+        state=ConfigEntryState.LOADED,
+        version=4,
+    )
+    disabled_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="disabled",
+        data=_config(
+            170,
+            **{
+                CONF_ADVANCED_DAY_OF_WEEK: True,
+                CONF_LOCK_ENTITY_ID: "lock.disabled",
+                CONF_LOCK_NAME: "disabled",
+            },
+        ),
+        disabled_by=ConfigEntryDisabler.USER,
+        state=ConfigEntryState.NOT_LOADED,
+        version=4,
+    )
+    stale_entry.add_to_hass(hass)
+    disabled_entry.add_to_hass(hass)
+    await async_update_large_lock_repair_issue(
+        hass,
+        stale_entry,
+        _config(170, **{CONF_ADVANCED_DAY_OF_WEEK: True}),
+    )
+    await async_update_large_lock_repair_issue(hass, disabled_entry)
+    disabled_projected = projected_lock_entity_count(disabled_entry.data)
+    await async_set_large_lock_ack(hass, disabled_entry.entry_id, disabled_projected)
+
+    await async_update_all_large_lock_repair_issues(hass)
+
+    assert _issue(hass, stale_entry.entry_id) is None
+    assert _issue(hass, disabled_entry.entry_id) is None
+    assert await async_get_large_lock_ack(hass, disabled_entry.entry_id) == disabled_projected
+
+
+async def test_setup_sweep_entry_failure_logs_and_continues(
+    hass: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test one per-entry repair failure does not stop the setup sweep."""
+    active_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="active",
+        data=_config(
+            170,
+            **{
+                CONF_ADVANCED_DAY_OF_WEEK: True,
+                CONF_LOCK_ENTITY_ID: "lock.active",
+                CONF_LOCK_NAME: "active",
+            },
+        ),
+        state=ConfigEntryState.LOADED,
+        version=4,
+    )
+    disabled_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="disabled",
+        data=_config(
+            170,
+            **{
+                CONF_ADVANCED_DAY_OF_WEEK: True,
+                CONF_LOCK_ENTITY_ID: "lock.disabled",
+                CONF_LOCK_NAME: "disabled",
+            },
+        ),
+        disabled_by=ConfigEntryDisabler.USER,
+        state=ConfigEntryState.NOT_LOADED,
+        version=4,
+    )
+    active_entry.add_to_hass(hass)
+    disabled_entry.add_to_hass(hass)
+    await async_update_large_lock_repair_issue(hass, disabled_entry)
+    caplog.set_level(logging.ERROR)
+
+    with patch(
+        "custom_components.keymaster.helpers.async_update_large_lock_repair_issue",
+        new_callable=AsyncMock,
+        side_effect=Exception("per-entry repair update failed"),
+    ):
+        await async_update_all_large_lock_repair_issues(hass)
+
+    assert "Failed to update large-lock repair issue" in caplog.text
+    assert _issue(hass, disabled_entry.entry_id) is None
+
+
+@pytest.mark.parametrize("supports_connection_status", [True, False])
+async def test_supports_connection_status_uses_loaded_provider(
+    hass: Any,
+    supports_connection_status: bool,
+) -> None:
+    """Test helper returns the loaded provider's connection-status support."""
+    entry_id = "entry-with-provider"
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.frontdoor",
+        keymaster_config_entry_id=entry_id,
+        provider=cast(
+            Any,
+            SimpleNamespace(supports_connection_status=supports_connection_status),
+        ),
+    )
+    hass.data.setdefault(DOMAIN, {})[COORDINATOR] = SimpleNamespace(
+        sync_get_lock_by_config_entry_id=lambda requested_entry_id: (
+            kmlock if requested_entry_id == entry_id else None
+        )
+    )
+
+    assert _supports_connection_status(hass, entry_id) is supports_connection_status
+
+
+async def test_supports_connection_status_defaults_true_without_loaded_provider(hass: Any) -> None:
+    """Test helper defaults to creating the connection-status sensor before provider load."""
+    hass.data.setdefault(DOMAIN, {})[COORDINATOR] = SimpleNamespace(
+        sync_get_lock_by_config_entry_id=lambda requested_entry_id: None
+    )
+
+    assert _supports_connection_status(hass, "missing-entry") is True
+
+
+async def test_setup_checks_all_existing_entries(hass: Any) -> None:
+    """Test setup creates repairs for all existing entries, not only the loaded entry."""
+    large_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="large",
+        data=_config(
+            170,
+            **{
+                CONF_ADVANCED_DAY_OF_WEEK: True,
+                CONF_LOCK_ENTITY_ID: "lock.large",
+                CONF_LOCK_NAME: "large",
+            },
+        ),
+        state=ConfigEntryState.LOADED,
+        version=4,
+    )
+    small_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="small",
+        data=_config(
+            6,
+            **{
+                CONF_ADVANCED_DAY_OF_WEEK: False,
+                CONF_LOCK_ENTITY_ID: "lock.small",
+                CONF_LOCK_NAME: "small",
+            },
+        ),
+        version=4,
+    )
+    large_entry.add_to_hass(hass)
+    small_entry.add_to_hass(hass)
+
+    with _setup_patches():
+        await hass.config_entries.async_setup(small_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert _issue(hass, large_entry.entry_id) is not None
+    assert _issue(hass, small_entry.entry_id) is None
+
+
+async def test_setup_sweeps_large_lock_repairs_once(hass: Any) -> None:
+    """Test startup repair sweep runs only once across multiple entry setups."""
+    first_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="first",
+        data=_config(
+            6,
+            **{
+                CONF_ADVANCED_DAY_OF_WEEK: False,
+                CONF_LOCK_ENTITY_ID: "lock.first",
+                CONF_LOCK_NAME: "first",
+            },
+        ),
+        version=4,
+    )
+    second_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="second",
+        data=_config(
+            6,
+            **{
+                CONF_ADVANCED_DAY_OF_WEEK: False,
+                CONF_LOCK_ENTITY_ID: "lock.second",
+                CONF_LOCK_NAME: "second",
+            },
+        ),
+        version=4,
+    )
+    first_entry.add_to_hass(hass)
+
+    with (
+        _setup_patches(),
+        patch(
+            "custom_components.keymaster.async_update_all_large_lock_repair_issues",
+            new_callable=AsyncMock,
+        ) as mock_sweep,
+    ):
+        await hass.config_entries.async_setup(first_entry.entry_id)
+        await hass.async_block_till_done()
+        second_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(second_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(mock_sweep.mock_calls) == 1
+
+
+async def test_reconfigure_updates_large_lock_repair_issue(
+    hass: Any,
+    mock_get_entities: Any,
+) -> None:
+    """Test reconfigure creates and clears the large-lock repair issue."""
+    del mock_get_entities
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(70, **{CONF_ADVANCED_DAY_OF_WEEK: False}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+
+    with _setup_patches():
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    large_input = _config(
+        170,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: True,
+            CONF_DOOR_SENSOR_ENTITY_ID: "binary_sensor.frontdoor",
+        },
+    )
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": config_entry.entry_id,
+        },
+    )
+    assert reconfigure_result["type"] is FlowResultType.FORM
+    with patch("homeassistant.config_entries.ConfigEntries.async_reload", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            reconfigure_result["flow_id"],
+            large_input,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert _issue(hass, config_entry.entry_id) is not None
+
+    small_input = _config(
+        70,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: False,
+            CONF_DOOR_SENSOR_ENTITY_ID: "binary_sensor.frontdoor",
+        },
+    )
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": config_entry.entry_id,
+        },
+    )
+    with patch("homeassistant.config_entries.ConfigEntries.async_reload", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            reconfigure_result["flow_id"],
+            small_input,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert _issue(hass, config_entry.entry_id) is None
+
+
+async def test_reconfigure_repair_update_failure_does_not_block_flow(
+    hass: Any,
+    mock_get_entities: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test reconfigure still succeeds if updating the repair issue fails."""
+    del mock_get_entities
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(70, **{CONF_ADVANCED_DAY_OF_WEEK: False}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+
+    with _setup_patches():
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    user_input = _config(
+        170,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: True,
+            CONF_DOOR_SENSOR_ENTITY_ID: "binary_sensor.frontdoor",
+        },
+    )
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": config_entry.entry_id,
+        },
+    )
+    assert reconfigure_result["type"] is FlowResultType.FORM
+    caplog.set_level(logging.ERROR)
+
+    with (
+        patch("homeassistant.config_entries.ConfigEntries.async_reload", return_value=True),
+        patch(
+            "custom_components.keymaster.config_flow.async_update_large_lock_repair_issue",
+            new_callable=AsyncMock,
+            side_effect=Exception("repair update failed"),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            reconfigure_result["flow_id"],
+            user_input,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_SLOTS] == 170
+    assert "Failed to update large-lock repair issue" in caplog.text
+
+
+async def test_reconfigure_accepts_very_large_warn_only_config(
+    hass: Any,
+    mock_get_entities: Any,
+) -> None:
+    """Test very large configurations are accepted and only create a warning."""
+    del mock_get_entities
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=_config(70, **{CONF_ADVANCED_DAY_OF_WEEK: False}),
+        version=4,
+    )
+    config_entry.add_to_hass(hass)
+
+    with _setup_patches():
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    large_input = _config(
+        250,
+        **{
+            CONF_ADVANCED_DAY_OF_WEEK: True,
+            CONF_DOOR_SENSOR_ENTITY_ID: "binary_sensor.frontdoor",
+        },
+    )
+    assert projected_lock_entity_count(large_input) > 10000
+
+    reconfigure_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": config_entry.entry_id,
+        },
+    )
+    assert reconfigure_result["type"] is FlowResultType.FORM
+    with patch("homeassistant.config_entries.ConfigEntries.async_reload", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            reconfigure_result["flow_id"],
+            large_input,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_SLOTS] == 250
+    assert _issue(hass, config_entry.entry_id) is not None


### PR DESCRIPTION
Part of #670
Closes #679

## What

Adds a Home Assistant **Repairs** warning when a single keymaster lock's projected entity count reaches **8000** entities (HA's per-dispatch event guard trips at 10,000). The repair is **fixable — an acknowledgement**: selecting *Fix* opens a confirm step ("here be dragons") that records that the user understands the risk and dismisses the warning. Two thresholds: **8000** raises the acknowledgeable warning; **9500** (critical, nearing the 10k guard) re-raises even after acknowledgement because the risk has materially worsened. It also auto-clears when the projected count drops back below 8000. Acknowledgement is persisted per-lock in a dedicated HA Store (survives restarts; no config-entry reload), preserved across disable/unload, and cleared on removal / below-threshold / critical re-alert.

## Details

- Projection helper computes a lock's entity count from its config (slots, advanced date range, advanced day-of-week, parent/child, door sensor, provider connection-status), matching the real platform generators.
- The check runs at integration setup for all existing entries (swept once per startup) and on config/reconfigure; disabled/ignored/not-loaded entries have any stale issue cleared and are skipped.
- Repair create/clear is wrapped so a failure can never block setup or a reconfigure flow.
- **No hard slot cap** — large configs are still accepted; this only warns. The structural mitigation is the per-lock coordinator work (#680–#684).
- Adds `repairs.py` (fixable acknowledgement fix flow) and a dedicated ack Store. Translations cover the issue text and the fix-flow confirm step. Unit tests cover projection (parent/child, DOW on/off, door-sensor sentinel), the 8000 boundary, >10000 warn-only/no-cap, setup-time stale clearing, disabled/unload ack preservation vs removal cleanup, the two-threshold + critical re-alert logic, and the fix-flow confirm/abort paths.

