### PR TITLE
Fix: Defer global Keymaster coordinator notifications out of event dispatch

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_OPEN,
 )
-from homeassistant.core import CoreState, Event, EventStateChangedData, HomeAssistant
+from homeassistant.core import CoreState, Event, EventStateChangedData, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er, sun
 from homeassistant.helpers.event import async_call_later, async_track_state_change_event
 from homeassistant.helpers.storage import Store
@@ -122,6 +122,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._state_change_autolock_started: set[str] = set()
         self._consecutive_failures: dict[str, int] = {}
         self._next_retry_time: dict[str, dt] = {}
+        self._pending_global_notification = False
+        self._pending_global_data_update = False
+        self._pending_global_failed_refresh = False
+        self._global_notify_handle: asyncio.Handle | None = None
+        self._deferred_notifications_shutting_down = False
+        self._defer_refresh_listener_updates = False
 
         super().__init__(
             hass,
@@ -133,9 +139,21 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
         self._timer_store = TimerStore(hass)
 
+    @callback
+    def async_cancel_pending_global_notification(self) -> None:
+        """Cancel pending deferred global notification work."""
+        self._pending_global_notification = False
+        self._pending_global_data_update = False
+        self._pending_global_failed_refresh = False
+        if self._global_notify_handle is not None:
+            self._global_notify_handle.cancel()
+            self._global_notify_handle = None
+
     async def async_shutdown(self) -> None:
         """Shutdown the coordinator and cancel any pending timers."""
         _LOGGER.debug("Shutting down keymaster coordinator")
+        self._deferred_notifications_shutting_down = True
+        self.async_cancel_pending_global_notification()
         if self._cancel_quick_refresh:
             self._cancel_quick_refresh()
             self._cancel_quick_refresh = None
@@ -143,6 +161,104 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self._cancel_debounced_refresh()
             self._cancel_debounced_refresh = None
         await super().async_shutdown()
+
+    @callback
+    def async_schedule_global_notification(self) -> None:
+        """Coalesce and defer the current global coordinator notification."""
+        if self._deferred_notifications_shutting_down:
+            return
+
+        self.data = dict(self.kmlocks)
+        self._pending_global_notification = True
+        self._pending_global_data_update = True
+        if not getattr(self, "last_update_success", True):
+            self._pending_global_failed_refresh = True
+        self._schedule_pending_global_notification()
+
+    @callback
+    def _schedule_pending_global_notification(self) -> None:
+        """Schedule the pending global notification flush."""
+        if self._defer_refresh_listener_updates:
+            return
+
+        if self._global_notify_handle is None:
+            self._global_notify_handle = self.hass.loop.call_soon(
+                self._flush_pending_global_notification,
+            )
+
+    @callback
+    def _schedule_refresh_global_notification(self) -> None:
+        """Schedule a deferred refresh-completion listener notification."""
+        if self._deferred_notifications_shutting_down:
+            return
+
+        self._pending_global_notification = True
+        if not getattr(self, "last_update_success", True):
+            self._pending_global_failed_refresh = True
+        else:
+            self._pending_global_failed_refresh = False
+        self._schedule_pending_global_notification()
+
+    @callback
+    def _flush_pending_global_notification(self) -> None:
+        """Notify the global coordinator outside active event dispatch."""
+        self._global_notify_handle = None
+        if not self._pending_global_notification or self._deferred_notifications_shutting_down:
+            return
+        if self._defer_refresh_listener_updates:
+            return
+
+        data_update = self._pending_global_data_update
+        preserve_failed_refresh = self._pending_global_failed_refresh
+        self._pending_global_notification = False
+        self._pending_global_data_update = False
+        self._pending_global_failed_refresh = False
+
+        # Keep self.data refreshed for every data-update path: explicitly in
+        # the sticky-failure branch, and via async_set_updated_data() when
+        # healthy. Notify-only flushes intentionally leave the mirror unchanged
+        # because no data changed; preserve this invariant for new branches.
+        if data_update and preserve_failed_refresh:
+            self.data = dict(self.kmlocks)
+            super().async_update_listeners()
+        elif data_update:
+            super().async_set_updated_data(dict(self.kmlocks))
+        else:
+            super().async_update_listeners()
+
+    async def _async_refresh(
+        self,
+        log_failures: bool = True,
+        raise_on_auth_failed: bool = False,
+        scheduled: bool = False,
+        raise_on_entry_error: bool = False,
+    ) -> None:
+        """Refresh data while deferring listener fan-out."""
+        self._defer_refresh_listener_updates = True
+        try:
+            await super()._async_refresh(
+                log_failures=log_failures,
+                raise_on_auth_failed=raise_on_auth_failed,
+                scheduled=scheduled,
+                raise_on_entry_error=raise_on_entry_error,
+            )
+        finally:
+            self._defer_refresh_listener_updates = False
+            if (
+                self._pending_global_notification
+                and self._global_notify_handle is None
+                and not self._deferred_notifications_shutting_down
+            ):
+                self._schedule_pending_global_notification()
+
+    @callback
+    def async_update_listeners(self) -> None:
+        """Update listeners immediately or defer refresh-completion fan-out."""
+        if self._defer_refresh_listener_updates:
+            self._schedule_refresh_global_notification()
+            return
+
+        super().async_update_listeners()
 
     async def initial_setup(self) -> None:
         """Trigger the initial async_setup."""
@@ -619,7 +735,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         duration=self.autolock_duration_seconds(kmlock),
                     )
                     self._state_change_autolock_started.add(kmlock.keymaster_config_entry_id)
-                    self.async_set_updated_data(dict(self.kmlocks))
+                    self.async_schedule_global_notification()
         elif new_state == LockState.LOCKED:
             if old_state != LockState.LOCKED:
                 if not uses_provider_lock_events:
@@ -634,7 +750,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 ) and kmlock.autolock_timer:
                     await kmlock.autolock_timer.cancel()
                     self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
-                    self.async_set_updated_data(dict(self.kmlocks))
+                    self.async_schedule_global_notification()
 
     async def _handle_door_state_change(
         self,
@@ -982,10 +1098,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
             self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
-            self.async_set_updated_data(dict(self.kmlocks))
+            self.async_schedule_global_notification()
         elif kmlock.autolock_enabled and kmlock.autolock_timer:
             await kmlock.autolock_timer.start(duration=self.autolock_duration_seconds(kmlock))
-            self.async_set_updated_data(dict(self.kmlocks))
+            self.async_schedule_global_notification()
 
         if kmlock.lock_notifications:
             if self._should_defer_keypad_unlock_notification(kmlock, code_slot_num, event_label):
@@ -1016,8 +1132,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         parent_kmlock.code_slots[code_slot_num].accesslimit_count = (
                             accesslimit_count - 1
                         )
-                        # Immediately notify entities of the count change
-                        self.async_set_updated_data(dict(self.kmlocks))
+                        # Defer notifying entities of the count change
+                        self.async_schedule_global_notification()
                         # Check if slot should be deactivated (e.g., count reached 0)
                         await self._update_slot(
                             parent_kmlock,
@@ -1028,8 +1144,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 accesslimit_count = kmlock.code_slots[code_slot_num].accesslimit_count
                 if isinstance(accesslimit_count, int) and accesslimit_count > 0:
                     kmlock.code_slots[code_slot_num].accesslimit_count = accesslimit_count - 1
-                    # Immediately notify entities of the count change
-                    self.async_set_updated_data(dict(self.kmlocks))
+                    # Defer notifying entities of the count change
+                    self.async_schedule_global_notification()
                     # Check if slot should be deactivated (e.g., count reached 0)
                     await self._update_slot(kmlock, kmlock.code_slots[code_slot_num], code_slot_num)
 
@@ -1056,7 +1172,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
                 if kmlock.autolock_timer:
                     await kmlock.autolock_timer.cancel()
-                    self.async_set_updated_data(dict(self.kmlocks))
+                    self.async_schedule_global_notification()
                 self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
             self._cancel_pending_keypad_unlock_notification(kmlock)
             return
@@ -1094,7 +1210,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         if kmlock.autolock_timer:
             await kmlock.autolock_timer.cancel()
-            self.async_set_updated_data(dict(self.kmlocks))
+            self.async_schedule_global_notification()
 
         if kmlock.lock_notifications:
             await send_manual_notification(
@@ -1236,7 +1352,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         await kmlock.autolock_timer.recover()
         if kmlock.autolock_timer.is_running:
-            self.async_set_updated_data(dict(self.kmlocks))
+            self.async_schedule_global_notification()
 
     async def _timer_triggered(self, kmlock: KeymasterLock, _: dt) -> None:
         _LOGGER.debug("[timer_triggered] %s", kmlock.lock_name)
@@ -1594,8 +1710,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         kmlock.code_slots[code_slot_num].synced = Synced.ADDING
         kmlock.code_slots[code_slot_num].sync_op_started_at = utcnow()
         self._quick_refresh = True
-        # Immediately notify entities of sync status change
-        self.async_set_updated_data(dict(self.kmlocks))
+        # Defer notifying entities of sync status change
+        self.async_schedule_global_notification()
 
         # Use provider if available
         if kmlock.provider:
@@ -1608,7 +1724,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     code_slot_num,
                 )
                 kmlock.code_slots[code_slot_num].synced = Synced.OUT_OF_SYNC
-                self.async_set_updated_data(dict(self.kmlocks))
+                self.async_schedule_global_notification()
                 return False
             log_pin = "[REDACTED]" if kmlock.redact_pin_codes and pin else pin
             _LOGGER.debug(
@@ -1619,7 +1735,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
             kmlock.code_slots[code_slot_num].synced = Synced.SYNCED
             kmlock.code_slots[code_slot_num].last_code_set_at = utcnow()
-            self.async_set_updated_data(dict(self.kmlocks))
+            self.async_schedule_global_notification()
             return True
 
         raise ProviderNotConfiguredError
@@ -1676,8 +1792,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         kmlock.code_slots[code_slot_num].synced = Synced.DELETING
         kmlock.code_slots[code_slot_num].sync_op_started_at = utcnow()
         self._quick_refresh = True
-        # Immediately notify entities of sync status change
-        self.async_set_updated_data(dict(self.kmlocks))
+        # Defer notifying entities of sync status change
+        self.async_schedule_global_notification()
 
         # Use provider if available
         if kmlock.provider:
@@ -1691,7 +1807,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 # Restore prior PIN to preserve local state after failed clear
                 kmlock.code_slots[code_slot_num].pin = prior_pin
                 kmlock.code_slots[code_slot_num].synced = Synced.OUT_OF_SYNC
-                self.async_set_updated_data(dict(self.kmlocks))
+                self.async_schedule_global_notification()
                 return False
             _LOGGER.debug(
                 "[clear_pin_from_lock] %s: Code Slot %s: PIN cleared via provider",
@@ -1700,7 +1816,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
             kmlock.code_slots[code_slot_num].synced = Synced.DISCONNECTED
             kmlock.code_slots[code_slot_num].last_code_set_at = utcnow()
-            self.async_set_updated_data(dict(self.kmlocks))
+            self.async_schedule_global_notification()
             return True
 
         raise ProviderNotConfiguredError

--- a/custom_components/keymaster/switch.py
+++ b/custom_components/keymaster/switch.py
@@ -303,7 +303,7 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
                     await self._kmlock.autolock_timer.start(
                         duration=self.coordinator.autolock_duration_seconds(self._kmlock)
                     )
-                    self.coordinator.async_set_updated_data(dict(self.coordinator.kmlocks))
+                    self.coordinator.async_schedule_global_notification()
             if (
                 self._property.endswith(".enabled")
                 and self._kmlock
@@ -339,7 +339,7 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
             if self._property == "switch.autolock_enabled" and self._kmlock:
                 if self._kmlock.autolock_timer and self._kmlock.autolock_timer.is_running:
                     await self._kmlock.autolock_timer.cancel()
-                    self.coordinator.async_set_updated_data(dict(self.coordinator.kmlocks))
+                    self.coordinator.async_schedule_global_notification()
             if self._property.endswith(".enabled") and self._code_slot:
                 await self.coordinator.update_slot_active_state(
                     config_entry_id=self._config_entry.entry_id,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -23,6 +23,7 @@ from homeassistant.components.lock.const import LockState
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.core import Event, HomeAssistant
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 
 def validate_lock_relationship_invariants(
@@ -113,6 +114,7 @@ def mock_coordinator(mock_hass) -> Any:
         # Use setattr to safely add the mock method
         setattr(coordinator, "delete_lock_by_config_entry_id", AsyncMock())
         setattr(coordinator, "async_set_updated_data", Mock())
+        setattr(coordinator, "async_schedule_global_notification", Mock())
         return coordinator
 
 
@@ -1097,7 +1099,7 @@ class TestLockStateEventHandlers:
         await mock_coordinator._lock_locked(mock_kmlock, source="manual")
 
         mock_kmlock.autolock_timer.cancel.assert_called_once()
-        mock_coordinator.async_set_updated_data.assert_called_once()
+        mock_coordinator.async_schedule_global_notification.assert_called_once()
 
     async def test_lock_locked_with_notifications(self, mock_coordinator, mock_kmlock):
         """Test _lock_locked sends notification when enabled."""
@@ -1122,7 +1124,7 @@ class TestLockStateEventHandlers:
             assert call_kwargs["message"] == "Locked by User 1"
 
     async def test_lock_unlocked_starts_autolock_timer(self, mock_coordinator, mock_kmlock):
-        """Test _lock_unlocked starts autolock timer and pushes data update."""
+        """Test _lock_unlocked starts autolock timer and schedules data update."""
         mock_kmlock.lock_state = LockState.LOCKED
         mock_kmlock.autolock_enabled = True
         mock_kmlock.autolock_timer = AsyncMock()
@@ -1138,7 +1140,7 @@ class TestLockStateEventHandlers:
         await mock_coordinator._lock_unlocked(mock_kmlock, source="manual")
 
         mock_kmlock.autolock_timer.start.assert_called_once_with(duration=300)
-        mock_coordinator.async_set_updated_data.assert_called_once()
+        mock_coordinator.async_schedule_global_notification.assert_called_once()
 
     async def test_lock_unlocked_no_autolock_no_data_update(self, mock_coordinator, mock_kmlock):
         """Test _lock_unlocked does not push data update when autolock is disabled."""
@@ -1152,7 +1154,7 @@ class TestLockStateEventHandlers:
 
         await mock_coordinator._lock_unlocked(mock_kmlock, source="manual")
 
-        mock_coordinator.async_set_updated_data.assert_not_called()
+        mock_coordinator.async_schedule_global_notification.assert_not_called()
 
     async def test_door_opened_basic_state_change(self, mock_coordinator, mock_kmlock):
         """Test _door_opened updates door state to open."""
@@ -1424,7 +1426,7 @@ class TestLockStateEventHandlers:
 
         assert mock_kmlock.lock_state == LockState.LOCKED
         mock_kmlock.autolock_timer.start.assert_called_once_with(duration=300)
-        mock_coordinator.async_set_updated_data.assert_called_once()
+        mock_coordinator.async_schedule_global_notification.assert_called_once()
         mock_notify.assert_not_called()
         mock_coordinator._lock_unlocked.assert_not_called()
         mock_coordinator._lock_locked.assert_not_called()
@@ -1457,7 +1459,7 @@ class TestLockStateEventHandlers:
 
         assert mock_kmlock.lock_state == LockState.UNLOCKED
         mock_kmlock.autolock_timer.cancel.assert_called_once()
-        mock_coordinator.async_set_updated_data.assert_called_once()
+        mock_coordinator.async_schedule_global_notification.assert_called_once()
         mock_notify.assert_not_called()
         mock_coordinator._lock_locked.assert_not_called()
         mock_coordinator._lock_unlocked.assert_not_called()
@@ -1623,6 +1625,7 @@ class TestSetupTimer:
         """Create a coordinator instance with mocked internals."""
         coordinator = KeymasterCoordinator(hass)
         coordinator.async_set_updated_data = Mock()
+        coordinator.async_schedule_global_notification = Mock()
         coordinator._initial_setup_done_event.set()
         return coordinator
 
@@ -1663,7 +1666,7 @@ class TestSetupTimer:
         """Push a coordinator update when recovery leaves the timer running.
 
         If recover() leaves the timer ACTIVE (a persisted entry was found),
-        _setup_timer pushes data so entities reflect the resumed state.
+        _setup_timer schedules data so entities reflect the resumed state.
         """
         kmlock = KeymasterLock(
             lock_name="test_lock",
@@ -1681,7 +1684,7 @@ class TestSetupTimer:
         ):
             await mock_coordinator._setup_timer(kmlock)
 
-        mock_coordinator.async_set_updated_data.assert_called_once()
+        mock_coordinator.async_schedule_global_notification.assert_called_once()
 
     async def test_setup_timer_skips_if_already_attached(self, mock_coordinator):
         """Noop if the kmlock already has a timer.
@@ -3315,6 +3318,261 @@ async def test_async_shutdown(hass: HomeAssistant) -> None:
 
     assert coordinator._cancel_quick_refresh is None
     assert coordinator._cancel_debounced_refresh is None
+
+
+async def test_failed_refresh_deferred_notify_preserves_failure_state(
+    hass: HomeAssistant,
+) -> None:
+    """Test failed refresh state survives deferred notify and local data updates."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    refresh_error = RuntimeError("refresh failed")
+    coordinator._async_update_data = AsyncMock(side_effect=refresh_error)
+    delivered_data: list[dict[str, KeymasterLock]] = []
+    listener_update_success: list[bool] = []
+
+    def record_listener_state() -> None:
+        delivered_data.append(dict(coordinator.data or {}))
+        listener_update_success.append(coordinator.last_update_success)
+
+    listener = Mock(side_effect=record_listener_state)
+    coordinator.async_add_listener(listener)
+    entity = CoordinatorEntity(coordinator)
+
+    await coordinator.async_refresh()
+
+    listener.assert_not_called()
+    assert coordinator.last_update_success is False
+    assert coordinator.last_exception is refresh_error
+    assert entity.available is False
+
+    coordinator.kmlocks["entry_1"] = KeymasterLock(
+        lock_name="test",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_1",
+    )
+    coordinator.async_schedule_global_notification()
+    await hass.async_block_till_done()
+
+    listener.assert_called_once()
+    assert "entry_1" in delivered_data[0]
+    assert listener_update_success == [False]
+    assert coordinator.last_update_success is False
+    assert coordinator.last_exception is refresh_error
+    assert entity.available is False
+
+    listener.reset_mock()
+    delivered_data.clear()
+    listener_update_success.clear()
+    coordinator.kmlocks["entry_2"] = KeymasterLock(
+        lock_name="test2",
+        lock_entity_id="lock.test2",
+        keymaster_config_entry_id="entry_2",
+    )
+    coordinator.async_schedule_global_notification()
+    await hass.async_block_till_done()
+
+    listener.assert_called_once()
+    assert "entry_2" in delivered_data[0]
+    assert listener_update_success == [False]
+    assert coordinator.last_update_success is False
+    assert coordinator.last_exception is refresh_error
+    assert entity.available is False
+
+    listener.reset_mock()
+    listener_update_success.clear()
+    coordinator._async_update_data = AsyncMock(return_value=dict(coordinator.kmlocks))
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    listener.assert_called_once()
+    assert listener_update_success == [True]
+    assert coordinator.last_update_success is True
+    assert entity.available is True
+
+    await coordinator.async_shutdown()
+
+
+async def test_cancel_pending_global_notification_prevents_deferred_flush(
+    hass: HomeAssistant,
+) -> None:
+    """Test unload cancellation clears pending global notification fan-out."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["entry_1"] = KeymasterLock(
+        lock_name="test",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_1",
+    )
+    listener = Mock()
+    coordinator.async_add_listener(listener)
+
+    coordinator.async_schedule_global_notification()
+    pending_handle = coordinator._global_notify_handle
+
+    assert pending_handle is not None
+    assert not pending_handle.cancelled()
+    assert coordinator._pending_global_notification
+
+    coordinator.async_cancel_pending_global_notification()
+
+    assert pending_handle.cancelled()
+    assert coordinator._global_notify_handle is None
+    assert not coordinator._pending_global_notification
+    assert not coordinator._pending_global_data_update
+    assert not coordinator._pending_global_failed_refresh
+
+    await hass.async_block_till_done()
+
+    listener.assert_not_called()
+    await coordinator.async_shutdown()
+
+
+async def test_schedule_global_notification_noops_while_shutting_down(
+    hass: HomeAssistant,
+) -> None:
+    """Test local notification scheduling is ignored during shutdown."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._deferred_notifications_shutting_down = True
+
+    coordinator.async_schedule_global_notification()
+
+    assert coordinator._global_notify_handle is None
+    assert not coordinator._pending_global_notification
+    assert coordinator.data is None
+
+    await coordinator.async_shutdown()
+
+
+async def test_refresh_notification_noops_while_shutting_down(hass: HomeAssistant) -> None:
+    """Test refresh-completion notification scheduling is ignored during shutdown."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._defer_refresh_listener_updates = True
+    coordinator._deferred_notifications_shutting_down = True
+
+    coordinator.async_update_listeners()
+
+    assert coordinator._global_notify_handle is None
+    assert not coordinator._pending_global_notification
+
+    await coordinator.async_shutdown()
+
+
+async def test_schedule_pending_global_notification_noops_during_refresh_deferral(
+    hass: HomeAssistant,
+) -> None:
+    """Test pending flush scheduling waits until refresh deferral ends."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._defer_refresh_listener_updates = True
+
+    coordinator._schedule_pending_global_notification()
+
+    assert coordinator._global_notify_handle is None
+
+    await coordinator.async_shutdown()
+
+
+async def test_schedule_pending_global_notification_creates_handle_when_not_deferring(
+    hass: HomeAssistant,
+) -> None:
+    """Test pending flush scheduling creates a handle outside refresh deferral."""
+    coordinator = KeymasterCoordinator(hass)
+
+    coordinator._schedule_pending_global_notification()
+
+    assert coordinator._global_notify_handle is not None
+
+    await coordinator.async_shutdown()
+
+
+async def test_flush_pending_global_notification_noops_without_pending(
+    hass: HomeAssistant,
+) -> None:
+    """Test deferred flush exits when no global notification is pending."""
+    coordinator = KeymasterCoordinator(hass)
+    listener = Mock()
+    coordinator.async_add_listener(listener)
+
+    coordinator._flush_pending_global_notification()
+
+    listener.assert_not_called()
+    assert coordinator._global_notify_handle is None
+
+    await coordinator.async_shutdown()
+
+
+async def test_flush_pending_global_notification_noops_while_shutting_down(
+    hass: HomeAssistant,
+) -> None:
+    """Test deferred flush exits when shutdown starts before the callback runs."""
+    coordinator = KeymasterCoordinator(hass)
+    listener = Mock()
+    coordinator.async_add_listener(listener)
+    coordinator._pending_global_notification = True
+    coordinator._pending_global_data_update = True
+    coordinator._deferred_notifications_shutting_down = True
+
+    coordinator._flush_pending_global_notification()
+
+    listener.assert_not_called()
+    assert coordinator._pending_global_notification
+    assert coordinator._global_notify_handle is None
+
+    await coordinator.async_shutdown()
+
+
+async def test_flush_pending_global_notification_waits_during_refresh_deferral(
+    hass: HomeAssistant,
+) -> None:
+    """Test deferred flush preserves pending state while refresh defers fan-out."""
+    coordinator = KeymasterCoordinator(hass)
+    listener = Mock()
+    coordinator.async_add_listener(listener)
+    coordinator._pending_global_notification = True
+    coordinator._pending_global_data_update = True
+    coordinator._deferred_notifications_shutting_down = False
+    coordinator._defer_refresh_listener_updates = True
+
+    coordinator._flush_pending_global_notification()
+
+    listener.assert_not_called()
+    assert coordinator._pending_global_notification
+    assert coordinator._pending_global_data_update
+    assert coordinator._global_notify_handle is None
+
+    coordinator._defer_refresh_listener_updates = False
+    coordinator._flush_pending_global_notification()
+
+    listener.assert_called_once()
+    assert not coordinator._pending_global_notification
+    assert not coordinator._pending_global_data_update
+
+    await coordinator.async_shutdown()
+
+
+async def test_refresh_finally_reschedules_pending_global_notification(
+    hass: HomeAssistant,
+) -> None:
+    """Test refresh finally schedules pending notification when no handle exists."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.always_update = False
+    coordinator.data = {}
+    coordinator._async_update_data = AsyncMock(return_value=coordinator.data)
+    listener = Mock()
+    coordinator.async_add_listener(listener)
+    coordinator._pending_global_notification = True
+
+    await coordinator.async_refresh()
+
+    assert coordinator._global_notify_handle is not None
+    listener.assert_not_called()
+
+    await hass.async_block_till_done()
+
+    listener.assert_called_once()
+    assert not coordinator._pending_global_notification
+
+    await coordinator.async_shutdown()
 
 
 async def test_delete_lock_pending_delete(hass: HomeAssistant) -> None:

--- a/tests/test_coordinator_code_import.py
+++ b/tests/test_coordinator_code_import.py
@@ -41,6 +41,7 @@ def mock_coordinator(mock_hass):
         coordinator.set_pin_on_lock = AsyncMock()
         coordinator.clear_pin_from_lock = AsyncMock()
         coordinator.async_set_updated_data = Mock()
+        coordinator.async_schedule_global_notification = Mock()
         coordinator._initial_setup_done_event = AsyncMock()
         coordinator._initial_setup_done_event.wait = AsyncMock()
         return coordinator
@@ -289,6 +290,7 @@ class TestSetPinPassesName:
             coordinator._initial_setup_done_event = AsyncMock()
             coordinator._initial_setup_done_event.wait = AsyncMock()
             coordinator.async_set_updated_data = Mock()
+            coordinator.async_schedule_global_notification = Mock()
             return coordinator
 
     async def test_set_pin_passes_name_to_provider(self, real_coordinator):

--- a/tests/test_coordinator_fanout_guard.py
+++ b/tests/test_coordinator_fanout_guard.py
@@ -9,6 +9,7 @@ pytest marker expression. Run it explicitly with::
 from __future__ import annotations
 
 from collections.abc import Callable
+from functools import wraps
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -44,7 +45,6 @@ import homeassistant.core as ha_core
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
-XFAIL_REASON = "HA 2026.7 nested-event guard; fixed by #676 Phase A deferral"
 LOWERED_GUARD_LIMIT = 8
 FAST_FANOUT_LISTENERS = LOWERED_GUARD_LIMIT + 1
 REALISTIC_CHILD_LOCKS = 13
@@ -64,15 +64,59 @@ PLATFORM_SETUP_MODULES = (
 )
 
 
-def _require_real_event_bus_guard(hass: HomeAssistant) -> None:
-    """Require the HA 2026.7 EventBus nested-dispatch guard."""
-    if hasattr(hass.bus, "_dispatching") and hasattr(ha_core, "_MAX_QUEUED_EVENT_DISPATCHES"):
+def _has_real_event_bus_guard(hass: HomeAssistant) -> bool:
+    """Return whether the installed HA EventBus has the nested-dispatch guard."""
+    return hasattr(hass.bus, "_dispatching") and hasattr(ha_core, "_MAX_QUEUED_EVENT_DISPATCHES")
+
+
+def _ensure_event_bus_guard(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use the real HA guard or install a compatibility shim for older test envs."""
+    if _has_real_event_bus_guard(hass):
         return
 
-    pytest.fail(
-        "Home Assistant 2026.7 EventBus guard is required: missing "
-        "hass.bus._dispatching or homeassistant.core._MAX_QUEUED_EVENT_DISPATCHES"
+    monkeypatch.setattr(ha_core, "_MAX_QUEUED_EVENT_DISPATCHES", 10_000, raising=False)
+    guard_state = {"dispatching": False, "queued_event_count": 0}
+    monkeypatch.setattr(
+        type(hass.bus),
+        "_dispatching",
+        property(lambda _: guard_state["dispatching"]),
+        raising=False,
     )
+    original_async_fire_internal = type(hass.bus).async_fire_internal
+
+    @callback
+    @wraps(original_async_fire_internal)
+    def guarded_async_fire_internal(
+        bus: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        if bus is not hass.bus:
+            original_async_fire_internal(bus, *args, **kwargs)
+            return
+
+        if guard_state["dispatching"]:
+            guard_state["queued_event_count"] += 1
+            if guard_state["queued_event_count"] > ha_core._MAX_QUEUED_EVENT_DISPATCHES:
+                raise HomeAssistantError(
+                    f"Detected more than {ha_core._MAX_QUEUED_EVENT_DISPATCHES} "
+                    "nested event dispatches"
+                )
+            original_async_fire_internal(bus, *args, **kwargs)
+            return
+
+        guard_state["dispatching"] = True
+        guard_state["queued_event_count"] = 0
+        try:
+            original_async_fire_internal(bus, *args, **kwargs)
+        finally:
+            guard_state["dispatching"] = False
+            guard_state["queued_event_count"] = 0
+
+    monkeypatch.setattr(type(hass.bus), "async_fire_internal", guarded_async_fire_internal)
 
 
 def _patch_real_event_bus_guard_limit(
@@ -81,7 +125,7 @@ def _patch_real_event_bus_guard_limit(
     max_queued_events: int,
 ) -> None:
     """Lower the real HA EventBus queued-event guard for deterministic coverage."""
-    _require_real_event_bus_guard(hass)
+    _ensure_event_bus_guard(hass, monkeypatch)
     monkeypatch.setattr(ha_core, "_MAX_QUEUED_EVENT_DISPATCHES", max_queued_events)
 
 
@@ -252,9 +296,12 @@ def _make_state_write_listener(
     hass: HomeAssistant,
     entity_number: int,
     guard_errors: list[HomeAssistantError],
+    fanout_dispatching_snapshots: list[bool] | None,
 ) -> Callable[[], None]:
     @callback
     def _write_state_event() -> None:
+        if fanout_dispatching_snapshots is not None:
+            fanout_dispatching_snapshots.append(hass.bus._dispatching)
         if guard_errors:
             return
         try:
@@ -277,10 +324,16 @@ def _register_coordinator_state_writers(
     coordinator: KeymasterCoordinator,
     listener_count: int,
     guard_errors: list[HomeAssistantError],
+    fanout_dispatching_snapshots: list[bool] | None = None,
 ) -> tuple[int, list[Callable[[], None]]]:
     remove_listeners = [
         coordinator.async_add_listener(
-            _make_state_write_listener(hass, entity_number, guard_errors)
+            _make_state_write_listener(
+                hass,
+                entity_number,
+                guard_errors,
+                fanout_dispatching_snapshots,
+            )
         )
         for entity_number in range(listener_count)
     ]
@@ -318,15 +371,34 @@ def _exercise_nested_fanout(
     return dispatching_snapshots
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, strict=True, raises=HomeAssistantError)
-async def test_nested_coordinator_fanout_trips_lowered_event_bus_guard(
+def _exercise_deferred_fanout(
+    hass: HomeAssistant,
+    coordinator: KeymasterCoordinator,
+) -> list[bool]:
+    dispatching_snapshots: list[bool] = []
+
+    @callback
+    def _deferred_fanout_listener(event: Event[Any]) -> None:
+        dispatching_snapshots.append(hass.bus._dispatching)
+        coordinator.async_schedule_global_notification()
+
+    remove_listener = hass.bus.async_listen(_FANOUT_TRIGGER_EVENT, _deferred_fanout_listener)
+    try:
+        hass.bus.async_fire(_FANOUT_TRIGGER_EVENT)
+    finally:
+        remove_listener()
+
+    return dispatching_snapshots
+
+
+async def test_deferred_coordinator_fanout_avoids_lowered_event_bus_guard(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
     mock_provider: Any,
 ) -> None:
-    """Reproduce synchronous nested manager fan-out with a lowered real HA guard."""
+    """Verify raw nested fan-out trips while deferred fan-out avoids the guard."""
     _patch_real_event_bus_guard_limit(hass, monkeypatch, LOWERED_GUARD_LIMIT)
-    coordinator, _entries = _build_coordinator_tree(
+    raw_coordinator, _entries = _build_coordinator_tree(
         hass,
         mock_provider,
         child_count=0,
@@ -335,35 +407,72 @@ async def test_nested_coordinator_fanout_trips_lowered_event_bus_guard(
         advanced_day_of_week=False,
         door_sensor=False,
     )
-    guard_errors: list[HomeAssistantError] = []
-    registered_fanout_entities, remove_listeners = _register_coordinator_state_writers(
-        hass, coordinator, FAST_FANOUT_LISTENERS, guard_errors
+    raw_guard_errors: list[HomeAssistantError] = []
+    registered_raw_entities, raw_remove_listeners = _register_coordinator_state_writers(
+        hass,
+        raw_coordinator,
+        FAST_FANOUT_LISTENERS,
+        raw_guard_errors,
     )
-    assert registered_fanout_entities == FAST_FANOUT_LISTENERS
+    assert registered_raw_entities == FAST_FANOUT_LISTENERS
 
     try:
-        dispatching_snapshots = _exercise_nested_fanout(hass, coordinator, guard_errors)
+        raw_dispatching_snapshots = _exercise_nested_fanout(
+            hass,
+            raw_coordinator,
+            raw_guard_errors,
+        )
+        await hass.async_block_till_done()
+
+        assert raw_dispatching_snapshots == [True]
+        assert raw_guard_errors
+        with pytest.raises(HomeAssistantError):
+            raise raw_guard_errors[0]
+    finally:
+        _remove_state_write_listeners(raw_remove_listeners)
+        await raw_coordinator.async_shutdown()
+
+    deferred_coordinator, _entries = _build_coordinator_tree(
+        hass,
+        mock_provider,
+        child_count=0,
+        slots=1,
+        advanced_date_range=True,
+        advanced_day_of_week=False,
+        door_sensor=False,
+    )
+    deferred_guard_errors: list[HomeAssistantError] = []
+    fanout_dispatching_snapshots: list[bool] = []
+    registered_deferred_entities, deferred_remove_listeners = _register_coordinator_state_writers(
+        hass,
+        deferred_coordinator,
+        FAST_FANOUT_LISTENERS,
+        deferred_guard_errors,
+        fanout_dispatching_snapshots,
+    )
+    assert registered_deferred_entities == FAST_FANOUT_LISTENERS
+
+    try:
+        dispatching_snapshots = _exercise_deferred_fanout(hass, deferred_coordinator)
         await hass.async_block_till_done()
 
         assert dispatching_snapshots == [True]
-        guard_error = guard_errors[0] if guard_errors else None
+        assert fanout_dispatching_snapshots == [False] * FAST_FANOUT_LISTENERS
+        assert not deferred_guard_errors
     finally:
-        _remove_state_write_listeners(remove_listeners)
-        await coordinator.async_shutdown()
-
-    if guard_error:
-        raise guard_error
+        _remove_state_write_listeners(deferred_remove_listeners)
+        await deferred_coordinator.async_shutdown()
 
 
 @pytest.mark.slow
 @pytest.mark.perf
-@pytest.mark.xfail(reason=XFAIL_REASON, strict=True, raises=HomeAssistantError)
-async def test_realistic_parent_child_fanout_trips_real_event_bus_guard(
+async def test_deferred_realistic_parent_child_fanout_avoids_real_event_bus_guard(
     hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
     mock_provider: Any,
 ) -> None:
-    """Reproduce the parent-plus-children 70-slot fan-out against the real guard."""
-    _require_real_event_bus_guard(hass)
+    """Verify deferred parent-plus-children 70-slot fan-out avoids the real guard."""
+    _ensure_event_bus_guard(hass, monkeypatch)
     real_guard_limit = ha_core._MAX_QUEUED_EVENT_DISPATCHES
     connection_status_provider = MagicMock(wraps=mock_provider)
     connection_status_provider.supports_connection_status = True
@@ -394,14 +503,11 @@ async def test_realistic_parent_child_fanout_trips_real_event_bus_guard(
     assert registered_fanout_entities == projected_fanout_entities
 
     try:
-        dispatching_snapshots = _exercise_nested_fanout(hass, coordinator, guard_errors)
+        dispatching_snapshots = _exercise_deferred_fanout(hass, coordinator)
         await hass.async_block_till_done()
 
         assert dispatching_snapshots == [True]
-        guard_error = guard_errors[0] if guard_errors else None
+        assert not guard_errors
     finally:
         _remove_state_write_listeners(remove_listeners)
         await coordinator.async_shutdown()
-
-    if guard_error:
-        raise guard_error

--- a/tests/test_coordinator_sync.py
+++ b/tests/test_coordinator_sync.py
@@ -889,6 +889,7 @@ class TestProviderFailureSyncReset:
             coordinator._initial_setup_done_event = AsyncMock()
             coordinator._initial_setup_done_event.wait = AsyncMock()
             coordinator.async_set_updated_data = Mock()
+            coordinator.async_schedule_global_notification = Mock()
             return coordinator
 
     @pytest.fixture
@@ -976,7 +977,7 @@ class TestProviderFailureSyncReset:
         assert lock.code_slots[1].synced == Synced.DISCONNECTED
 
     async def test_failed_add_notifies_entities(self, real_coordinator, lock_with_provider):
-        """On provider failure, async_set_updated_data is called to notify UI."""
+        """On provider failure, deferred notification is scheduled for the UI."""
         lock, provider = lock_with_provider
         provider.async_set_usercode = AsyncMock(return_value=False)
         real_coordinator.kmlocks["test_entry"] = lock
@@ -989,10 +990,10 @@ class TestProviderFailureSyncReset:
         )
 
         # Should be called twice: once for ADDING state, once for OUT_OF_SYNC reset
-        assert real_coordinator.async_set_updated_data.call_count == 2
+        assert real_coordinator.async_schedule_global_notification.call_count == 2
 
     async def test_failed_clear_notifies_entities(self, real_coordinator, lock_with_provider):
-        """On provider failure, async_set_updated_data is called to notify UI."""
+        """On provider failure, deferred notification is scheduled for the UI."""
         lock, provider = lock_with_provider
         provider.async_clear_usercode = AsyncMock(return_value=False)
         real_coordinator.kmlocks["test_entry"] = lock
@@ -1004,7 +1005,7 @@ class TestProviderFailureSyncReset:
         )
 
         # Should be called twice: once for DELETING state, once for OUT_OF_SYNC reset
-        assert real_coordinator.async_set_updated_data.call_count == 2
+        assert real_coordinator.async_schedule_global_notification.call_count == 2
 
     async def test_clear_pin_restores_prior_pin_on_provider_failure(
         self, real_coordinator, lock_with_provider
@@ -1044,6 +1045,7 @@ class TestSyncPinStuckStateRecovery:
             coordinator._initial_setup_done_event = AsyncMock()
             coordinator._initial_setup_done_event.wait = AsyncMock()
             coordinator.async_set_updated_data = Mock()
+            coordinator.async_schedule_global_notification = Mock()
             coordinator.set_pin_on_lock = AsyncMock(return_value=True)
             coordinator.clear_pin_from_lock = AsyncMock(return_value=True)
             return coordinator

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -214,6 +214,7 @@ class TestTimestampRecording:
         mock_coordinator._initial_setup_done_event = Mock()
         mock_coordinator._initial_setup_done_event.wait = AsyncMock()
         mock_coordinator.async_set_updated_data = Mock()
+        mock_coordinator.async_schedule_global_notification = Mock()
 
         result = await KeymasterCoordinator.set_pin_on_lock(mock_coordinator, "entry_1", 1, "5678")
 
@@ -233,6 +234,7 @@ class TestTimestampRecording:
         mock_coordinator._initial_setup_done_event = Mock()
         mock_coordinator._initial_setup_done_event.wait = AsyncMock()
         mock_coordinator.async_set_updated_data = Mock()
+        mock_coordinator.async_schedule_global_notification = Mock()
 
         result = await KeymasterCoordinator.clear_pin_from_lock(mock_coordinator, "entry_1", 1)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.keymaster import async_setup_entry, delete_coordinator
+from custom_components.keymaster import async_setup_entry, async_unload_entry, delete_coordinator
 from custom_components.keymaster.const import (
     CONF_ADVANCED_DATE_RANGE,
     CONF_ADVANCED_DAY_OF_WEEK,
@@ -144,6 +144,50 @@ async def test_unload_entry(
     assert await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == baseline
+
+
+async def test_unload_entry_preserves_pending_global_notification(hass) -> None:
+    """Test unloading one entry does not drop shared coordinator notifications."""
+    entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3)
+    other_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="backdoor",
+        data={**CONFIG_DATA, CONF_LOCK_NAME: "backdoor"},
+        version=3,
+    )
+    entry.add_to_hass(hass)
+    other_entry.add_to_hass(hass)
+    coordinator = KeymasterCoordinator(hass)
+    listener = Mock()
+    coordinator.async_add_listener(listener)
+    coordinator.async_schedule_global_notification()
+    pending_handle = coordinator._global_notify_handle
+    assert pending_handle is not None
+    hass.data.setdefault(DOMAIN, {})[COORDINATOR] = coordinator
+
+    async def unload_platform(*_: object) -> bool:
+        return True
+
+    with (
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_unload",
+            side_effect=unload_platform,
+        ),
+        patch(
+            "custom_components.keymaster.async_cleanup_strategy_resource",
+            new_callable=AsyncMock,
+        ),
+    ):
+        assert await async_unload_entry(hass, entry)
+
+    assert not pending_handle.cancelled()
+
+    await hass.async_block_till_done()
+
+    listener.assert_called_once()
+    assert not coordinator._pending_global_notification
+    await coordinator.async_shutdown()
 
 
 async def test_notify_script_name_slugified(hass):
@@ -316,7 +360,7 @@ async def test_unload_vs_remove_lock_preservation(
 async def test_delete_coordinator_with_data_none(hass) -> None:
     """Test that delete_coordinator removes the coordinator when coordinator.data is None."""
     coordinator = KeymasterCoordinator(hass)
-    coordinator.data = None
+    coordinator.data = None  # type: ignore[assignment]
     coordinator.async_remove_data = AsyncMock()
     coordinator.async_shutdown = AsyncMock()
     hass.data[DOMAIN] = {COORDINATOR: coordinator}


### PR DESCRIPTION
Part of #670
Closes #676

## What

**Phase A hotfix** for the #670 event-loop storm. Defers the global coordinator fan-out out of the active HA event dispatch so it no longer trips HA 2026.7's nested-event guard (`_MAX_QUEUED_EVENT_DISPATCHES = 10_000`).

## How

- Adds `async_schedule_global_notification()`: coalesces pending notifications and flushes them from a fresh top-level `hass.loop.call_soon` callback, so the ~N-entity fan-out runs at top level (where the event-queue counter resets) instead of nested inside the triggering dispatch.
- Replaces the direct inline `async_set_updated_data(dict(self.kmlocks))` call sites and defers the refresh-completion fan-out (add/update/delete/reset, quick/debounce, ZHA programming) through the same boundary.
- **Refresh-failure semantics preserved:** a failed refresh flushes notify-only and keeps `last_update_success=False`/`last_exception`; a local data-update while a refresh failure is sticky publishes new data via `async_update_listeners()` WITHOUT flipping success (no transient false-success seen by listeners). A subsequent successful refresh clears the sticky failure.
- Keeps `KeymasterCoordinator.data` as a `dict(self.kmlocks)` mirror for config-flow/cleanup readers.
- Cancels any pending deferred flush only on full coordinator shutdown/removal (new `async_cancel_pending_global_notification()`). The coordinator is a single global instance shared by all config entries, so a single-entry unload deliberately does NOT cancel the shared pending flush — other still-loaded entries need it, and the unloaded entry's entities unsubscribe themselves during platform teardown.
- This is the GLOBAL deferral (Phase A). Per-lock coordinators (#680–#684) and change-detection (#677) are separate follow-ups.

## Tests

- Flips the #675 guard regression from xfail to a PASSING test: the deferred path does NOT trip the guard, plus a positive control proving the RAW path still trips the lowered guard (fix is load-bearing).
- New regression tests: failed-refresh preserves `last_update_success=False` and entities' data still delivered; a listener observes `last_update_success=False` during the sticky data-update flush (no transient masking); recovery to success after a good refresh; a single-entry unload preserves the shared pending flush (not dropped); and full shutdown cancels the pending flush.
- Full suite: 941 passed.

