### PR TITLE
Refactor: Add runtime per-lock Keymaster coordinators

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -47,6 +47,7 @@ from .const import (
     DEFAULT_REDACT_PIN_CODES,
     DEFAULT_REDACT_SLOT_NAMES,
     DOMAIN,
+    LOCK_COORDINATORS,
     NORMALIZED_TO_NONE_SENTINELS,
     PLATFORMS,
     STRATEGY_FILENAME,
@@ -225,6 +226,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     except asyncio.exceptions.CancelledError as e:
         _LOGGER.error("Timeout on add_lock. %s: %s", e.__class__.__qualname__, e)
 
+    lock_coordinator = coordinator.async_get_lock_coordinator(config_entry.entry_id)
+    hass.data[DOMAIN].setdefault(LOCK_COORDINATORS, {})[config_entry.entry_id] = lock_coordinator
+
     try:
         await async_load_large_lock_ack_store(hass)
         supports_connection_status = True
@@ -333,6 +337,8 @@ async def async_remove_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     if DOMAIN in hass.data and COORDINATOR in hass.data[DOMAIN]:
         coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
         await coordinator.delete_lock_by_config_entry_id(config_entry.entry_id, immediate=True)
+        coordinator.async_remove_lock_coordinator(config_entry.entry_id)
+        hass.data[DOMAIN].get(LOCK_COORDINATORS, {}).pop(config_entry.entry_id, None)
 
         if coordinator.count_locks_not_pending_delete == 0:
             delay = 0 if "pytest" in sys.modules else 20

--- a/custom_components/keymaster/const.py
+++ b/custom_components/keymaster/const.py
@@ -40,6 +40,7 @@ LARGE_LOCK_ACK_STORE_VERSION = 1
 # hass.data attributes
 CHILD_LOCKS = "child_locks"
 COORDINATOR = "coordinator"
+LOCK_COORDINATORS = "lock_coordinators"
 PRIMARY_LOCK = "primary_lock"
 UNSUB_LISTENERS = "unsub_listeners"
 

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from collections.abc import Callable, MutableMapping
+from collections.abc import Callable, Iterable, MutableMapping
 import contextlib
 from dataclasses import fields, is_dataclass
 from datetime import datetime as dt, time as dt_time, timedelta
@@ -102,6 +102,93 @@ def _is_masked_code(code: str | None) -> bool:
     return code == "*" * len(code)
 
 
+class KeymasterLockCoordinator(DataUpdateCoordinator[KeymasterLock | None]):
+    """Entity-facing coordinator for a single Keymaster lock."""
+
+    def __init__(self, manager: KeymasterCoordinator, config_entry_id: str) -> None:
+        """Initialize the per-lock coordinator."""
+        self.manager = manager
+        self.config_entry_id = config_entry_id
+        super().__init__(
+            manager.hass,
+            _LOGGER,
+            name=f"{DOMAIN}_{config_entry_id}",
+            update_interval=None,
+            config_entry=manager.hass.config_entries.async_get_entry(config_entry_id),
+            always_update=False,
+        )
+        self.data = manager.sync_get_lock_by_config_entry_id(config_entry_id)
+
+    async def _async_update_data(self) -> KeymasterLock | None:
+        """Mirror the manager's current lock snapshot."""
+        return self.manager.sync_get_lock_by_config_entry_id(self.config_entry_id)
+
+    async def set_pin_on_lock(
+        self,
+        config_entry_id: str,
+        code_slot_num: int,
+        pin: str,
+        override: bool = False,
+        set_in_kmlock: bool = False,
+    ) -> bool:
+        """Set a user code."""
+        return await self.manager.set_pin_on_lock(
+            config_entry_id,
+            code_slot_num,
+            pin,
+            override,
+            set_in_kmlock,
+        )
+
+    async def clear_pin_from_lock(
+        self,
+        config_entry_id: str,
+        code_slot_num: int,
+        override: bool = False,
+        clear_from_kmlock: bool = False,
+    ) -> bool:
+        """Clear the usercode from a code slot."""
+        return await self.manager.clear_pin_from_lock(
+            config_entry_id,
+            code_slot_num,
+            override,
+            clear_from_kmlock,
+        )
+
+    async def reset_lock(self, config_entry_id: str) -> None:
+        """Reset all of the keymaster lock settings."""
+        return await self.manager.reset_lock(config_entry_id)
+
+    async def reset_code_slot(self, config_entry_id: str, code_slot_num: int) -> None:
+        """Reset the settings of a code slot."""
+        return await self.manager.reset_code_slot(config_entry_id, code_slot_num)
+
+    async def update_slot_active_state(self, config_entry_id: str, code_slot_num: int) -> bool:
+        """Update the active state for a code slot."""
+        return await self.manager.update_slot_active_state(config_entry_id, code_slot_num)
+
+    async def async_request_debounced_refresh(self) -> None:
+        """Request a debounced coordinator refresh."""
+        return await self.manager.async_request_debounced_refresh()
+
+    def autolock_duration_seconds(self, kmlock: KeymasterLock) -> int:
+        """Compute the autolock duration for a kmlock based on time of day."""
+        return self.manager.autolock_duration_seconds(kmlock)
+
+    async def get_lock_by_config_entry_id(self, config_entry_id: str) -> KeymasterLock | None:
+        """Get a keymaster lock by entry_id."""
+        return await self.manager.get_lock_by_config_entry_id(config_entry_id)
+
+    def sync_get_lock_by_config_entry_id(self, config_entry_id: str) -> KeymasterLock | None:
+        """Get a keymaster lock by entry_id."""
+        return self.manager.sync_get_lock_by_config_entry_id(config_entry_id)
+
+    @property
+    def kmlocks(self) -> MutableMapping[str, KeymasterLock]:
+        """Return the manager-owned lock mapping."""
+        return self.manager.kmlocks
+
+
 class KeymasterCoordinator(DataUpdateCoordinator):
     """Coordinator to manage keymaster locks."""
 
@@ -128,6 +215,9 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._global_notify_handle: asyncio.Handle | None = None
         self._deferred_notifications_shutting_down = False
         self._defer_refresh_listener_updates = False
+        self._lock_coordinators: dict[str, KeymasterLockCoordinator] = {}
+        self._pending_notify_entry_ids: set[str] = set()
+        self._notify_handle: asyncio.Handle | None = None
 
         super().__init__(
             hass,
@@ -154,6 +244,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Shutting down keymaster coordinator")
         self._deferred_notifications_shutting_down = True
         self.async_cancel_pending_global_notification()
+        if self._notify_handle is not None:
+            self._notify_handle.cancel()
+            self._notify_handle = None
+        self._pending_notify_entry_ids.clear()
+        self._lock_coordinators.clear()
         if self._cancel_quick_refresh:
             self._cancel_quick_refresh()
             self._cancel_quick_refresh = None
@@ -226,6 +321,77 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         else:
             super().async_update_listeners()
 
+    @callback
+    def async_get_lock_coordinator(self, config_entry_id: str) -> KeymasterLockCoordinator:
+        """Return the entity-facing lock coordinator for an entry, creating it if needed."""
+        coordinator = self._lock_coordinators.get(config_entry_id)
+        if coordinator is None:
+            coordinator = KeymasterLockCoordinator(self, config_entry_id)
+            self._lock_coordinators[config_entry_id] = coordinator
+        return coordinator
+
+    @callback
+    def async_remove_lock_coordinator(self, config_entry_id: str) -> None:
+        """Remove a per-lock coordinator and drop any pending bridge state for it."""
+        self._lock_coordinators.pop(config_entry_id, None)
+        self._pending_notify_entry_ids.discard(config_entry_id)
+
+    @callback
+    def async_schedule_keymaster_notifications(self, entry_ids: Iterable[str]) -> None:
+        """Coalesce dirty IDs and notify global and per-lock coordinator listeners."""
+        if self._deferred_notifications_shutting_down:
+            return
+
+        valid = {entry_id for entry_id in entry_ids if entry_id in self.kmlocks}
+        if not valid and not self._pending_notify_entry_ids:
+            return
+        self._pending_notify_entry_ids |= valid
+        self.data = dict(self.kmlocks)
+        self._pending_global_notification = True
+        self._pending_global_data_update = True
+        if not getattr(self, "last_update_success", True):
+            self._pending_global_failed_refresh = True
+        else:
+            self._pending_global_failed_refresh = False
+        self._schedule_pending_keymaster_notifications()
+
+    @callback
+    def _schedule_pending_keymaster_notifications(self) -> None:
+        """Schedule the pending per-lock notification flush if not deferred."""
+        if self._defer_refresh_listener_updates:
+            return
+        if self._notify_handle is None:
+            self._notify_handle = self.hass.loop.call_soon(
+                self._flush_pending_keymaster_notifications,
+            )
+
+    @callback
+    def _flush_pending_keymaster_notifications(self) -> None:
+        """Flush both notification legs outside the active event dispatch."""
+        self._notify_handle = None
+        if self._deferred_notifications_shutting_down or self._defer_refresh_listener_updates:
+            return
+
+        entry_ids = self._pending_notify_entry_ids
+        self._pending_notify_entry_ids = set()
+        manager_healthy = getattr(self, "last_update_success", True)
+        self._flush_pending_global_notification()
+        for entry_id in entry_ids:
+            if entry_id not in self.kmlocks:
+                continue
+            lock_coordinator = self._lock_coordinators.get(entry_id)
+            if lock_coordinator is None:
+                continue
+            lock = self.kmlocks[entry_id]
+            if manager_healthy:
+                lock_coordinator.async_set_updated_data(lock)
+            else:
+                # Mirror the manager's failed-refresh state so per-lock-bound
+                # entities do not appear healthy while the manager is failing.
+                lock_coordinator.data = lock
+                lock_coordinator.last_update_success = False
+                lock_coordinator.async_update_listeners()
+
     async def _async_refresh(
         self,
         log_failures: bool = True,
@@ -250,6 +416,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 and not self._deferred_notifications_shutting_down
             ):
                 self._schedule_pending_global_notification()
+            if (
+                self._pending_notify_entry_ids
+                and self._notify_handle is None
+                and not self._deferred_notifications_shutting_down
+            ):
+                self._schedule_pending_keymaster_notifications()
 
     @callback
     def async_update_listeners(self) -> None:

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -1,11 +1,14 @@
 """Tests for KeymasterCoordinator lifecycle methods."""
 
+import asyncio
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.keymaster.coordinator import KeymasterCoordinator
+from custom_components.keymaster.const import DOMAIN
+from custom_components.keymaster.coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,6 +41,303 @@ def mock_lock():
     # Mock dataclass fields if needed for dict conversion
     lock.__dataclass_fields__ = {}
     return lock
+
+
+def _make_lock(entry_id: str = "test_entry", lock_name: str = "test_lock") -> KeymasterLock:
+    """Create a KeymasterLock for coordinator tests."""
+    return KeymasterLock(
+        lock_name=lock_name,
+        lock_entity_id=f"lock.{lock_name}",
+        keymaster_config_entry_id=entry_id,
+    )
+
+
+async def test_lock_coordinator_created_once_with_current_lock(hass):
+    """Test manager creates one lock coordinator per entry with current data."""
+    entry = MockConfigEntry(domain=DOMAIN, entry_id="test_entry", title="Test Lock", data={})
+    entry.add_to_hass(hass)
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    same_lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+
+    assert isinstance(lock_coordinator, KeymasterLockCoordinator)
+    assert same_lock_coordinator is lock_coordinator
+    assert lock_coordinator.always_update is False
+    assert lock_coordinator.update_interval is None
+    assert lock_coordinator.data is lock
+
+
+async def test_lock_coordinator_refresh_same_lock_does_not_notify(hass):
+    """Test equal-data refresh does not notify lock coordinator listeners."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    listener = MagicMock()
+    lock_coordinator.async_add_listener(listener)
+
+    await lock_coordinator.async_refresh()
+
+    listener.assert_not_called()
+    assert lock_coordinator.data is lock
+
+
+async def test_keymaster_notification_bridge_notifies_global_and_lock(hass):
+    """Test bridge notifies manager listeners and per-lock coordinator listeners."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    manager_listener = MagicMock()
+    lock_listener = MagicMock()
+    coordinator.async_add_listener(manager_listener)
+    lock_coordinator.async_add_listener(lock_listener)
+    coordinator.last_update_success = False
+
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+    assert coordinator._pending_global_failed_refresh is True
+    await asyncio.sleep(0)
+
+    manager_listener.assert_called_once()
+    lock_listener.assert_called_once()
+    assert coordinator.data == {"test_entry": lock}
+    assert lock_coordinator.data is lock
+
+    manager_listener.reset_mock()
+    lock_listener.reset_mock()
+    coordinator.async_schedule_keymaster_notifications(["missing_entry"])
+    await asyncio.sleep(0)
+
+    manager_listener.assert_not_called()
+    lock_listener.assert_not_called()
+    assert coordinator._notify_handle is None
+    await coordinator.async_shutdown()
+
+
+async def test_keymaster_notification_bridge_coalesces_duplicate_entries(hass):
+    """Test bridge coalesces duplicate entry IDs into a single flush."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    manager_listener = MagicMock()
+    lock_listener = MagicMock()
+    coordinator.async_add_listener(manager_listener)
+    lock_coordinator.async_add_listener(lock_listener)
+
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+    first_handle = coordinator._notify_handle
+    coordinator.async_schedule_keymaster_notifications(["test_entry", "missing_entry"])
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+    await asyncio.sleep(0)
+
+    assert first_handle is not None
+    manager_listener.assert_called_once()
+    lock_listener.assert_called_once()
+    assert coordinator._notify_handle is None
+    assert lock_coordinator.last_update_success is True
+    await coordinator.async_shutdown()
+
+
+async def test_keymaster_notification_bridge_preserves_lock_failed_refresh_state(hass):
+    """Test per-lock notifications preserve the manager failed-refresh state."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    lock_listener = MagicMock()
+    lock_coordinator.async_add_listener(lock_listener)
+    coordinator.last_update_success = False
+
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+    await asyncio.sleep(0)
+
+    lock_listener.assert_called_once()
+    assert lock_coordinator.data is lock
+    assert lock_coordinator.last_update_success is False
+
+
+async def test_keymaster_notification_bridge_clears_failed_refresh_flag_when_healthy(hass):
+    """Test bridge clears the pending failed-refresh flag when the manager is healthy."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    lock_listener = MagicMock()
+    lock_coordinator.async_add_listener(lock_listener)
+    coordinator._pending_global_failed_refresh = True
+    coordinator.last_update_success = True
+
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+
+    assert coordinator._pending_global_failed_refresh is False
+    await asyncio.sleep(0)
+    lock_listener.assert_called_once()
+    assert lock_coordinator.last_update_success is True
+
+
+async def test_keymaster_notification_bridge_notifies_on_in_place_mutation(hass):
+    """Test the bridge notifies per-lock listeners even for in-place lock mutation."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    lock_listener = MagicMock()
+    lock_coordinator.async_add_listener(lock_listener)
+
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+    await asyncio.sleep(0)
+    lock_listener.assert_called_once()
+    lock_listener.reset_mock()
+
+    lock.lock_state = "locked"
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+    await asyncio.sleep(0)
+
+    lock_listener.assert_called_once()
+    assert lock_coordinator.data is lock
+
+
+async def test_keymaster_notification_bridge_deferred_and_missing_lock_paths(hass):
+    """Test deferred bridge scheduling and missing per-lock coordinator paths."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    orphan_lock = _make_lock("orphan_entry", "orphan_lock")
+    coordinator.kmlocks["test_entry"] = lock
+    coordinator.kmlocks["orphan_entry"] = orphan_lock
+    coordinator.async_get_lock_coordinator("test_entry")
+    coordinator._defer_refresh_listener_updates = True
+
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+
+    assert coordinator._notify_handle is None
+    assert coordinator._pending_notify_entry_ids == {"test_entry"}
+
+    coordinator._defer_refresh_listener_updates = False
+    coordinator._pending_notify_entry_ids = {"missing_entry", "orphan_entry"}
+    coordinator._pending_global_notification = True
+    coordinator._pending_global_data_update = True
+
+    coordinator._flush_pending_keymaster_notifications()
+
+    assert coordinator._pending_notify_entry_ids == set()
+
+
+async def test_keymaster_notification_bridge_reschedules_after_refresh_deferral(hass):
+    """Test pending per-lock notifications flush after a refresh deferral window."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    lock_listener = MagicMock()
+    lock_coordinator.async_add_listener(lock_listener)
+
+    async def update_data():
+        assert coordinator._defer_refresh_listener_updates is True
+        coordinator.async_schedule_keymaster_notifications(["test_entry"])
+        assert coordinator._notify_handle is None
+        lock_listener.assert_not_called()
+        return dict(coordinator.kmlocks)
+
+    coordinator._async_update_data = update_data
+
+    await coordinator._async_refresh()
+
+    assert coordinator._notify_handle is not None
+    await asyncio.sleep(0)
+
+    lock_listener.assert_called_once()
+    assert lock_coordinator.data is lock
+    assert coordinator._pending_notify_entry_ids == set()
+
+
+async def test_keymaster_notification_bridge_shutdown_guard(hass):
+    """Test bridge does not schedule notifications while shutting down."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["test_entry"] = _make_lock()
+    coordinator._deferred_notifications_shutting_down = True
+
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+
+    assert coordinator._notify_handle is None
+    assert coordinator._pending_notify_entry_ids == set()
+
+
+async def test_lock_coordinator_proxy_methods_delegate(hass):
+    """Test lock coordinator proxy methods delegate to the manager."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    coordinator.set_pin_on_lock = AsyncMock(return_value=True)
+    coordinator.clear_pin_from_lock = AsyncMock(return_value=False)
+    coordinator.reset_lock = AsyncMock()
+    coordinator.reset_code_slot = AsyncMock()
+    coordinator.update_slot_active_state = AsyncMock(return_value=True)
+    coordinator.async_request_debounced_refresh = AsyncMock()
+    coordinator.autolock_duration_seconds = MagicMock(return_value=123)
+    coordinator.get_lock_by_config_entry_id = AsyncMock(return_value=lock)
+    coordinator.sync_get_lock_by_config_entry_id = MagicMock(return_value=lock)
+
+    assert await lock_coordinator.set_pin_on_lock("test_entry", 1, "1234", True, True) is True
+    coordinator.set_pin_on_lock.assert_awaited_once_with("test_entry", 1, "1234", True, True)
+
+    assert await lock_coordinator.clear_pin_from_lock("test_entry", 1, True, True) is False
+    coordinator.clear_pin_from_lock.assert_awaited_once_with("test_entry", 1, True, True)
+
+    await lock_coordinator.reset_lock("test_entry")
+    coordinator.reset_lock.assert_awaited_once_with("test_entry")
+
+    await lock_coordinator.reset_code_slot("test_entry", 1)
+    coordinator.reset_code_slot.assert_awaited_once_with("test_entry", 1)
+
+    assert await lock_coordinator.update_slot_active_state("test_entry", 1) is True
+    coordinator.update_slot_active_state.assert_awaited_once_with("test_entry", 1)
+
+    await lock_coordinator.async_request_debounced_refresh()
+    coordinator.async_request_debounced_refresh.assert_awaited_once_with()
+
+    assert lock_coordinator.autolock_duration_seconds(lock) == 123
+    coordinator.autolock_duration_seconds.assert_called_once_with(lock)
+
+    assert await lock_coordinator.get_lock_by_config_entry_id("test_entry") is lock
+    coordinator.get_lock_by_config_entry_id.assert_awaited_once_with("test_entry")
+
+    assert lock_coordinator.sync_get_lock_by_config_entry_id("test_entry") is lock
+    coordinator.sync_get_lock_by_config_entry_id.assert_called_once_with("test_entry")
+
+    assert lock_coordinator.kmlocks is coordinator.kmlocks
+
+
+async def test_lock_coordinator_cleanup_and_shutdown(hass):
+    """Test lock coordinator removal and shutdown bridge cleanup."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    coordinator._pending_notify_entry_ids.add("test_entry")
+
+    coordinator.async_remove_lock_coordinator("test_entry")
+
+    assert "test_entry" not in coordinator._lock_coordinators
+    assert "test_entry" not in coordinator._pending_notify_entry_ids
+
+    coordinator._lock_coordinators["test_entry"] = lock_coordinator
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+    pending_handle = coordinator._notify_handle
+    assert pending_handle is not None
+
+    await coordinator.async_shutdown()
+
+    assert pending_handle.cancelled()
+    assert coordinator._notify_handle is None
+    assert coordinator._pending_notify_entry_ids == set()
+    assert coordinator._lock_coordinators == {}
+
+    coordinator._flush_pending_keymaster_notifications()
 
 
 async def test_add_lock_new(mock_coordinator, mock_lock):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -25,8 +25,9 @@ from custom_components.keymaster.const import (
     DEFAULT_ADVANCED_DATE_RANGE,
     DEFAULT_ADVANCED_DAY_OF_WEEK,
     DOMAIN,
+    LOCK_COORDINATORS,
 )
-from custom_components.keymaster.coordinator import KeymasterCoordinator
+from custom_components.keymaster.coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.util.dt import utcnow
@@ -80,6 +81,10 @@ async def test_setup_entry(
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == baseline + KEYMASTER_SENSOR_COUNT
+
+    lock_coordinator = hass.data[DOMAIN][LOCK_COORDINATORS][entry.entry_id]
+    assert isinstance(lock_coordinator, KeymasterLockCoordinator)
+    assert lock_coordinator.manager is hass.data[DOMAIN][COORDINATOR]
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -339,6 +344,7 @@ async def test_unload_vs_remove_lock_preservation(
 
     coordinator = hass.data[DOMAIN][COORDINATOR]
     assert entry.entry_id in coordinator.kmlocks
+    assert entry.entry_id in hass.data[DOMAIN][LOCK_COORDINATORS]
 
     # Set up a mock provider to ensure line 240 is covered
     kmlock = coordinator.kmlocks[entry.entry_id]
@@ -355,6 +361,10 @@ async def test_unload_vs_remove_lock_preservation(
     assert await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
     assert entry.entry_id not in coordinator.kmlocks
+    assert DOMAIN not in hass.data or entry.entry_id not in hass.data[DOMAIN].get(
+        LOCK_COORDINATORS,
+        {},
+    )
 
 
 async def test_delete_coordinator_with_data_none(hass) -> None:

--- a/tests/test_large_lock_repairs.py
+++ b/tests/test_large_lock_repairs.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 import logging
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -501,6 +501,7 @@ async def test_remove_entry_cleanup_failure_does_not_skip_coordinator_teardown(
     delete_lock = AsyncMock()
     hass.data.setdefault(DOMAIN, {})[COORDINATOR] = SimpleNamespace(
         delete_lock_by_config_entry_id=delete_lock,
+        async_remove_lock_coordinator=Mock(),
         count_locks_not_pending_delete=1,
     )
     caplog.set_level(logging.ERROR)
@@ -591,6 +592,7 @@ async def test_setup_uses_loaded_provider_connection_status(hass: Any) -> None:
     fake_coordinator = SimpleNamespace(
         kmlocks={},
         add_lock=AsyncMock(side_effect=add_lock_with_provider),
+        async_get_lock_coordinator=Mock(),
     )
     hass.data[DOMAIN][COORDINATOR] = fake_coordinator
 
@@ -626,6 +628,7 @@ async def test_setup_continues_when_add_lock_times_out(
     hass.data.setdefault(DOMAIN, {})[COORDINATOR] = SimpleNamespace(
         kmlocks={},
         add_lock=AsyncMock(side_effect=asyncio.CancelledError()),
+        async_get_lock_coordinator=Mock(),
     )
     caplog.set_level(logging.ERROR)
 


### PR DESCRIPTION
## Summary

Phase B **foundation** for issue #670. Adds the per-lock coordinator primitive and a dual-target notification bridge **without** rebinding entities (they remain bound to the global manager `KeymasterCoordinator`) and **without** changing persisted storage. This PR is deliberately scoped as scaffolding: the follow-up issues wire it into runtime.

## Changes

- **`KeymasterLockCoordinator`** (`coordinator.py`): one entity-facing coordinator per config entry. Constructed with `always_update=False` and `update_interval=None` — it never owns a 60s interval and never polls providers directly. Its `data` is a single `KeymasterLock | None`, initialized from the manager before platforms build entities. Proxies the manager methods entities will need after rebinding.
- **Dual-target notification bridge** (`KeymasterCoordinator.async_schedule_keymaster_notifications`): coalesces dirty entry IDs, drops IDs not in `kmlocks`, and on a deferred `call_soon` flush is **capable of** notifying both the global manager leg (for still-bound entities) and any existing per-lock coordinator legs — mirroring the manager's sticky-failure semantics and rescheduling symmetrically with the global leg after a refresh-deferral window. It is verified by tests but is **not yet invoked from runtime mutation paths in this PR** (see Scope below).
- **Manager storage/lookup**: `LOCK_COORDINATORS` hass-data key, `async_get_lock_coordinator` (create-if-missing), `async_remove_lock_coordinator`. `KeymasterCoordinator` remains the manager/storage owner and its `.data` stays a `dict` mirror of `kmlocks`.
- **Lifecycle** (`__init__.py`): the per-entry lock coordinator is created after `add_lock` and before platform forwarding; removed on entry removal; `async_shutdown` cancels the bridge handle and clears per-lock state.

## Scope (intentional)

This is the foundation only. Entities remain bound to the global manager and continue to receive updates via the existing global notification path, so behavior is unchanged. Wiring the bridge into runtime is split into the follow-up issues:
- **#681** rebinds entities to the per-lock coordinators.
- **#682** / **#684** route refresh and mutation paths through the bridge with dirty-lock scoping.

Keeping the bridge dormant-but-tested here keeps each PR small and reviewable.

## Testing

- New/extended tests in `tests/test_coordinator_lifecycle.py` and `tests/test_init.py`: per-entry creation, `always_update=False` no-notify-on-equal-data via the refresh path, dual-target fan-out, coalescing, refresh-deferral rescheduling, sticky-failure preservation, in-place-mutation notification, failed-refresh-flag clearing, shutdown guard/cleanup, proxy delegation, and setup/remove wiring.
- `ruff check`, `ruff format`, `mypy`, and the targeted suites pass; 100% patch coverage on new lines.

Closes #680
Part of #670