### PR TITLE
Refactor: Bind Keymaster entities to per-lock coordinators

### DIFF
--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
-from .coordinator import KeymasterCoordinator
+from .coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from .entity import KeymasterEntity, KeymasterEntityDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -27,8 +27,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Create the keymaster Binary Sensors."""
-    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
-    kmlock = await coordinator.get_lock_by_config_entry_id(config_entry.entry_id)
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
+        config_entry.entry_id
+    )
+    kmlock = await manager.get_lock_by_config_entry_id(config_entry.entry_id)
     entities: list = []
 
     if not kmlock:

--- a/custom_components/keymaster/button.py
+++ b/custom_components/keymaster/button.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
-from .coordinator import KeymasterCoordinator
+from .coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from .entity import KeymasterEntity, KeymasterEntityDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -23,7 +23,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up keymaster button."""
-    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
+        config_entry.entry_id
+    )
     entities: list = []
     entities.append(
         KeymasterButton(

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -188,6 +188,11 @@ class KeymasterLockCoordinator(DataUpdateCoordinator[KeymasterLock | None]):
         """Return the manager-owned lock mapping."""
         return self.manager.kmlocks
 
+    @callback
+    def async_schedule_notification(self) -> None:
+        """Schedule a dual-target notification for this lock's config entry."""
+        self.manager.async_schedule_keymaster_notifications([self.config_entry_id])
+
 
 class KeymasterCoordinator(DataUpdateCoordinator):
     """Coordinator to manage keymaster locks."""
@@ -218,6 +223,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._lock_coordinators: dict[str, KeymasterLockCoordinator] = {}
         self._pending_notify_entry_ids: set[str] = set()
         self._notify_handle: asyncio.Handle | None = None
+        self._refresh_keepalive_unsub: Callable[[], None] | None = None
 
         super().__init__(
             hass,
@@ -249,6 +255,9 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self._notify_handle = None
         self._pending_notify_entry_ids.clear()
         self._lock_coordinators.clear()
+        if self._refresh_keepalive_unsub is not None:
+            self._refresh_keepalive_unsub()
+            self._refresh_keepalive_unsub = None
         if self._cancel_quick_refresh:
             self._cancel_quick_refresh()
             self._cancel_quick_refresh = None
@@ -295,24 +304,13 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._schedule_pending_global_notification()
 
     @callback
-    def _flush_pending_global_notification(self) -> None:
-        """Notify the global coordinator outside active event dispatch."""
-        self._global_notify_handle = None
-        if not self._pending_global_notification or self._deferred_notifications_shutting_down:
-            return
-        if self._defer_refresh_listener_updates:
-            return
-
+    def _flush_global_leg(self) -> tuple[bool, bool]:
+        """Notify manager listeners / update the mirror; return (data_update, preserve_failed_refresh)."""
         data_update = self._pending_global_data_update
         preserve_failed_refresh = self._pending_global_failed_refresh
         self._pending_global_notification = False
         self._pending_global_data_update = False
         self._pending_global_failed_refresh = False
-
-        # Keep self.data refreshed for every data-update path: explicitly in
-        # the sticky-failure branch, and via async_set_updated_data() when
-        # healthy. Notify-only flushes intentionally leave the mirror unchanged
-        # because no data changed; preserve this invariant for new branches.
         if data_update and preserve_failed_refresh:
             self.data = dict(self.kmlocks)
             super().async_update_listeners()
@@ -320,6 +318,52 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             super().async_set_updated_data(dict(self.kmlocks))
         else:
             super().async_update_listeners()
+        return data_update, preserve_failed_refresh
+
+    @callback
+    def _push_lock_coordinator_update(
+        self, entry_id: str, *, data_update: bool, preserve_failed_refresh: bool
+    ) -> None:
+        """Push the current lock snapshot to one per-lock coordinator, mirroring manager health."""
+        lock_coordinator = self._lock_coordinators.get(entry_id)
+        if lock_coordinator is None or entry_id not in self.kmlocks:
+            return
+        lock = self.kmlocks[entry_id]
+        if data_update and not preserve_failed_refresh:
+            lock_coordinator.async_set_updated_data(lock)
+        else:
+            lock_coordinator.data = lock
+            lock_coordinator.last_update_success = self.last_update_success
+            lock_coordinator.async_update_listeners()
+
+    @callback
+    def _flush_pending_global_notification(self) -> None:
+        """Notify the global leg and (conservatively) every per-lock coordinator."""
+        self._global_notify_handle = None
+        if not self._pending_global_notification or self._deferred_notifications_shutting_down:
+            return
+        if self._defer_refresh_listener_updates:
+            return
+        # Absorb any pending scoped bridge flush; the all-lock fan-out covers it.
+        if self._notify_handle is not None:
+            self._notify_handle.cancel()
+            self._notify_handle = None
+        self._pending_notify_entry_ids = set()
+        data_update, preserve_failed_refresh = self._flush_global_leg()
+        for entry_id in list(self._lock_coordinators):
+            self._push_lock_coordinator_update(
+                entry_id, data_update=data_update, preserve_failed_refresh=preserve_failed_refresh
+            )
+
+    @callback
+    def _keepalive_listener(self) -> None:
+        """No-op listener that keeps the manager's periodic refresh scheduled."""
+
+    @callback
+    def _ensure_refresh_keepalive(self) -> None:
+        """Keep the manager refresh loop alive now that entities listen on per-lock coordinators."""
+        if self._refresh_keepalive_unsub is None:
+            self._refresh_keepalive_unsub = self.async_add_listener(self._keepalive_listener)
 
     @callback
     def async_get_lock_coordinator(self, config_entry_id: str) -> KeymasterLockCoordinator:
@@ -328,6 +372,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if coordinator is None:
             coordinator = KeymasterLockCoordinator(self, config_entry_id)
             self._lock_coordinators[config_entry_id] = coordinator
+        self._ensure_refresh_keepalive()
         return coordinator
 
     @callback
@@ -335,6 +380,9 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         """Remove a per-lock coordinator and drop any pending bridge state for it."""
         self._lock_coordinators.pop(config_entry_id, None)
         self._pending_notify_entry_ids.discard(config_entry_id)
+        if not self._lock_coordinators and self._refresh_keepalive_unsub is not None:
+            self._refresh_keepalive_unsub()
+            self._refresh_keepalive_unsub = None
 
     @callback
     def async_schedule_keymaster_notifications(self, entry_ids: Iterable[str]) -> None:
@@ -367,30 +415,26 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
     @callback
     def _flush_pending_keymaster_notifications(self) -> None:
-        """Flush both notification legs outside the active event dispatch."""
+        """Flush the global leg and per-lock coordinators (scoped, or all if a global fan-out was also pending)."""
         self._notify_handle = None
         if self._deferred_notifications_shutting_down or self._defer_refresh_listener_updates:
             return
-
         entry_ids = self._pending_notify_entry_ids
         self._pending_notify_entry_ids = set()
-        manager_healthy = getattr(self, "last_update_success", True)
-        self._flush_pending_global_notification()
-        for entry_id in entry_ids:
-            if entry_id not in self.kmlocks:
-                continue
-            lock_coordinator = self._lock_coordinators.get(entry_id)
-            if lock_coordinator is None:
-                continue
-            lock = self.kmlocks[entry_id]
-            if manager_healthy:
-                lock_coordinator.async_set_updated_data(lock)
-            else:
-                # Mirror the manager's failed-refresh state so per-lock-bound
-                # entities do not appear healthy while the manager is failing.
-                lock_coordinator.data = lock
-                lock_coordinator.last_update_success = False
-                lock_coordinator.async_update_listeners()
+        # If a global all-lock fan-out was also pending, absorb it and fan out to all.
+        global_notify_handle = self._global_notify_handle
+        if global_notify_handle is not None:
+            all_fanout = True
+            global_notify_handle.cancel()
+            self._global_notify_handle = None
+        else:
+            all_fanout = False
+        data_update, preserve_failed_refresh = self._flush_global_leg()
+        targets = list(self._lock_coordinators) if all_fanout else list(entry_ids)
+        for entry_id in targets:
+            self._push_lock_coordinator_update(
+                entry_id, data_update=data_update, preserve_failed_refresh=preserve_failed_refresh
+            )
 
     async def _async_refresh(
         self,

--- a/custom_components/keymaster/datetime.py
+++ b/custom_components/keymaster/datetime.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_ADVANCED_DATE_RANGE, CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
-from .coordinator import KeymasterCoordinator
+from .coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from .entity import KeymasterEntity, KeymasterEntityDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -23,7 +23,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Create the keymaster DateTime Entities."""
-    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
+        config_entry.entry_id
+    )
     entities: list = []
 
     if not config_entry.data[CONF_ADVANCED_DATE_RANGE]:

--- a/custom_components/keymaster/entity.py
+++ b/custom_components/keymaster/entity.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
 from .const import DOMAIN
-from .coordinator import KeymasterCoordinator
+from .coordinator import KeymasterLockCoordinator
 from .lock import KeymasterLock
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -25,14 +25,14 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 # Items cannot contain . or : in their names
 
 
-class KeymasterEntity(CoordinatorEntity[KeymasterCoordinator]):
+class KeymasterEntity(CoordinatorEntity[KeymasterLockCoordinator]):
     """Base entity for Keymaster."""
 
     def __init__(self, entity_description: KeymasterEntityDescription) -> None:
         """Initialize base keymaster entity."""
         # _LOGGER.debug("[Entity init] entity_description: %s", entity_description)
         self.hass: HomeAssistant = entity_description.hass
-        self.coordinator: KeymasterCoordinator = entity_description.coordinator
+        self.coordinator: KeymasterLockCoordinator = entity_description.coordinator
         self._config_entry: ConfigEntry = entity_description.config_entry
         self.entity_description: KeymasterEntityDescription = entity_description
         self._property: str = entity_description.key  # <Platform>.<Property>.<SubProperty>:<Slot Number*>.<SubProperty>:<Slot Number*>  *Only if needed
@@ -146,4 +146,4 @@ class KeymasterEntityDescription(EntityDescription):
 
     hass: HomeAssistant
     config_entry: ConfigEntry
-    coordinator: KeymasterCoordinator
+    coordinator: KeymasterLockCoordinator

--- a/custom_components/keymaster/event.py
+++ b/custom_components/keymaster/event.py
@@ -23,7 +23,7 @@ from .const import (
     EVENT_KEYMASTER_CODE_SLOT_RESET,
     EVENT_KEYMASTER_LOCK_STATE_CHANGED,
 )
-from .coordinator import KeymasterCoordinator
+from .coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from .entity import KeymasterEntity, KeymasterEntityDescription
 
 EVENT_TYPE_UNLOCKED = "unlocked"
@@ -42,7 +42,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up event entities for keymaster code slots."""
-    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
+        config_entry.entry_id
+    )
 
     entities: list[KeymasterCodeSlotEventEntity] = [
         KeymasterCodeSlotEventEntity(

--- a/custom_components/keymaster/number.py
+++ b/custom_components/keymaster/number.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
-from .coordinator import KeymasterCoordinator
+from .coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from .entity import KeymasterEntity, KeymasterEntityDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -28,7 +28,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Create keymaster Number entities."""
-    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
+        config_entry.entry_id
+    )
 
     entities: list = [
         KeymasterNumber(

--- a/custom_components/keymaster/sensor.py
+++ b/custom_components/keymaster/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
-from .coordinator import KeymasterCoordinator
+from .coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from .entity import KeymasterEntity, KeymasterEntityDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -25,8 +25,11 @@ async def async_setup_entry(
 ) -> None:
     """Create keymaster Sensor entities."""
 
-    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
-    kmlock = await coordinator.get_lock_by_config_entry_id(config_entry.entry_id)
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
+        config_entry.entry_id
+    )
+    kmlock = await manager.get_lock_by_config_entry_id(config_entry.entry_id)
     entities: list = []
 
     entities.append(

--- a/custom_components/keymaster/switch.py
+++ b/custom_components/keymaster/switch.py
@@ -25,7 +25,7 @@ from .const import (
     DEFAULT_AUTOLOCK_MIN_NIGHT,
     DOMAIN,
 )
-from .coordinator import KeymasterCoordinator
+from .coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from .entity import KeymasterEntity, KeymasterEntityDescription
 from .lock import KeymasterCodeSlot, KeymasterCodeSlotDayOfWeek, KeymasterLock
 
@@ -38,10 +38,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Create keymaster Switches."""
-    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
-    kmlock: KeymasterLock | None = await coordinator.get_lock_by_config_entry_id(
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
         config_entry.entry_id
     )
+    kmlock: KeymasterLock | None = await manager.get_lock_by_config_entry_id(config_entry.entry_id)
     entities: list = []
 
     if not kmlock:
@@ -303,7 +304,7 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
                     await self._kmlock.autolock_timer.start(
                         duration=self.coordinator.autolock_duration_seconds(self._kmlock)
                     )
-                    self.coordinator.async_schedule_global_notification()
+                    self.coordinator.async_schedule_notification()
             if (
                 self._property.endswith(".enabled")
                 and self._kmlock
@@ -339,7 +340,7 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
             if self._property == "switch.autolock_enabled" and self._kmlock:
                 if self._kmlock.autolock_timer and self._kmlock.autolock_timer.is_running:
                     await self._kmlock.autolock_timer.cancel()
-                    self.coordinator.async_schedule_global_notification()
+                    self.coordinator.async_schedule_notification()
             if self._property.endswith(".enabled") and self._code_slot:
                 await self.coordinator.update_slot_active_state(
                     config_entry_id=self._config_entry.entry_id,

--- a/custom_components/keymaster/text.py
+++ b/custom_components/keymaster/text.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_HIDE_PINS, CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
-from .coordinator import KeymasterCoordinator
+from .coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from .entity import KeymasterEntity, KeymasterEntityDescription
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -23,7 +23,10 @@ async def async_setup_entry(
 ) -> None:
     """Create keymaster Text entities."""
 
-    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
+        config_entry.entry_id
+    )
     entities: list = []
 
     for x in range(

--- a/custom_components/keymaster/time.py
+++ b/custom_components/keymaster/time.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_ADVANCED_DAY_OF_WEEK, CONF_SLOTS, CONF_START, COORDINATOR, DAY_NAMES, DOMAIN
-from .coordinator import KeymasterCoordinator
+from .coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from .entity import KeymasterEntity, KeymasterEntityDescription
 from .lock import KeymasterCodeSlotDayOfWeek
 
@@ -25,7 +25,10 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Create keymaster Time entities."""
-    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
+        config_entry.entry_id
+    )
     entities: list = []
 
     if not config_entry.data[CONF_ADVANCED_DAY_OF_WEEK]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,8 @@ from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
 from zwave_js_server.model.version import VersionInfo
 
-from custom_components.keymaster.const import NONE_TEXT
+from custom_components.keymaster.const import COORDINATOR, DOMAIN, NONE_TEXT
+from custom_components.keymaster.coordinator import KeymasterCoordinator
 from custom_components.keymaster.providers._base import BaseLockProvider, CodeSlot
 from homeassistant.components.zwave_js import PLATFORMS
 from homeassistant.const import Platform
@@ -157,6 +158,9 @@ async def auto_unload(hass: HomeAssistant):
     for entry in hass.config_entries.async_entries("keymaster"):
         await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+    coordinator = hass.data.get(DOMAIN, {}).get(COORDINATOR)
+    if isinstance(coordinator, KeymasterCoordinator):
+        await coordinator.async_shutdown()
 
 
 @pytest.fixture

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -7,7 +7,14 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from zwave_js_server.event import Event
 
 from custom_components.keymaster.binary_sensor import async_setup_entry
-from custom_components.keymaster.const import CONF_SLOTS, CONF_START, COORDINATOR, DOMAIN
+from custom_components.keymaster.const import (
+    CONF_LOCK_ENTITY_ID,
+    CONF_SLOTS,
+    CONF_START,
+    COORDINATOR,
+    DOMAIN,
+)
+from custom_components.keymaster.coordinator import KeymasterCoordinator
 from custom_components.keymaster.lock import KeymasterLock
 from homeassistant.components.lock.const import LockState
 from homeassistant.config_entries import ConfigEntryState
@@ -41,6 +48,7 @@ async def test_setup_entry_creates_connection_sensor_when_provider_none(hass):
     mock_coordinator = MagicMock()
     mock_coordinator.get_lock_by_config_entry_id = AsyncMock(return_value=mock_lock)
     mock_coordinator.sync_get_lock_by_config_entry_id = MagicMock(return_value=mock_lock)
+    mock_coordinator.async_get_lock_coordinator.return_value = mock_coordinator
 
     hass.data.setdefault(DOMAIN, {})[COORDINATOR] = mock_coordinator
 
@@ -75,6 +83,7 @@ async def test_setup_entry_creates_connection_sensor_when_provider_supports_it(h
     mock_coordinator = MagicMock()
     mock_coordinator.get_lock_by_config_entry_id = AsyncMock(return_value=mock_lock)
     mock_coordinator.sync_get_lock_by_config_entry_id = MagicMock(return_value=mock_lock)
+    mock_coordinator.async_get_lock_coordinator.return_value = mock_coordinator
 
     hass.data.setdefault(DOMAIN, {})[COORDINATOR] = mock_coordinator
 
@@ -108,6 +117,7 @@ async def test_setup_entry_no_connection_sensor_when_provider_unsupported(hass):
     mock_coordinator = MagicMock()
     mock_coordinator.get_lock_by_config_entry_id = AsyncMock(return_value=mock_lock)
     mock_coordinator.sync_get_lock_by_config_entry_id = MagicMock(return_value=mock_lock)
+    mock_coordinator.async_get_lock_coordinator.return_value = mock_coordinator
 
     hass.data.setdefault(DOMAIN, {})[COORDINATOR] = mock_coordinator
 
@@ -118,6 +128,34 @@ async def test_setup_entry_no_connection_sensor_when_provider_unsupported(hass):
         e for e in added_entities if "binary_sensor.connected" in e.entity_description.key
     ]
     assert len(connection_sensors) == 0
+
+
+async def test_setup_entry_binds_binary_sensors_to_lock_coordinator(hass):
+    """Test binary sensors created by setup use the per-lock coordinator."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_lock",
+        data={**CONFIG_DATA_910, CONF_START: 1, CONF_SLOTS: 1},
+    )
+    config_entry.add_to_hass(hass)
+
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    kmlock = KeymasterLock(
+        lock_name="Test Lock",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=config_entry.entry_id,
+    )
+    kmlock.provider = None
+    coordinator.kmlocks[config_entry.entry_id] = kmlock
+    hass.data.setdefault(DOMAIN, {})[COORDINATOR] = coordinator
+
+    added_entities: list = []
+    await async_setup_entry(hass, config_entry, lambda entities, _: added_entities.extend(entities))
+
+    lock_coordinator = coordinator.async_get_lock_coordinator(config_entry.entry_id)
+    assert all(entity.coordinator is lock_coordinator for entity in added_entities)
+    assert added_entities[0].unique_id == f"{config_entry.entry_id}_binary_sensor_connected"
 
 
 async def test_zwavejs_network_ready(hass, client, lock_kwikset_910, integration, caplog):
@@ -145,8 +183,12 @@ async def test_zwavejs_network_ready(hass, client, lock_kwikset_910, integration
     assert state.state == LockState.UNLOCKED
 
     # Load the integration with wrong lock entity_id
+    hass.data.pop(DOMAIN, None)
     config_entry = MockConfigEntry(
-        domain=DOMAIN, title="frontdoor", data=CONFIG_DATA_910, version=3
+        domain=DOMAIN,
+        title="frontdoor",
+        data={**CONFIG_DATA_910, CONF_LOCK_ENTITY_ID: "lock.missing"},
+        version=3,
     )
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -59,8 +59,8 @@ async def button_config_entry(hass: HomeAssistant):
 @pytest.fixture
 async def coordinator(hass: HomeAssistant, button_config_entry):
     """Get the coordinator."""
-    del button_config_entry  # Parameter needed to ensure setup runs first
-    return hass.data[DOMAIN][COORDINATOR]
+    manager = hass.data[DOMAIN][COORDINATOR]
+    return manager.async_get_lock_coordinator(button_config_entry.entry_id)
 
 
 async def test_button_entities_created(hass: HomeAssistant, button_config_entry):
@@ -82,6 +82,11 @@ async def test_button_entities_created(hass: HomeAssistant, button_config_entry)
     assert "Reset Lock" in entity_names
     assert "Code Slot 1: Reset" in entity_names
     assert "Code Slot 2: Reset" in entity_names
+
+    manager = hass.data[DOMAIN][COORDINATOR]
+    lock_coordinator = manager.async_get_lock_coordinator(button_config_entry.entry_id)
+    assert all(entity.coordinator is lock_coordinator for entity in entities)
+    assert entities[0].unique_id == f"{button_config_entry.entry_id}_button_reset_lock"
 
 
 async def test_button_entity_initialization(hass: HomeAssistant, button_config_entry, coordinator):

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -68,6 +68,7 @@ async def test_lock_coordinator_created_once_with_current_lock(hass):
     assert lock_coordinator.always_update is False
     assert lock_coordinator.update_interval is None
     assert lock_coordinator.data is lock
+    await coordinator.async_shutdown()
 
 
 async def test_lock_coordinator_refresh_same_lock_does_not_notify(hass):
@@ -83,6 +84,47 @@ async def test_lock_coordinator_refresh_same_lock_does_not_notify(hass):
 
     listener.assert_not_called()
     assert lock_coordinator.data is lock
+    await coordinator.async_shutdown()
+
+
+async def test_lock_coordinator_creation_installs_refresh_keepalive(hass):
+    """Test lock coordinator creation keeps the manager refresh loop alive."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["test_entry"] = _make_lock()
+
+    coordinator.async_get_lock_coordinator("test_entry")
+    assert coordinator._refresh_keepalive_unsub is not None
+
+    await coordinator.async_shutdown()
+
+    assert coordinator._refresh_keepalive_unsub is None
+
+
+async def test_lock_coordinator_removal_manages_refresh_keepalive(hass):
+    """Test keepalive is removed with the last lock coordinator and can be reinstalled."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["A"] = _make_lock("A", "lock_a")
+    coordinator.kmlocks["B"] = _make_lock("B", "lock_b")
+    coordinator.kmlocks["C"] = _make_lock("C", "lock_c")
+
+    coordinator.async_get_lock_coordinator("A")
+    coordinator.async_get_lock_coordinator("B")
+
+    assert coordinator._refresh_keepalive_unsub is not None
+
+    coordinator.async_remove_lock_coordinator("A")
+
+    assert coordinator._refresh_keepalive_unsub is not None
+
+    coordinator.async_remove_lock_coordinator("B")
+
+    assert coordinator._refresh_keepalive_unsub is None
+
+    coordinator.async_get_lock_coordinator("C")
+
+    assert coordinator._refresh_keepalive_unsub is not None
+
+    await coordinator.async_shutdown()
 
 
 async def test_keymaster_notification_bridge_notifies_global_and_lock(hass):
@@ -114,6 +156,140 @@ async def test_keymaster_notification_bridge_notifies_global_and_lock(hass):
     manager_listener.assert_not_called()
     lock_listener.assert_not_called()
     assert coordinator._notify_handle is None
+    await coordinator.async_shutdown()
+
+
+async def test_global_notification_conservatively_notifies_all_lock_coordinators(hass):
+    """Test global mutation notifications fan out to every per-lock coordinator."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    other_lock = _make_lock("other_entry", "other_lock")
+    coordinator.kmlocks["test_entry"] = lock
+    coordinator.kmlocks["other_entry"] = other_lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    other_lock_coordinator = coordinator.async_get_lock_coordinator("other_entry")
+    lock_listener = MagicMock()
+    other_lock_listener = MagicMock()
+    lock_coordinator.async_add_listener(lock_listener)
+    other_lock_coordinator.async_add_listener(other_lock_listener)
+
+    coordinator.async_schedule_global_notification()
+    await asyncio.sleep(0)
+
+    lock_listener.assert_called_once()
+    other_lock_listener.assert_called_once()
+    assert lock_coordinator.data is lock
+    assert other_lock_coordinator.data is other_lock
+    await coordinator.async_shutdown()
+
+
+async def test_global_flush_absorbs_pending_scoped_bridge(hass):
+    """Test global flush covers pending scoped notifications without double-firing."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    other_lock = _make_lock("other_entry", "other_lock")
+    coordinator.kmlocks["test_entry"] = lock
+    coordinator.kmlocks["other_entry"] = other_lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    other_lock_coordinator = coordinator.async_get_lock_coordinator("other_entry")
+    lock_listener = MagicMock()
+    other_lock_listener = MagicMock()
+    lock_coordinator.async_add_listener(lock_listener)
+    other_lock_coordinator.async_add_listener(other_lock_listener)
+
+    coordinator.async_schedule_global_notification()
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+    await asyncio.sleep(0)
+
+    lock_listener.assert_called_once()
+    other_lock_listener.assert_called_once()
+    assert coordinator._global_notify_handle is None
+    assert coordinator._notify_handle is None
+    await coordinator.async_shutdown()
+
+
+async def test_scoped_bridge_absorbs_pending_global_flush(hass):
+    """Test scoped bridge expands to all locks when a global flush is also pending."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    other_lock = _make_lock("other_entry", "other_lock")
+    coordinator.kmlocks["test_entry"] = lock
+    coordinator.kmlocks["other_entry"] = other_lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    other_lock_coordinator = coordinator.async_get_lock_coordinator("other_entry")
+    lock_listener = MagicMock()
+    other_lock_listener = MagicMock()
+    lock_coordinator.async_add_listener(lock_listener)
+    other_lock_coordinator.async_add_listener(other_lock_listener)
+
+    coordinator.async_schedule_keymaster_notifications(["test_entry"])
+    coordinator.async_schedule_global_notification()
+    await asyncio.sleep(0)
+
+    lock_listener.assert_called_once()
+    other_lock_listener.assert_called_once()
+    assert coordinator._global_notify_handle is None
+    assert coordinator._notify_handle is None
+    await coordinator.async_shutdown()
+
+
+async def test_refresh_completion_notification_fans_out_to_lock_coordinators(hass):
+    """Test deferred refresh-completion notifications reach per-lock coordinators."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    lock_listener = MagicMock()
+    lock_coordinator.async_add_listener(lock_listener)
+
+    async def update_data():
+        assert coordinator._defer_refresh_listener_updates is True
+        coordinator.async_update_listeners()
+        lock_listener.assert_not_called()
+        return dict(coordinator.kmlocks)
+
+    coordinator._async_update_data = update_data
+
+    await coordinator._async_refresh()
+
+    assert coordinator._global_notify_handle is not None
+    await asyncio.sleep(0)
+
+    lock_listener.assert_called_once()
+    assert lock_coordinator.data is lock
+    await coordinator.async_shutdown()
+
+
+async def test_global_notification_flush_guards(hass):
+    """Test global notification flush returns while empty or refresh-deferred."""
+    coordinator = KeymasterCoordinator(hass)
+
+    coordinator._flush_pending_global_notification()
+
+    coordinator._pending_global_notification = True
+    coordinator._defer_refresh_listener_updates = True
+
+    coordinator._flush_pending_global_notification()
+
+    assert coordinator._pending_global_notification is True
+
+
+async def test_lock_coordinator_schedule_notification_targets_own_entry(hass):
+    """Test per-lock notification helper schedules the bridge for its own entry."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+    lock_listener = MagicMock()
+    lock_coordinator.async_add_listener(lock_listener)
+
+    lock_coordinator.async_schedule_notification()
+
+    assert coordinator._pending_notify_entry_ids == {"test_entry"}
+    await asyncio.sleep(0)
+
+    lock_listener.assert_called_once()
+    assert coordinator._pending_notify_entry_ids == set()
     await coordinator.async_shutdown()
 
 
@@ -158,6 +334,7 @@ async def test_keymaster_notification_bridge_preserves_lock_failed_refresh_state
     lock_listener.assert_called_once()
     assert lock_coordinator.data is lock
     assert lock_coordinator.last_update_success is False
+    await coordinator.async_shutdown()
 
 
 async def test_keymaster_notification_bridge_clears_failed_refresh_flag_when_healthy(hass):
@@ -177,6 +354,7 @@ async def test_keymaster_notification_bridge_clears_failed_refresh_flag_when_hea
     await asyncio.sleep(0)
     lock_listener.assert_called_once()
     assert lock_coordinator.last_update_success is True
+    await coordinator.async_shutdown()
 
 
 async def test_keymaster_notification_bridge_notifies_on_in_place_mutation(hass):
@@ -199,6 +377,7 @@ async def test_keymaster_notification_bridge_notifies_on_in_place_mutation(hass)
 
     lock_listener.assert_called_once()
     assert lock_coordinator.data is lock
+    await coordinator.async_shutdown()
 
 
 async def test_keymaster_notification_bridge_deferred_and_missing_lock_paths(hass):
@@ -224,6 +403,7 @@ async def test_keymaster_notification_bridge_deferred_and_missing_lock_paths(has
     coordinator._flush_pending_keymaster_notifications()
 
     assert coordinator._pending_notify_entry_ids == set()
+    await coordinator.async_shutdown()
 
 
 async def test_keymaster_notification_bridge_reschedules_after_refresh_deferral(hass):
@@ -252,6 +432,7 @@ async def test_keymaster_notification_bridge_reschedules_after_refresh_deferral(
     lock_listener.assert_called_once()
     assert lock_coordinator.data is lock
     assert coordinator._pending_notify_entry_ids == set()
+    await coordinator.async_shutdown()
 
 
 async def test_keymaster_notification_bridge_shutdown_guard(hass):
@@ -310,6 +491,7 @@ async def test_lock_coordinator_proxy_methods_delegate(hass):
     coordinator.sync_get_lock_by_config_entry_id.assert_called_once_with("test_entry")
 
     assert lock_coordinator.kmlocks is coordinator.kmlocks
+    await coordinator.async_shutdown()
 
 
 async def test_lock_coordinator_cleanup_and_shutdown(hass):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -63,8 +63,8 @@ async def datetime_config_entry(hass: HomeAssistant):
 @pytest.fixture
 async def coordinator(hass: HomeAssistant, datetime_config_entry):
     """Get the coordinator."""
-    del datetime_config_entry  # Parameter needed to ensure setup runs first
-    return hass.data[DOMAIN][COORDINATOR]
+    manager = hass.data[DOMAIN][COORDINATOR]
+    return manager.async_get_lock_coordinator(datetime_config_entry.entry_id)
 
 
 async def test_datetime_entity_not_created_without_advanced_date_range(
@@ -115,6 +115,14 @@ async def test_datetime_entities_created_with_advanced_date_range(
 
     # Should create entities: 2 slots * 2 (start/end) = 4 entities
     assert len(entities) == 4
+
+    manager = hass.data[DOMAIN][COORDINATOR]
+    lock_coordinator = manager.async_get_lock_coordinator(datetime_config_entry.entry_id)
+    assert all(entity.coordinator is lock_coordinator for entity in entities)
+    assert (
+        entities[0].unique_id
+        == f"{datetime_config_entry.entry_id}_datetime_code_slots_1_accesslimit_date_range_start"
+    )
 
     # Verify entity names follow expected pattern
     entity_names = [e.entity_description.name for e in entities]

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -54,8 +54,37 @@ async def entity_config_entry(hass: HomeAssistant):
 @pytest.fixture
 async def coordinator(hass: HomeAssistant, entity_config_entry):
     """Get the coordinator."""
-    del entity_config_entry  # Parameter needed to ensure setup runs first
-    return hass.data[DOMAIN][COORDINATOR]
+    manager = hass.data[DOMAIN][COORDINATOR]
+    return manager.async_get_lock_coordinator(entity_config_entry.entry_id)
+
+
+async def test_entity_uses_lock_coordinator_and_stable_unique_id(
+    hass: HomeAssistant, entity_config_entry, coordinator
+):
+    """Test base entities bind to the per-lock coordinator without changing unique IDs."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=entity_config_entry.entry_id,
+    )
+    coordinator.kmlocks[entity_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterEntityDescription(
+        key="switch.autolock_enabled",
+        name="Auto Lock",
+        hass=hass,
+        config_entry=entity_config_entry,
+        coordinator=coordinator,
+    )
+
+    class MockEntity(KeymasterEntity):
+        def _handle_coordinator_update(self):
+            pass
+
+    entity = MockEntity(entity_description=entity_description)
+
+    assert entity.coordinator is coordinator
+    assert entity.unique_id == f"{entity_config_entry.entry_id}_switch_autolock_enabled"
 
 
 async def test_entity_get_property_value_simple(

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -494,3 +494,7 @@ async def test_event_entity_created_in_setup(hass: HomeAssistant):
     assert added_entities[0].entity_description.key == "event.code_slots:1.last_used"
     assert added_entities[1].entity_description.key == "event.code_slots:2.last_used"
     assert added_entities[0].event_types == [EVENT_TYPE_UNLOCKED]
+
+    lock_coordinator = coordinator.async_get_lock_coordinator(config_entry.entry_id)
+    assert all(entity.coordinator is lock_coordinator for entity in added_entities)
+    assert added_entities[0].unique_id == f"{config_entry.entry_id}_event_code_slots_1_last_used"

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -62,7 +62,8 @@ async def number_config_entry(hass: HomeAssistant):
 @pytest.fixture
 async def coordinator(hass: HomeAssistant, number_config_entry):
     """Get the coordinator."""
-    return hass.data[DOMAIN][COORDINATOR]
+    manager = hass.data[DOMAIN][COORDINATOR]
+    return manager.async_get_lock_coordinator(number_config_entry.entry_id)
 
 
 async def test_number_entities_created(hass: HomeAssistant, number_config_entry):
@@ -86,6 +87,11 @@ async def test_number_entities_created(hass: HomeAssistant, number_config_entry)
     assert "Night Auto Lock" in entity_names
     assert "Code Slot 1: Uses Remaining" in entity_names
     assert "Code Slot 2: Uses Remaining" in entity_names
+
+    manager = hass.data[DOMAIN][COORDINATOR]
+    lock_coordinator = manager.async_get_lock_coordinator(number_config_entry.entry_id)
+    assert all(entity.coordinator is lock_coordinator for entity in entities)
+    assert entities[0].unique_id == f"{number_config_entry.entry_id}_number_autolock_min_day"
 
 
 async def test_number_autolock_entities_have_correct_config(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -61,7 +61,8 @@ async def sensor_config_entry(hass: HomeAssistant):
 @pytest.fixture
 async def coordinator(hass: HomeAssistant, sensor_config_entry):
     """Get the coordinator."""
-    return hass.data[DOMAIN][COORDINATOR]
+    manager = hass.data[DOMAIN][COORDINATOR]
+    return manager.async_get_lock_coordinator(sensor_config_entry.entry_id)
 
 
 async def test_sensor_entity_initialization(hass: HomeAssistant, sensor_config_entry, coordinator):
@@ -267,6 +268,10 @@ async def test_async_setup_entry_with_parent_lock(hass: HomeAssistant):
     # Code slot sensors for slots 1 and 2
     assert added_entities[3].entity_description.key == "sensor.code_slots:1.synced"
     assert added_entities[4].entity_description.key == "sensor.code_slots:2.synced"
+
+    lock_coordinator = coordinator.async_get_lock_coordinator(config_entry.entry_id)
+    assert all(entity.coordinator is lock_coordinator for entity in added_entities)
+    assert added_entities[0].unique_id == f"{config_entry.entry_id}_sensor_lock_name"
 
 
 async def test_autolock_sensor_initialization(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -22,7 +22,11 @@ from custom_components.keymaster.const import (
 )
 from custom_components.keymaster.coordinator import KeymasterCoordinator
 from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
-from custom_components.keymaster.switch import KeymasterSwitch, KeymasterSwitchEntityDescription
+from custom_components.keymaster.switch import (
+    KeymasterSwitch,
+    KeymasterSwitchEntityDescription,
+    async_setup_entry,
+)
 from homeassistant.components.lock.const import LockState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
@@ -62,7 +66,34 @@ async def switch_config_entry(hass: HomeAssistant):
 @pytest.fixture
 async def coordinator(hass: HomeAssistant, switch_config_entry):
     """Get the coordinator."""
-    return hass.data[DOMAIN][COORDINATOR]
+    manager = hass.data[DOMAIN][COORDINATOR]
+    return manager.async_get_lock_coordinator(switch_config_entry.entry_id)
+
+
+async def test_switch_entities_created_with_lock_coordinator(
+    hass: HomeAssistant, switch_config_entry
+):
+    """Test switch setup binds entities to the per-lock coordinator."""
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    manager._initial_setup_done_event.set()
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=switch_config_entry.entry_id,
+    )
+    manager.kmlocks[switch_config_entry.entry_id] = kmlock
+    entities = []
+
+    def mock_add_entities(new_entities, update_before_add=False):
+        del update_before_add
+        entities.extend(new_entities)
+
+    await async_setup_entry(hass, switch_config_entry, mock_add_entities)
+
+    lock_coordinator = manager.async_get_lock_coordinator(switch_config_entry.entry_id)
+    assert entities
+    assert all(entity.coordinator is lock_coordinator for entity in entities)
+    assert entities[0].unique_id == f"{switch_config_entry.entry_id}_switch_autolock_enabled"
 
 
 async def test_switch_entity_initialization(hass: HomeAssistant, switch_config_entry, coordinator):

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -63,7 +63,8 @@ async def text_config_entry(hass: HomeAssistant):
 @pytest.fixture
 async def coordinator(hass: HomeAssistant, text_config_entry):
     """Get the coordinator."""
-    return hass.data[DOMAIN][COORDINATOR]
+    manager = hass.data[DOMAIN][COORDINATOR]
+    return manager.async_get_lock_coordinator(text_config_entry.entry_id)
 
 
 async def test_text_entities_created(hass: HomeAssistant, text_config_entry):
@@ -87,6 +88,11 @@ async def test_text_entities_created(hass: HomeAssistant, text_config_entry):
     assert "Code Slot 1: PIN" in entity_names
     assert "Code Slot 2: Name" in entity_names
     assert "Code Slot 2: PIN" in entity_names
+
+    manager = hass.data[DOMAIN][COORDINATOR]
+    lock_coordinator = manager.async_get_lock_coordinator(text_config_entry.entry_id)
+    assert all(entity.coordinator is lock_coordinator for entity in entities)
+    assert entities[0].unique_id == f"{text_config_entry.entry_id}_text_code_slots_1_name"
 
 
 async def test_text_pin_entity_password_mode_when_hide_pins(hass: HomeAssistant):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -117,6 +117,14 @@ async def test_time_entities_created_with_advanced_dow(hass: HomeAssistant, time
     assert any("Start Time" in name for name in entity_names)
     assert any("End Time" in name for name in entity_names)
 
+    manager = hass.data[DOMAIN][COORDINATOR]
+    lock_coordinator = manager.async_get_lock_coordinator(time_config_entry.entry_id)
+    assert all(entity.coordinator is lock_coordinator for entity in entities)
+    assert (
+        entities[0].unique_id
+        == f"{time_config_entry.entry_id}_time_code_slots_1_accesslimit_day_of_week_0_time_start"
+    )
+
 
 async def test_time_entity_initialization(hass: HomeAssistant, time_config_entry):
     """Test time entity initialization."""


### PR DESCRIPTION
## Summary

Phase B of issue #670: move entity listeners off the global manager onto the per-entry `KeymasterLockCoordinator` introduced in #680. Entity registry stability (unique IDs, names, device identifiers) and the persisted storage format are unchanged.

## Changes

- **Entities** (`entity.py` + all 9 platforms): `KeymasterEntity` is now `CoordinatorEntity[KeymasterLockCoordinator]`; each platform constructs entities with `manager.async_get_lock_coordinator(entry_id)` while setup-time lock lookups use the manager. `_kmlock`, unique IDs, names, and device info are unchanged.
- **Conservative per-lock fan-out** (`coordinator.py`): the manager's deferred global-notification flush now also pushes fresh lock data to **all** per-lock coordinators (via shared `_flush_global_leg` + `_push_lock_coordinator_update` helpers), so mutation and periodic-refresh notifications reach the rebound entities. Per-dirty-lock scoping is deferred to #682/#684.
- **Manager refresh keepalive**: HA only reschedules a coordinator's interval poll while it has listeners. Since entities no longer listen on the manager, a no-op keepalive listener keeps the manager's 60s refresh loop alive while lock coordinators exist (removed on shutdown).
- **Notification flush handles**: the scoped dual-target bridge and the all-lock global flush now symmetrically absorb each other's pending handle, eliminating a same-turn swallow/double-fire. `switch.py` optimistic updates route through the new `KeymasterLockCoordinator.async_schedule_notification()`.

## Testing

- New/updated tests: entities listen on the per-lock coordinator (not the manager) after setup; unique IDs remain `{entry_id}_{slugify(property)}`; conservative fan-out and refresh-completion reach per-lock listeners; both flush orderings notify every coordinator exactly once; keepalive install/remove.
- `ruff check`, `ruff format`, `mypy`, targeted platform suites, and the full suite pass; 100% patch coverage on new lines.

Closes #681
Part of #670