### PR TITLE
Refactor: Pipeline Keymaster refreshes through dirty lock scopes

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import MutableMapping
 from datetime import datetime as dt, timedelta
 import functools
+import inspect
 import logging
 from pathlib import Path
 import sys
@@ -268,6 +269,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     )
 
     config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
+    flush_pending_save = getattr(
+        coordinator,
+        "async_flush_pending_save_data_if_setup_complete",
+        None,
+    )
+    if inspect.iscoroutinefunction(flush_pending_save):
+        await flush_pending_save()
 
     return True
 

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -6,7 +6,6 @@ import asyncio
 from collections.abc import MutableMapping
 from datetime import datetime as dt, timedelta
 import functools
-import inspect
 import logging
 from pathlib import Path
 import sys
@@ -227,55 +226,53 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     except asyncio.exceptions.CancelledError as e:
         _LOGGER.error("Timeout on add_lock. %s: %s", e.__class__.__qualname__, e)
 
-    lock_coordinator = coordinator.async_get_lock_coordinator(config_entry.entry_id)
-    hass.data[DOMAIN].setdefault(LOCK_COORDINATORS, {})[config_entry.entry_id] = lock_coordinator
-
     try:
-        await async_load_large_lock_ack_store(hass)
-        supports_connection_status = True
-        if kmlock.provider:
-            supports_connection_status = kmlock.provider.supports_connection_status
-        await async_update_large_lock_repair_issue(
-            hass,
-            config_entry,
-            supports_connection_status=supports_connection_status,
-        )
-    except Exception:
-        _LOGGER.exception(
-            "Failed to update large-lock repair issue for %s",
-            config_entry.entry_id,
+        lock_coordinator = coordinator.async_get_lock_coordinator(config_entry.entry_id)
+        hass.data[DOMAIN].setdefault(LOCK_COORDINATORS, {})[config_entry.entry_id] = (
+            lock_coordinator
         )
 
-    if not hass.data[DOMAIN].get(_LARGE_LOCK_REPAIR_SWEEP_DONE):
-        hass.data[DOMAIN][_LARGE_LOCK_REPAIR_SWEEP_DONE] = True
         try:
-            await async_update_all_large_lock_repair_issues(hass)
+            await async_load_large_lock_ack_store(hass)
+            supports_connection_status = True
+            if kmlock.provider:
+                supports_connection_status = kmlock.provider.supports_connection_status
+            await async_update_large_lock_repair_issue(
+                hass,
+                config_entry,
+                supports_connection_status=supports_connection_status,
+            )
         except Exception:
-            _LOGGER.exception("Failed to update large-lock repair issues during setup sweep")
+            _LOGGER.exception(
+                "Failed to update large-lock repair issue for %s",
+                config_entry.entry_id,
+            )
 
-    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-    await async_generate_lovelace(
-        hass=hass,
-        kmlock_name=config_entry.data[CONF_LOCK_NAME],
-        keymaster_config_entry_id=config_entry.entry_id,
-        parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
-        code_slot_start=config_entry.data[CONF_START],
-        code_slots=config_entry.data[CONF_SLOTS],
-        lock_entity=config_entry.data[CONF_LOCK_ENTITY_ID],
-        advanced_date_range=config_entry.data[CONF_ADVANCED_DATE_RANGE],
-        advanced_day_of_week=config_entry.data[CONF_ADVANCED_DAY_OF_WEEK],
-        door_sensor=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
-        hide_pins=config_entry.data.get(CONF_HIDE_PINS, False),
-    )
+        if not hass.data[DOMAIN].get(_LARGE_LOCK_REPAIR_SWEEP_DONE):
+            hass.data[DOMAIN][_LARGE_LOCK_REPAIR_SWEEP_DONE] = True
+            try:
+                await async_update_all_large_lock_repair_issues(hass)
+            except Exception:
+                _LOGGER.exception("Failed to update large-lock repair issues during setup sweep")
 
-    config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
-    flush_pending_save = getattr(
-        coordinator,
-        "async_flush_pending_save_data_if_setup_complete",
-        None,
-    )
-    if inspect.iscoroutinefunction(flush_pending_save):
-        await flush_pending_save()
+        await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+        await async_generate_lovelace(
+            hass=hass,
+            kmlock_name=config_entry.data[CONF_LOCK_NAME],
+            keymaster_config_entry_id=config_entry.entry_id,
+            parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
+            code_slot_start=config_entry.data[CONF_START],
+            code_slots=config_entry.data[CONF_SLOTS],
+            lock_entity=config_entry.data[CONF_LOCK_ENTITY_ID],
+            advanced_date_range=config_entry.data[CONF_ADVANCED_DATE_RANGE],
+            advanced_day_of_week=config_entry.data[CONF_ADVANCED_DAY_OF_WEEK],
+            door_sensor=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
+            hide_pins=config_entry.data.get(CONF_HIDE_PINS, False),
+        )
+
+        config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
+    finally:
+        await coordinator.async_flush_pending_save_data_if_setup_complete()
 
     return True
 

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -75,16 +75,17 @@ _LARGE_LOCK_REPAIR_SWEEP_DONE = "large_lock_repair_sweep_done"
 
 async def _flush_pending_save_after_setup(
     coordinator: KeymasterCoordinator,
+    entry_id: str,
     *,
     setup_failed: bool,
 ) -> None:
     """Flush deferred setup save work without masking setup failures."""
     if not setup_failed:
-        await coordinator.async_flush_pending_save_data_if_setup_complete()
+        await coordinator.async_flush_pending_save_data_if_setup_complete(entry_id)
         return
 
     try:
-        await coordinator.async_flush_pending_save_data_if_setup_complete()
+        await coordinator.async_flush_pending_save_data_if_setup_complete(entry_id)
     except Exception:
         _LOGGER.exception("Failed to flush pending keymaster save data after setup error")
 
@@ -292,7 +293,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         setup_failed = True
         raise
     finally:
-        await _flush_pending_save_after_setup(coordinator, setup_failed=setup_failed)
+        await _flush_pending_save_after_setup(
+            coordinator,
+            config_entry.entry_id,
+            setup_failed=setup_failed,
+        )
 
     return True
 

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -73,6 +73,22 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 _LARGE_LOCK_REPAIR_SWEEP_DONE = "large_lock_repair_sweep_done"
 
 
+async def _flush_pending_save_after_setup(
+    coordinator: KeymasterCoordinator,
+    *,
+    setup_failed: bool,
+) -> None:
+    """Flush deferred setup save work without masking setup failures."""
+    if not setup_failed:
+        await coordinator.async_flush_pending_save_data_if_setup_complete()
+        return
+
+    try:
+        await coordinator.async_flush_pending_save_data_if_setup_complete()
+    except Exception:
+        _LOGGER.exception("Failed to flush pending keymaster save data after setup error")
+
+
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up integration."""
     hass.data.setdefault(DOMAIN, {"resources": False})
@@ -226,6 +242,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     except asyncio.exceptions.CancelledError as e:
         _LOGGER.error("Timeout on add_lock. %s: %s", e.__class__.__qualname__, e)
 
+    setup_failed = False
     try:
         lock_coordinator = coordinator.async_get_lock_coordinator(config_entry.entry_id)
         hass.data[DOMAIN].setdefault(LOCK_COORDINATORS, {})[config_entry.entry_id] = (
@@ -271,8 +288,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         )
 
         config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
+    except BaseException:
+        setup_failed = True
+        raise
     finally:
-        await coordinator.async_flush_pending_save_data_if_setup_complete()
+        await _flush_pending_save_after_setup(coordinator, setup_failed=setup_failed)
 
     return True
 

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 from collections.abc import Callable, Iterable, MutableMapping
 import contextlib
+import copy
 from dataclasses import fields, is_dataclass
 from datetime import datetime as dt, time as dt_time, timedelta
 import functools
@@ -118,6 +119,8 @@ class KeymasterLockCoordinator(DataUpdateCoordinator[KeymasterLock | None]):
             always_update=False,
         )
         self.data = manager.sync_get_lock_by_config_entry_id(config_entry_id)
+        self.last_update_success = manager.last_update_success
+        self.last_exception = getattr(manager, "last_exception", None)
 
     async def _async_update_data(self) -> KeymasterLock | None:
         """Mirror the manager's current lock snapshot."""
@@ -169,7 +172,8 @@ class KeymasterLockCoordinator(DataUpdateCoordinator[KeymasterLock | None]):
 
     async def async_request_debounced_refresh(self) -> None:
         """Request a debounced coordinator refresh."""
-        return await self.manager.async_request_debounced_refresh()
+        self.manager.async_schedule_keymaster_notifications([self.config_entry_id])
+        return await self.manager.async_request_debounced_refresh(self.config_entry_id)
 
     def autolock_duration_seconds(self, kmlock: KeymasterLock) -> int:
         """Compute the autolock duration for a kmlock based on time of day."""
@@ -214,15 +218,16 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._state_change_autolock_started: set[str] = set()
         self._consecutive_failures: dict[str, int] = {}
         self._next_retry_time: dict[str, dt] = {}
-        self._pending_global_notification = False
-        self._pending_global_data_update = False
-        self._pending_global_failed_refresh = False
-        self._global_notify_handle: asyncio.Handle | None = None
         self._deferred_notifications_shutting_down = False
         self._defer_refresh_listener_updates = False
         self._lock_coordinators: dict[str, KeymasterLockCoordinator] = {}
         self._pending_notify_entry_ids: set[str] = set()
+        self._pending_notify_all_entry_ids = False
+        self._pending_failed_refresh = False
         self._notify_handle: asyncio.Handle | None = None
+        self._refresh_dirty_entry_ids: set[str] | None = None
+        self._refresh_previous_update_success: bool | None = None
+        self._externally_dirty_entry_ids: set[str] = set()
         self._refresh_keepalive_unsub: Callable[[], None] | None = None
 
         super().__init__(
@@ -236,24 +241,20 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._timer_store = TimerStore(hass)
 
     @callback
-    def async_cancel_pending_global_notification(self) -> None:
-        """Cancel pending deferred global notification work."""
-        self._pending_global_notification = False
-        self._pending_global_data_update = False
-        self._pending_global_failed_refresh = False
-        if self._global_notify_handle is not None:
-            self._global_notify_handle.cancel()
-            self._global_notify_handle = None
+    def async_cancel_pending_notifications(self) -> None:
+        """Cancel pending deferred all-lock notification work."""
+        self._pending_notify_entry_ids.clear()
+        self._pending_notify_all_entry_ids = False
+        self._pending_failed_refresh = False
+        if self._notify_handle is not None:
+            self._notify_handle.cancel()
+            self._notify_handle = None
 
     async def async_shutdown(self) -> None:
         """Shutdown the coordinator and cancel any pending timers."""
         _LOGGER.debug("Shutting down keymaster coordinator")
         self._deferred_notifications_shutting_down = True
-        self.async_cancel_pending_global_notification()
-        if self._notify_handle is not None:
-            self._notify_handle.cancel()
-            self._notify_handle = None
-        self._pending_notify_entry_ids.clear()
+        self.async_cancel_pending_notifications()
         self._lock_coordinators.clear()
         if self._refresh_keepalive_unsub is not None:
             self._refresh_keepalive_unsub()
@@ -267,93 +268,42 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         await super().async_shutdown()
 
     @callback
-    def async_schedule_global_notification(self) -> None:
-        """Coalesce and defer the current global coordinator notification."""
+    def async_schedule_all_lock_notifications(self) -> None:
+        """Coalesce and defer notification for every per-lock coordinator."""
+        self.async_schedule_keymaster_notifications(self.kmlocks, all_entry_ids=True)
+
+    @callback
+    def _schedule_refresh_notifications(self) -> None:
+        """Schedule deferred refresh-completion per-lock notifications."""
         if self._deferred_notifications_shutting_down:
             return
 
-        self.data = dict(self.kmlocks)
-        self._pending_global_notification = True
-        self._pending_global_data_update = True
-        if not getattr(self, "last_update_success", True):
-            self._pending_global_failed_refresh = True
-        self._schedule_pending_global_notification()
-
-    @callback
-    def _schedule_pending_global_notification(self) -> None:
-        """Schedule the pending global notification flush."""
-        if self._defer_refresh_listener_updates:
-            return
-
-        if self._global_notify_handle is None:
-            self._global_notify_handle = self.hass.loop.call_soon(
-                self._flush_pending_global_notification,
-            )
-
-    @callback
-    def _schedule_refresh_global_notification(self) -> None:
-        """Schedule a deferred refresh-completion listener notification."""
-        if self._deferred_notifications_shutting_down:
-            return
-
-        self._pending_global_notification = True
-        if not getattr(self, "last_update_success", True):
-            self._pending_global_failed_refresh = True
+        if (
+            self._refresh_previous_update_success is not None
+            and self._refresh_previous_update_success != self.last_update_success
+        ) or self._refresh_dirty_entry_ids is None:
+            self.async_schedule_all_lock_notifications()
         else:
-            self._pending_global_failed_refresh = False
-        self._schedule_pending_global_notification()
-
-    @callback
-    def _flush_global_leg(self) -> tuple[bool, bool]:
-        """Notify manager listeners / update the mirror; return (data_update, preserve_failed_refresh)."""
-        data_update = self._pending_global_data_update
-        preserve_failed_refresh = self._pending_global_failed_refresh
-        self._pending_global_notification = False
-        self._pending_global_data_update = False
-        self._pending_global_failed_refresh = False
-        if data_update and preserve_failed_refresh:
-            self.data = dict(self.kmlocks)
-            super().async_update_listeners()
-        elif data_update:
-            super().async_set_updated_data(dict(self.kmlocks))
-        else:
-            super().async_update_listeners()
-        return data_update, preserve_failed_refresh
+            self.async_schedule_keymaster_notifications(self._refresh_dirty_entry_ids)
 
     @callback
     def _push_lock_coordinator_update(
-        self, entry_id: str, *, data_update: bool, preserve_failed_refresh: bool
+        self, entry_id: str, *, preserve_failed_refresh: bool
     ) -> None:
         """Push the current lock snapshot to one per-lock coordinator, mirroring manager health."""
         lock_coordinator = self._lock_coordinators.get(entry_id)
         if lock_coordinator is None or entry_id not in self.kmlocks:
             return
         lock = self.kmlocks[entry_id]
-        if data_update and not preserve_failed_refresh:
+        lock_coordinator.last_exception = (
+            None if self.last_update_success else getattr(self, "last_exception", None)
+        )
+        if not preserve_failed_refresh:
             lock_coordinator.async_set_updated_data(lock)
         else:
             lock_coordinator.data = lock
             lock_coordinator.last_update_success = self.last_update_success
             lock_coordinator.async_update_listeners()
-
-    @callback
-    def _flush_pending_global_notification(self) -> None:
-        """Notify the global leg and (conservatively) every per-lock coordinator."""
-        self._global_notify_handle = None
-        if not self._pending_global_notification or self._deferred_notifications_shutting_down:
-            return
-        if self._defer_refresh_listener_updates:
-            return
-        # Absorb any pending scoped bridge flush; the all-lock fan-out covers it.
-        if self._notify_handle is not None:
-            self._notify_handle.cancel()
-            self._notify_handle = None
-        self._pending_notify_entry_ids = set()
-        data_update, preserve_failed_refresh = self._flush_global_leg()
-        for entry_id in list(self._lock_coordinators):
-            self._push_lock_coordinator_update(
-                entry_id, data_update=data_update, preserve_failed_refresh=preserve_failed_refresh
-            )
 
     @callback
     def _keepalive_listener(self) -> None:
@@ -385,22 +335,23 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self._refresh_keepalive_unsub = None
 
     @callback
-    def async_schedule_keymaster_notifications(self, entry_ids: Iterable[str]) -> None:
-        """Coalesce dirty IDs and notify global and per-lock coordinator listeners."""
+    def async_schedule_keymaster_notifications(
+        self, entry_ids: Iterable[str], *, all_entry_ids: bool = False
+    ) -> None:
+        """Coalesce dirty IDs and notify per-lock coordinator listeners."""
         if self._deferred_notifications_shutting_down:
             return
 
         valid = {entry_id for entry_id in entry_ids if entry_id in self.kmlocks}
-        if not valid and not self._pending_notify_entry_ids:
+        if not valid and not all_entry_ids and not self._pending_notify_entry_ids:
             return
         self._pending_notify_entry_ids |= valid
+        self._pending_notify_all_entry_ids |= all_entry_ids
         self.data = dict(self.kmlocks)
-        self._pending_global_notification = True
-        self._pending_global_data_update = True
         if not getattr(self, "last_update_success", True):
-            self._pending_global_failed_refresh = True
+            self._pending_failed_refresh = True
         else:
-            self._pending_global_failed_refresh = False
+            self._pending_failed_refresh = False
         self._schedule_pending_keymaster_notifications()
 
     @callback
@@ -415,25 +366,20 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
     @callback
     def _flush_pending_keymaster_notifications(self) -> None:
-        """Flush the global leg and per-lock coordinators (scoped, or all if a global fan-out was also pending)."""
+        """Flush per-lock coordinator notifications."""
         self._notify_handle = None
         if self._deferred_notifications_shutting_down or self._defer_refresh_listener_updates:
             return
         entry_ids = self._pending_notify_entry_ids
         self._pending_notify_entry_ids = set()
-        # If a global all-lock fan-out was also pending, absorb it and fan out to all.
-        global_notify_handle = self._global_notify_handle
-        if global_notify_handle is not None:
-            all_fanout = True
-            global_notify_handle.cancel()
-            self._global_notify_handle = None
-        else:
-            all_fanout = False
-        data_update, preserve_failed_refresh = self._flush_global_leg()
-        targets = list(self._lock_coordinators) if all_fanout else list(entry_ids)
+        all_entry_ids = self._pending_notify_all_entry_ids
+        self._pending_notify_all_entry_ids = False
+        preserve_failed_refresh = self._pending_failed_refresh
+        self._pending_failed_refresh = False
+        targets = list(self._lock_coordinators) if all_entry_ids else list(entry_ids)
         for entry_id in targets:
             self._push_lock_coordinator_update(
-                entry_id, data_update=data_update, preserve_failed_refresh=preserve_failed_refresh
+                entry_id, preserve_failed_refresh=preserve_failed_refresh
             )
 
     async def _async_refresh(
@@ -445,6 +391,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Refresh data while deferring listener fan-out."""
         self._defer_refresh_listener_updates = True
+        self._refresh_dirty_entry_ids = None
+        self._refresh_previous_update_success = self.last_update_success
         try:
             await super()._async_refresh(
                 log_failures=log_failures,
@@ -455,13 +403,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         finally:
             self._defer_refresh_listener_updates = False
             if (
-                self._pending_global_notification
-                and self._global_notify_handle is None
-                and not self._deferred_notifications_shutting_down
-            ):
-                self._schedule_pending_global_notification()
-            if (
-                self._pending_notify_entry_ids
+                (self._pending_notify_entry_ids or self._pending_notify_all_entry_ids)
                 and self._notify_handle is None
                 and not self._deferred_notifications_shutting_down
             ):
@@ -471,10 +413,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     def async_update_listeners(self) -> None:
         """Update listeners immediately or defer refresh-completion fan-out."""
         if self._defer_refresh_listener_updates:
-            self._schedule_refresh_global_notification()
+            self._schedule_refresh_notifications()
             return
 
-        super().async_update_listeners()
+        self.async_schedule_all_lock_notifications()
 
     async def initial_setup(self) -> None:
         """Trigger the initial async_setup."""
@@ -597,21 +539,16 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if kmlocks is None:
             kmlocks = self.kmlocks
 
-        config: dict[str, Any] = {
-            key: self._kmlocks_to_dict(kmlock) for key, kmlock in kmlocks.items()
-        }
-        for lock in config.values():
-            lock.pop("zwave_js_lock_device", None)
-            lock.pop("zwave_js_lock_node", None)
-            lock.pop("autolock_timer", None)
-            lock.pop("listeners", None)
-            lock.pop("provider", None)
+        config: dict[str, Any] = {}
+        for key, kmlock in kmlocks.items():
+            lock = self._sanitized_lock_dict(self._kmlocks_to_dict(kmlock))
             for kmslot in lock.get("code_slots", {}).values():
                 if isinstance(kmslot.get("pin", None), str):
                     kmslot["pin"] = KeymasterCoordinator._encode_pin(
                         kmslot["pin"],
                         lock["keymaster_config_entry_id"],
                     )
+            config[key] = lock
 
         if config == self._prev_kmlocks_dict:
             _LOGGER.debug("[save_data] No changes to kmlocks. Not saving.")
@@ -619,6 +556,23 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._prev_kmlocks_dict = dict(config)
         await self._store.async_save(config)
         _LOGGER.debug("[save_data] Data saved to storage")
+
+    def _sanitized_lock_dict(self, lock: object) -> dict[str, Any]:
+        """Remove runtime-only lock fields from a serialized lock dictionary."""
+        sanitized = dict(lock) if isinstance(lock, dict) else {}
+        sanitized.pop("zwave_js_lock_device", None)
+        sanitized.pop("zwave_js_lock_node", None)
+        sanitized.pop("autolock_timer", None)
+        sanitized.pop("listeners", None)
+        sanitized.pop("provider", None)
+        return sanitized
+
+    def _lock_snapshot(self, entry_id: str) -> dict[str, Any] | None:
+        """Return a sanitized comparable snapshot for one lock."""
+        kmlock = self.kmlocks.get(entry_id)
+        if kmlock is None:
+            return None
+        return copy.deepcopy(self._sanitized_lock_dict(self._kmlocks_to_dict(kmlock)))
 
     async def async_remove_data(self) -> None:
         """Remove stored data."""
@@ -951,7 +905,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         duration=self.autolock_duration_seconds(kmlock),
                     )
                     self._state_change_autolock_started.add(kmlock.keymaster_config_entry_id)
-                    self.async_schedule_global_notification()
+                    self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
         elif new_state == LockState.LOCKED:
             if old_state != LockState.LOCKED:
                 if not uses_provider_lock_events:
@@ -966,7 +920,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 ) and kmlock.autolock_timer:
                     await kmlock.autolock_timer.cancel()
                     self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
-                    self.async_schedule_global_notification()
+                    self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
     async def _handle_door_state_change(
         self,
@@ -1314,10 +1268,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
             self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
-            self.async_schedule_global_notification()
+            self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
         elif kmlock.autolock_enabled and kmlock.autolock_timer:
             await kmlock.autolock_timer.start(duration=self.autolock_duration_seconds(kmlock))
-            self.async_schedule_global_notification()
+            self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
         if kmlock.lock_notifications:
             if self._should_defer_keypad_unlock_notification(kmlock, code_slot_num, event_label):
@@ -1349,7 +1303,9 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                             accesslimit_count - 1
                         )
                         # Defer notifying entities of the count change
-                        self.async_schedule_global_notification()
+                        self.async_schedule_keymaster_notifications(
+                            [parent_kmlock.keymaster_config_entry_id]
+                        )
                         # Check if slot should be deactivated (e.g., count reached 0)
                         await self._update_slot(
                             parent_kmlock,
@@ -1361,7 +1317,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 if isinstance(accesslimit_count, int) and accesslimit_count > 0:
                     kmlock.code_slots[code_slot_num].accesslimit_count = accesslimit_count - 1
                     # Defer notifying entities of the count change
-                    self.async_schedule_global_notification()
+                    self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                     # Check if slot should be deactivated (e.g., count reached 0)
                     await self._update_slot(kmlock, kmlock.code_slots[code_slot_num], code_slot_num)
 
@@ -1388,7 +1344,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
                 if kmlock.autolock_timer:
                     await kmlock.autolock_timer.cancel()
-                    self.async_schedule_global_notification()
+                    self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                 self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
             self._cancel_pending_keypad_unlock_notification(kmlock)
             return
@@ -1426,7 +1382,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         if kmlock.autolock_timer:
             await kmlock.autolock_timer.cancel()
-            self.async_schedule_global_notification()
+            self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
         if kmlock.lock_notifications:
             await send_manual_notification(
@@ -1568,7 +1524,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         await kmlock.autolock_timer.recover()
         if kmlock.autolock_timer.is_running:
-            self.async_schedule_global_notification()
+            self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
     async def _timer_triggered(self, kmlock: KeymasterLock, _: dt) -> None:
         _LOGGER.debug("[timer_triggered] %s", kmlock.lock_name)
@@ -1927,7 +1883,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         kmlock.code_slots[code_slot_num].sync_op_started_at = utcnow()
         self._quick_refresh = True
         # Defer notifying entities of sync status change
-        self.async_schedule_global_notification()
+        self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
         # Use provider if available
         if kmlock.provider:
@@ -1940,7 +1896,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     code_slot_num,
                 )
                 kmlock.code_slots[code_slot_num].synced = Synced.OUT_OF_SYNC
-                self.async_schedule_global_notification()
+                self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                 return False
             log_pin = "[REDACTED]" if kmlock.redact_pin_codes and pin else pin
             _LOGGER.debug(
@@ -1951,7 +1907,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
             kmlock.code_slots[code_slot_num].synced = Synced.SYNCED
             kmlock.code_slots[code_slot_num].last_code_set_at = utcnow()
-            self.async_schedule_global_notification()
+            self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
             return True
 
         raise ProviderNotConfiguredError
@@ -2009,7 +1965,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         kmlock.code_slots[code_slot_num].sync_op_started_at = utcnow()
         self._quick_refresh = True
         # Defer notifying entities of sync status change
-        self.async_schedule_global_notification()
+        self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
         # Use provider if available
         if kmlock.provider:
@@ -2023,7 +1979,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 # Restore prior PIN to preserve local state after failed clear
                 kmlock.code_slots[code_slot_num].pin = prior_pin
                 kmlock.code_slots[code_slot_num].synced = Synced.OUT_OF_SYNC
-                self.async_schedule_global_notification()
+                self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                 return False
             _LOGGER.debug(
                 "[clear_pin_from_lock] %s: Code Slot %s: PIN cleared via provider",
@@ -2032,7 +1988,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
             kmlock.code_slots[code_slot_num].synced = Synced.DISCONNECTED
             kmlock.code_slots[code_slot_num].last_code_set_at = utcnow()
-            self.async_schedule_global_notification()
+            self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
             return True
 
         raise ProviderNotConfiguredError
@@ -2166,13 +2122,16 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     async def _trigger_quick_refresh(self, _: dt) -> None:
         await self.async_request_refresh()
 
-    async def async_request_debounced_refresh(self) -> None:
+    async def async_request_debounced_refresh(self, entry_id: str | None = None) -> None:
         """Request a debounced coordinator refresh.
 
         Batches rapid entity updates into a single refresh by cancelling
         any previously scheduled debounced refresh and scheduling a new
         one after ENTITY_DEBOUNCE_SECONDS.
         """
+        if entry_id is not None and entry_id in self.kmlocks:
+            self._externally_dirty_entry_ids.add(entry_id)
+
         if self._cancel_debounced_refresh:
             self._cancel_debounced_refresh()
             self._cancel_debounced_refresh = None
@@ -2279,11 +2238,51 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         return True
 
-    async def _async_update_data(self) -> dict[str, Any]:
-        """Update all keymaster locks."""
+    async def async_refresh_lock(self, entry_id: str) -> set[str]:
+        """Refresh one lock; return entry IDs whose entities may need notification."""
         await self._initial_setup_done_event.wait()
         self._quick_refresh = False
         self._sync_status_counter += 1
+        await self._clear_pending_quick_refresh()
+        if self._cancel_debounced_refresh:
+            self._cancel_debounced_refresh()
+            self._cancel_debounced_refresh = None
+        dirty = (
+            {entry_id}
+            if entry_id in self.kmlocks and entry_id in self._externally_dirty_entry_ids
+            else set()
+        )
+        self._externally_dirty_entry_ids.discard(entry_id)
+        before = self._lock_snapshot(entry_id)
+        await self._update_lock_data(entry_id)
+        if before != self._lock_snapshot(entry_id):
+            dirty.add(entry_id)
+        dirty.update(await self._sync_child_locks(entry_id))
+        if self._sync_status_counter > SYNC_STATUS_THRESHOLD:
+            before_sync_status = {
+                lock_entry_id: self._lock_snapshot(lock_entry_id) for lock_entry_id in self.kmlocks
+            }
+            self._sync_status_counter = 0
+            await self._update_door_and_lock_state(trigger_actions_if_changed=True)
+            dirty.update(
+                lock_entry_id
+                for lock_entry_id, before_lock in before_sync_status.items()
+                if before_lock != self._lock_snapshot(lock_entry_id)
+            )
+        await self._async_save_data()
+        self.data = dict(self.kmlocks)
+        await self._schedule_quick_refresh_if_needed()
+        return dirty
+
+    async def async_refresh_all_locks(self) -> set[str]:
+        """Refresh all locks for startup/maintenance; return dirty entry IDs."""
+        await self._initial_setup_done_event.wait()
+        self._quick_refresh = False
+        self._sync_status_counter += 1
+        dirty_entry_ids: set[str] = {
+            entry_id for entry_id in self._externally_dirty_entry_ids if entry_id in self.kmlocks
+        }
+        self._externally_dirty_entry_ids.clear()
 
         # Clear any pending refresh callbacks
         await self._clear_pending_quick_refresh()
@@ -2292,22 +2291,40 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self._cancel_debounced_refresh = None
 
         for keymaster_config_entry_id in self.kmlocks:
+            before = self._lock_snapshot(keymaster_config_entry_id)
             await self._update_lock_data(keymaster_config_entry_id=keymaster_config_entry_id)
+            if before != self._lock_snapshot(keymaster_config_entry_id):
+                dirty_entry_ids.add(keymaster_config_entry_id)
 
         # Propagate parent kmlock settings to child kmlocks
         for keymaster_config_entry_id in self.kmlocks:
-            await self._sync_child_locks(keymaster_config_entry_id=keymaster_config_entry_id)
+            dirty_entry_ids.update(
+                await self._sync_child_locks(keymaster_config_entry_id=keymaster_config_entry_id)
+            )
 
         # Handle sync status update if necessary
         if self._sync_status_counter > SYNC_STATUS_THRESHOLD:
+            before_sync_status = {
+                entry_id: self._lock_snapshot(entry_id) for entry_id in self.kmlocks
+            }
             self._sync_status_counter = 0
             await self._update_door_and_lock_state(trigger_actions_if_changed=True)
+            dirty_entry_ids.update(
+                entry_id
+                for entry_id, before in before_sync_status.items()
+                if before != self._lock_snapshot(entry_id)
+            )
 
         await self._async_save_data()
 
         # Schedule next refresh if needed
         await self._schedule_quick_refresh_if_needed()
 
+        return dirty_entry_ids
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Update all keymaster locks."""
+        self._refresh_dirty_entry_ids = await self.async_refresh_all_locks()
         return dict(self.kmlocks)
 
     async def _clear_pending_quick_refresh(self) -> None:
@@ -2688,29 +2705,34 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             # and consider it synced to avoid flip-flopping.
             slot.synced = Synced.SYNCED
 
-    async def _sync_child_locks(self, keymaster_config_entry_id: str) -> None:
-        """Propagate parent lock settings to child locks."""
+    async def _sync_child_locks(self, keymaster_config_entry_id: str) -> set[str]:
+        """Propagate parent lock settings to child locks and return dirty child IDs."""
+        dirty_entry_ids: set[str] = set()
         kmlock: KeymasterLock | None = await self.get_lock_by_config_entry_id(
             keymaster_config_entry_id,
         )
         if not isinstance(kmlock, KeymasterLock):
-            return
+            return dirty_entry_ids
         if not kmlock.connected:
             _LOGGER.error("[Coordinator] %s: Not Connected", kmlock.lock_name)
-            return
+            return dirty_entry_ids
 
         if not kmlock.provider:
             _LOGGER.error("[Coordinator] %s: No provider available", kmlock.lock_name)
-            return
+            return dirty_entry_ids
 
         if (
             not isinstance(kmlock.child_config_entry_ids, list)
             or len(kmlock.child_config_entry_ids) == 0
         ):
-            return
+            return dirty_entry_ids
 
         for child_entry_id in kmlock.child_config_entry_ids:
+            before = self._lock_snapshot(child_entry_id)
             await self._sync_child_lock(kmlock, child_entry_id)
+            if before != self._lock_snapshot(child_entry_id):
+                dirty_entry_ids.add(child_entry_id)
+        return dirty_entry_ids
 
     async def _sync_child_lock(self, kmlock: KeymasterLock, child_entry_id: str) -> None:
         """Sync the settings for a child lock."""

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -6,7 +6,6 @@ import asyncio
 import base64
 from collections.abc import Callable, Iterable, MutableMapping
 import contextlib
-import copy
 from dataclasses import fields, is_dataclass
 from datetime import datetime as dt, time as dt_time, timedelta
 import functools
@@ -587,7 +586,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         kmlock = self.kmlocks.get(entry_id)
         if kmlock is None:
             return None
-        return copy.deepcopy(self._sanitized_lock_dict(self._kmlocks_to_dict(kmlock)))
+        return self._sanitized_lock_dict(self._kmlocks_to_dict(kmlock))
 
     async def async_remove_data(self) -> None:
         """Remove stored data."""

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -243,6 +243,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._externally_dirty_entry_ids: set[str] = set()
         self._refresh_keepalive_unsub: Callable[[], None] | None = None
         self._pending_save_entry_ids: set[str] = set()
+        self._save_lock = asyncio.Lock()
         self._stop_unsub: Callable[[], None] | None = None
         self._shutdown_complete = False
 
@@ -262,6 +263,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
     async def _async_homeassistant_stop(self, _: Event) -> None:
         """Flush pending work when Home Assistant stops."""
+        self._stop_unsub = None
         await self.async_shutdown()
 
     @callback
@@ -280,7 +282,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             return
         _LOGGER.debug("Shutting down keymaster coordinator")
         if self._stop_unsub is not None:
-            self._stop_unsub()
+            with contextlib.suppress(ValueError):
+                self._stop_unsub()
             self._stop_unsub = None
         await self.async_flush_pending_save_data()
         self._deferred_notifications_shutting_down = True
@@ -583,6 +586,18 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         entry_ids: Iterable[str] | None = None,
     ) -> None:
         """Save data to Store."""
+        if not hasattr(self, "_save_lock"):
+            self._save_lock = asyncio.Lock()
+        async with self._save_lock:
+            await self._async_save_data_locked(kmlocks, entry_ids=entry_ids)
+
+    async def _async_save_data_locked(
+        self,
+        kmlocks: MutableMapping[str, KeymasterLock] | None = None,
+        *,
+        entry_ids: Iterable[str] | None = None,
+    ) -> None:
+        """Save data to Store while the save lock is held."""
         if kmlocks is None:
             kmlocks = self.kmlocks
 

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -281,25 +281,31 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if self._shutdown_complete:
             return
         _LOGGER.debug("Shutting down keymaster coordinator")
-        if self._stop_unsub is not None:
-            with contextlib.suppress(ValueError):
-                self._stop_unsub()
-            self._stop_unsub = None
-        await self.async_flush_pending_save_data()
-        self._deferred_notifications_shutting_down = True
-        self.async_cancel_pending_notifications()
-        self._lock_coordinators.clear()
-        if self._refresh_keepalive_unsub is not None:
-            self._refresh_keepalive_unsub()
-            self._refresh_keepalive_unsub = None
-        if self._cancel_quick_refresh:
-            self._cancel_quick_refresh()
-            self._cancel_quick_refresh = None
-        if self._cancel_debounced_refresh:
-            self._cancel_debounced_refresh()
-            self._cancel_debounced_refresh = None
-        await super().async_shutdown()
-        self._shutdown_complete = True
+        try:
+            await self.async_flush_pending_save_data()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _LOGGER.exception("Failed to flush pending keymaster save data during shutdown")
+        finally:
+            if self._stop_unsub is not None:
+                with contextlib.suppress(ValueError):
+                    self._stop_unsub()
+                self._stop_unsub = None
+            self._deferred_notifications_shutting_down = True
+            self.async_cancel_pending_notifications()
+            self._lock_coordinators.clear()
+            if self._refresh_keepalive_unsub is not None:
+                self._refresh_keepalive_unsub()
+                self._refresh_keepalive_unsub = None
+            if self._cancel_quick_refresh:
+                self._cancel_quick_refresh()
+                self._cancel_quick_refresh = None
+            if self._cancel_debounced_refresh:
+                self._cancel_debounced_refresh()
+                self._cancel_debounced_refresh = None
+            await super().async_shutdown()
+            self._shutdown_complete = True
 
     @callback
     def async_schedule_all_lock_notifications(self) -> None:

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -586,8 +586,6 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         entry_ids: Iterable[str] | None = None,
     ) -> None:
         """Save data to Store."""
-        if not hasattr(self, "_save_lock"):
-            self._save_lock = asyncio.Lock()
         async with self._save_lock:
             await self._async_save_data_locked(kmlocks, entry_ids=entry_ids)
 

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -2398,8 +2398,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         except asyncio.CancelledError as err:
             self.last_exception = err
             self.last_update_success = False
-            if (task := asyncio.current_task()) and task.cancelling() > 0:
-                raise
+            raise
         except Exception as exc:
             self.last_exception = exc
             self.last_update_success = False

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -281,6 +281,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if self._shutdown_complete:
             return
         _LOGGER.debug("Shutting down keymaster coordinator")
+        if self._stop_unsub is not None:
+            with contextlib.suppress(ValueError):
+                self._stop_unsub()
+            self._stop_unsub = None
         try:
             await self.async_flush_pending_save_data()
         except asyncio.CancelledError:
@@ -288,10 +292,6 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         except Exception:
             _LOGGER.exception("Failed to flush pending keymaster save data during shutdown")
         finally:
-            if self._stop_unsub is not None:
-                with contextlib.suppress(ValueError):
-                    self._stop_unsub()
-                self._stop_unsub = None
             self._deferred_notifications_shutting_down = True
             self.async_cancel_pending_notifications()
             self._lock_coordinators.clear()

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -105,6 +105,9 @@ def _is_masked_code(code: str | None) -> bool:
 class KeymasterLockCoordinator(DataUpdateCoordinator[KeymasterLock | None]):
     """Entity-facing coordinator for a single Keymaster lock."""
 
+    last_exception: BaseException | None
+    last_update_success: bool
+
     def __init__(self, manager: KeymasterCoordinator, config_entry_id: str) -> None:
         """Initialize the per-lock coordinator."""
         self.manager = manager
@@ -199,6 +202,9 @@ class KeymasterLockCoordinator(DataUpdateCoordinator[KeymasterLock | None]):
 
 class KeymasterCoordinator(DataUpdateCoordinator):
     """Coordinator to manage keymaster locks."""
+
+    last_exception: BaseException | None
+    last_update_success: bool
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize keymaster Coordinator."""
@@ -1570,9 +1576,19 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
             raise
 
-    async def _update_door_and_lock_state(self, trigger_actions_if_changed: bool = False) -> None:
+    async def _update_door_and_lock_state(
+        self,
+        trigger_actions_if_changed: bool = False,
+        entry_ids: Iterable[str] | None = None,
+    ) -> None:
         # _LOGGER.debug("[update_door_and_lock_state] Running")
-        for kmlock in self.kmlocks.values():
+        entry_id_filter = set(entry_ids) if entry_ids is not None else None
+        locks = (
+            (self.kmlocks[entry_id] for entry_id in entry_id_filter if entry_id in self.kmlocks)
+            if entry_id_filter is not None
+            else self.kmlocks.values()
+        )
+        for kmlock in locks:
             if isinstance(kmlock.lock_entity_id, str) and kmlock.lock_entity_id:
                 lock_state = None
                 if temp_lock_state := self.hass.states.get(kmlock.lock_entity_id):
@@ -1678,10 +1694,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("[add_lock] %s", kmlock.lock_name)
         self.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
         await self._rebuild_lock_relationships()
-        await self._update_door_and_lock_state()
+        await self._update_door_and_lock_state(entry_ids=[kmlock.keymaster_config_entry_id])
         await self._update_listeners(kmlock)
         await self._setup_timer(kmlock)
-        await self.async_refresh()
+        await self.async_refresh_lock(kmlock.keymaster_config_entry_id)
         return
 
     async def _update_lock(self, new: KeymasterLock) -> bool:
@@ -1711,6 +1727,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             if code_slot_num in del_code_slots:
                 del_code_slots.remove(code_slot_num)
 
+        relationships_changed = (
+            old.lock_name != new.lock_name
+            or old.parent_name != new.parent_name
+            or old.parent_config_entry_id != new.parent_config_entry_id
+        )
+
         # Carry user/runtime state from old → new (lock state, autolock
         # config, retry state, code slots + DOW). Owned by KeymasterLock
         # so the field-by-field copy lives next to the field declarations.
@@ -1730,15 +1752,16 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 keymaster_config_entry_id=new.keymaster_config_entry_id,
                 code_slot_num=code_slot_num,
             )
-        await self._rebuild_lock_relationships()
-        await self._update_door_and_lock_state()
+        if relationships_changed:
+            await self._rebuild_lock_relationships()
+        await self._update_door_and_lock_state(entry_ids=[new.keymaster_config_entry_id])
         await self._update_listeners(self.kmlocks[new.keymaster_config_entry_id])
         # Construct the timer if old didn't have one (defensive — should be
         # rare since add_lock sets one up, but a half-initialized old
         # instance might not).
         if new.autolock_timer is None:
             await self._setup_timer(new)
-        await self.async_refresh()
+        await self.async_refresh_lock(new.keymaster_config_entry_id)
         return True
 
     async def _delete_lock(self, kmlock: KeymasterLock, _: dt) -> None:
@@ -2254,6 +2277,57 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
     async def async_refresh_lock(self, entry_id: str) -> set[str]:
         """Refresh one lock; return entry IDs whose entities may need notification."""
+        async with self._debounced_refresh.async_lock():
+            return await self._async_refresh_lock(entry_id)
+
+    async def _async_refresh_lock(self, entry_id: str) -> set[str]:
+        """Refresh one lock, preserving manager health and scoped notifications."""
+        previous_update_success = self.last_update_success
+        dirty_entry_ids: set[str] = set()
+        if self._active_refresh_count == 0:
+            self._refresh_dirty_entry_ids = None
+            self._refresh_previous_update_success = self.last_update_success
+        self._active_refresh_count += 1
+        self._defer_refresh_listener_updates = True
+        try:
+            dirty_entry_ids = await self._async_refresh_lock_data(entry_id)
+        except asyncio.CancelledError as err:
+            self.last_exception = err
+            self.last_update_success = False
+            if (task := asyncio.current_task()) and task.cancelling() > 0:
+                raise
+        except Exception as exc:
+            self.last_exception = exc
+            self.last_update_success = False
+            self.logger.exception("Unexpected error fetching %s data", self.name)
+        else:
+            if not self.last_update_success:
+                self.last_update_success = True
+                self.logger.info("Fetching %s data recovered", self.name)
+            self._record_refresh_dirty_entry_ids(dirty_entry_ids)
+        finally:
+            self._active_refresh_count -= 1
+            if self._active_refresh_count == 0:
+                self._defer_refresh_listener_updates = False
+                if (
+                    (self._pending_notify_entry_ids or self._pending_notify_all_entry_ids)
+                    and self._notify_handle is None
+                    and not self._deferred_notifications_shutting_down
+                ):
+                    self._schedule_pending_keymaster_notifications()
+
+        if not self.last_update_success and not previous_update_success:
+            return dirty_entry_ids
+
+        if self.last_update_success != previous_update_success:
+            self.async_schedule_all_lock_notifications()
+        elif dirty_entry_ids:
+            self.async_schedule_keymaster_notifications(dirty_entry_ids)
+
+        return dirty_entry_ids
+
+    async def _async_refresh_lock_data(self, entry_id: str) -> set[str]:
+        """Refresh one lock's data and return dirty entry IDs."""
         await self._initial_setup_done_event.wait()
         self._quick_refresh = False
         self._sync_status_counter += 1
@@ -2272,6 +2346,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if before != self._lock_snapshot(entry_id):
             dirty.add(entry_id)
         dirty.update(await self._sync_child_locks(entry_id))
+        parent_entry_id = None
+        if entry_id in self.kmlocks:
+            parent_entry_id = self.kmlocks[entry_id].parent_config_entry_id
+        if parent_entry_id and parent_entry_id in self.kmlocks:
+            dirty.update(await self._sync_child_locks(parent_entry_id))
         if self._sync_status_counter > SYNC_STATUS_THRESHOLD:
             before_sync_status = {
                 lock_entry_id: self._lock_snapshot(lock_entry_id) for lock_entry_id in self.kmlocks
@@ -2283,7 +2362,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 for lock_entry_id, before_lock in before_sync_status.items()
                 if before_lock != self._lock_snapshot(lock_entry_id)
             )
-        await self._async_save_data()
+        if dirty:
+            await self._async_save_data()
         self.data = dict(self.kmlocks)
         await self._schedule_quick_refresh_if_needed()
         return dirty

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_STATE,
     EVENT_HOMEASSISTANT_STARTED,
+    EVENT_HOMEASSISTANT_STOP,
     SERVICE_LOCK,
     STATE_CLOSED,
     STATE_OFF,
@@ -242,6 +243,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._externally_dirty_entry_ids: set[str] = set()
         self._refresh_keepalive_unsub: Callable[[], None] | None = None
         self._pending_save_entry_ids: set[str] = set()
+        self._stop_unsub: Callable[[], None] | None = None
+        self._shutdown_complete = False
 
         super().__init__(
             hass,
@@ -252,6 +255,14 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
         self._timer_store = TimerStore(hass)
+        self._stop_unsub = hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STOP,
+            self._async_homeassistant_stop,
+        )
+
+    async def _async_homeassistant_stop(self, _: Event) -> None:
+        """Flush pending work when Home Assistant stops."""
+        await self.async_shutdown()
 
     @callback
     def async_cancel_pending_notifications(self) -> None:
@@ -265,7 +276,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
     async def async_shutdown(self) -> None:
         """Shutdown the coordinator and cancel any pending timers."""
+        if self._shutdown_complete:
+            return
         _LOGGER.debug("Shutting down keymaster coordinator")
+        if self._stop_unsub is not None:
+            self._stop_unsub()
+            self._stop_unsub = None
         await self.async_flush_pending_save_data()
         self._deferred_notifications_shutting_down = True
         self.async_cancel_pending_notifications()
@@ -280,6 +296,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self._cancel_debounced_refresh()
             self._cancel_debounced_refresh = None
         await super().async_shutdown()
+        self._shutdown_complete = True
 
     @callback
     def async_schedule_all_lock_notifications(self) -> None:
@@ -591,8 +608,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if config == self._prev_kmlocks_dict:
             _LOGGER.debug("[save_data] No changes to kmlocks. Not saving.")
             return
-        self._prev_kmlocks_dict = dict(config)
         await self._store.async_save(config)
+        self._prev_kmlocks_dict = dict(config)
         _LOGGER.debug("[save_data] Data saved to storage")
 
     @callback
@@ -604,12 +621,16 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
     async def async_flush_pending_save_data(self) -> None:
         """Flush any coalesced entry-scoped save work."""
-        if not self._pending_save_entry_ids:
-            return
-
-        entry_ids = set(self._pending_save_entry_ids)
-        await self._async_save_data(entry_ids=entry_ids)
-        self._pending_save_entry_ids.difference_update(entry_ids)
+        while self._pending_save_entry_ids:
+            entry_ids = set(self._pending_save_entry_ids)
+            self._pending_save_entry_ids.difference_update(entry_ids)
+            try:
+                await self._async_save_data(entry_ids=entry_ids)
+            except BaseException:
+                self._pending_save_entry_ids.update(
+                    entry_id for entry_id in entry_ids if entry_id in self.kmlocks
+                )
+                raise
 
     async def async_flush_pending_save_data_if_setup_complete(self) -> None:
         """Flush coalesced setup saves once every Keymaster entry has reached setup."""
@@ -618,7 +639,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         setup_states = {
             ConfigEntryState.LOADED,
+            ConfigEntryState.MIGRATION_ERROR,
+            ConfigEntryState.SETUP_ERROR,
             ConfigEntryState.SETUP_IN_PROGRESS,
+            ConfigEntryState.SETUP_RETRY,
         }
         entries = self.hass.config_entries.async_entries(DOMAIN)
         if all(entry.disabled_by is not None or entry.state in setup_states for entry in entries):
@@ -2406,15 +2430,15 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if advance_sync_status:
             self._sync_status_counter += 1
         await self._clear_pending_quick_refresh()
-        if self._cancel_debounced_refresh:
-            self._cancel_debounced_refresh()
-            self._cancel_debounced_refresh = None
         dirty = (
             {entry_id}
             if entry_id in self.kmlocks and entry_id in self._externally_dirty_entry_ids
             else set()
         )
         self._externally_dirty_entry_ids.discard(entry_id)
+        if self._cancel_debounced_refresh and not self._externally_dirty_entry_ids:
+            self._cancel_debounced_refresh()
+            self._cancel_debounced_refresh = None
         before = self._lock_snapshot(entry_id)
         await self._update_lock_data(entry_id)
         if before != self._lock_snapshot(entry_id):

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -226,6 +226,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._pending_failed_refresh = False
         self._notify_handle: asyncio.Handle | None = None
         self._refresh_dirty_entry_ids: set[str] | None = None
+        self._active_refresh_count = 0
         self._refresh_previous_update_success: bool | None = None
         self._externally_dirty_entry_ids: set[str] = set()
         self._refresh_keepalive_unsub: Callable[[], None] | None = None
@@ -278,13 +279,23 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if self._deferred_notifications_shutting_down:
             return
 
+        dirty_entry_ids = self._refresh_dirty_entry_ids
+        self._refresh_dirty_entry_ids = set()
         if (
             self._refresh_previous_update_success is not None
             and self._refresh_previous_update_success != self.last_update_success
-        ) or self._refresh_dirty_entry_ids is None:
+        ) or dirty_entry_ids is None:
             self.async_schedule_all_lock_notifications()
         else:
-            self.async_schedule_keymaster_notifications(self._refresh_dirty_entry_ids)
+            self.async_schedule_keymaster_notifications(dirty_entry_ids)
+
+    def _record_refresh_dirty_entry_ids(self, dirty_entry_ids: set[str]) -> None:
+        """Add refresh dirty entry IDs without dropping overlapping refresh results."""
+        if self._refresh_dirty_entry_ids is None:
+            self._refresh_dirty_entry_ids = set(dirty_entry_ids)
+            return
+
+        self._refresh_dirty_entry_ids.update(dirty_entry_ids)
 
     @callback
     def _push_lock_coordinator_update(
@@ -390,9 +401,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         raise_on_entry_error: bool = False,
     ) -> None:
         """Refresh data while deferring listener fan-out."""
+        if self._active_refresh_count == 0:
+            self._refresh_dirty_entry_ids = None
+            self._refresh_previous_update_success = self.last_update_success
+        self._active_refresh_count += 1
         self._defer_refresh_listener_updates = True
-        self._refresh_dirty_entry_ids = None
-        self._refresh_previous_update_success = self.last_update_success
         try:
             await super()._async_refresh(
                 log_failures=log_failures,
@@ -401,13 +414,15 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 raise_on_entry_error=raise_on_entry_error,
             )
         finally:
-            self._defer_refresh_listener_updates = False
-            if (
-                (self._pending_notify_entry_ids or self._pending_notify_all_entry_ids)
-                and self._notify_handle is None
-                and not self._deferred_notifications_shutting_down
-            ):
-                self._schedule_pending_keymaster_notifications()
+            self._active_refresh_count -= 1
+            if self._active_refresh_count == 0:
+                self._defer_refresh_listener_updates = False
+                if (
+                    (self._pending_notify_entry_ids or self._pending_notify_all_entry_ids)
+                    and self._notify_handle is None
+                    and not self._deferred_notifications_shutting_down
+                ):
+                    self._schedule_pending_keymaster_notifications()
 
     @callback
     def async_update_listeners(self) -> None:
@@ -2324,7 +2339,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update all keymaster locks."""
-        self._refresh_dirty_entry_ids = await self.async_refresh_all_locks()
+        self._record_refresh_dirty_entry_ids(await self.async_refresh_all_locks())
         return dict(self.kmlocks)
 
     async def _clear_pending_quick_refresh(self) -> None:

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any, Union, get_args, get_origin
 
 from homeassistant.components.lock.const import DOMAIN as LOCK_DOMAIN, LockState
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_STATE,
@@ -88,6 +88,12 @@ KEYPAD_UNLOCK_NOTIFICATION_DELAY_SECONDS = 1
 
 STORAGE_VERSION = 1
 STORAGE_KEY = f"{DOMAIN}.locks"
+
+
+@functools.cache
+def _serializable_dataclass_fields(cls: type) -> tuple[Any, ...]:
+    """Return dataclass fields that are persisted."""
+    return tuple(field for field in fields(cls) if field.init)
 
 
 def _is_masked_code(code: str | None) -> bool:
@@ -235,6 +241,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._refresh_previous_update_success: bool | None = None
         self._externally_dirty_entry_ids: set[str] = set()
         self._refresh_keepalive_unsub: Callable[[], None] | None = None
+        self._pending_save_entry_ids: set[str] = set()
 
         super().__init__(
             hass,
@@ -259,6 +266,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     async def async_shutdown(self) -> None:
         """Shutdown the coordinator and cancel any pending timers."""
         _LOGGER.debug("Shutting down keymaster coordinator")
+        await self.async_flush_pending_save_data()
         self._deferred_notifications_shutting_down = True
         self.async_cancel_pending_notifications()
         self._lock_coordinators.clear()
@@ -537,7 +545,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         for lock in config.values():
             lock["autolock_timer"] = None
             lock["listeners"] = []
-            for kmslot in lock.get("code_slots", {}).values():
+            for kmslot in (lock.get("code_slots") or {}).values():
                 if isinstance(kmslot.get("pin", None), str):
                     kmslot["pin"] = KeymasterCoordinator._decode_pin(
                         kmslot["pin"],
@@ -554,15 +562,25 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     async def _async_save_data(
         self,
         kmlocks: MutableMapping[str, KeymasterLock] | None = None,
+        *,
+        entry_ids: Iterable[str] | None = None,
     ) -> None:
         """Save data to Store."""
         if kmlocks is None:
             kmlocks = self.kmlocks
 
-        config: dict[str, Any] = {}
-        for key, kmlock in kmlocks.items():
+        if entry_ids is None or kmlocks is not self.kmlocks or not self._prev_kmlocks_dict:
+            config = {}
+            save_kmlocks: Iterable[tuple[str, KeymasterLock]] = kmlocks.items()
+        else:
+            config = dict(self._prev_kmlocks_dict)
+            save_kmlocks = (
+                (entry_id, kmlocks[entry_id]) for entry_id in set(entry_ids) if entry_id in kmlocks
+            )
+
+        for key, kmlock in save_kmlocks:
             lock = self._sanitized_lock_dict(self._kmlocks_to_dict(kmlock))
-            for kmslot in lock.get("code_slots", {}).values():
+            for kmslot in (lock.get("code_slots") or {}).values():
                 if isinstance(kmslot.get("pin", None), str):
                     kmslot["pin"] = KeymasterCoordinator._encode_pin(
                         kmslot["pin"],
@@ -576,6 +594,35 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._prev_kmlocks_dict = dict(config)
         await self._store.async_save(config)
         _LOGGER.debug("[save_data] Data saved to storage")
+
+    @callback
+    def async_schedule_save_data(self, entry_ids: Iterable[str]) -> None:
+        """Mark entries to be saved by the next setup-complete or shutdown flush."""
+        self._pending_save_entry_ids.update(
+            entry_id for entry_id in entry_ids if entry_id in self.kmlocks
+        )
+
+    async def async_flush_pending_save_data(self) -> None:
+        """Flush any coalesced entry-scoped save work."""
+        if not self._pending_save_entry_ids:
+            return
+
+        entry_ids = set(self._pending_save_entry_ids)
+        await self._async_save_data(entry_ids=entry_ids)
+        self._pending_save_entry_ids.difference_update(entry_ids)
+
+    async def async_flush_pending_save_data_if_setup_complete(self) -> None:
+        """Flush coalesced setup saves once every Keymaster entry has reached setup."""
+        if not self._pending_save_entry_ids:
+            return
+
+        setup_states = {
+            ConfigEntryState.LOADED,
+            ConfigEntryState.SETUP_IN_PROGRESS,
+        }
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        if all(entry.disabled_by is not None or entry.state in setup_states for entry in entries):
+            await self.async_flush_pending_save_data()
 
     def _sanitized_lock_dict(self, lock: object) -> dict[str, Any]:
         """Remove runtime-only lock fields from a serialized lock dictionary."""
@@ -632,12 +679,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if hasattr(cls, "__dataclass_fields__"):
             field_values: MutableMapping = {}
 
-            for field in fields(cls):
+            for field in _serializable_dataclass_fields(cls):
                 field_name: str = field.name
-
-                # Skip transient (init=False) fields — they are not persisted.
-                if not field.init:
-                    continue
 
                 field_type: type | None = keymasterlock_type_lookup.get(field_name)
                 if not field_type and isinstance(field.type, type):
@@ -748,12 +791,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         """Recursively convert a dataclass instance to a dictionary for JSON export."""
         if is_dataclass(instance):
             result: MutableMapping = {}
-            for field in fields(instance):
+            for field in _serializable_dataclass_fields(instance.__class__):
                 field_name: str = field.name
-
-                # Skip transient (init=False) fields — they are not persisted.
-                if not field.init:
-                    continue
 
                 field_value: Any = getattr(instance, field_name)
 
@@ -1697,7 +1736,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         await self._update_door_and_lock_state(entry_ids=[kmlock.keymaster_config_entry_id])
         await self._update_listeners(kmlock)
         await self._setup_timer(kmlock)
-        await self.async_refresh_lock(kmlock.keymaster_config_entry_id)
+        await self.async_refresh_lock(
+            kmlock.keymaster_config_entry_id,
+            advance_sync_status=False,
+            defer_save=True,
+        )
         return
 
     async def _update_lock(self, new: KeymasterLock) -> bool:
@@ -1761,7 +1804,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         # instance might not).
         if new.autolock_timer is None:
             await self._setup_timer(new)
-        await self.async_refresh_lock(new.keymaster_config_entry_id)
+        await self.async_refresh_lock(
+            new.keymaster_config_entry_id,
+            advance_sync_status=False,
+            defer_save=True,
+        )
         return True
 
     async def _delete_lock(self, kmlock: KeymasterLock, _: dt) -> None:
@@ -2275,12 +2322,28 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         return True
 
-    async def async_refresh_lock(self, entry_id: str) -> set[str]:
+    async def async_refresh_lock(
+        self,
+        entry_id: str,
+        *,
+        advance_sync_status: bool = True,
+        defer_save: bool = False,
+    ) -> set[str]:
         """Refresh one lock; return entry IDs whose entities may need notification."""
         async with self._debounced_refresh.async_lock():
-            return await self._async_refresh_lock(entry_id)
+            return await self._async_refresh_lock(
+                entry_id,
+                advance_sync_status=advance_sync_status,
+                defer_save=defer_save,
+            )
 
-    async def _async_refresh_lock(self, entry_id: str) -> set[str]:
+    async def _async_refresh_lock(
+        self,
+        entry_id: str,
+        *,
+        advance_sync_status: bool = True,
+        defer_save: bool = False,
+    ) -> set[str]:
         """Refresh one lock, preserving manager health and scoped notifications."""
         previous_update_success = self.last_update_success
         dirty_entry_ids: set[str] = set()
@@ -2290,7 +2353,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._active_refresh_count += 1
         self._defer_refresh_listener_updates = True
         try:
-            dirty_entry_ids = await self._async_refresh_lock_data(entry_id)
+            dirty_entry_ids = await self._async_refresh_lock_data(
+                entry_id,
+                advance_sync_status=advance_sync_status,
+                defer_save=defer_save,
+            )
         except asyncio.CancelledError as err:
             self.last_exception = err
             self.last_update_success = False
@@ -2326,11 +2393,18 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         return dirty_entry_ids
 
-    async def _async_refresh_lock_data(self, entry_id: str) -> set[str]:
+    async def _async_refresh_lock_data(
+        self,
+        entry_id: str,
+        *,
+        advance_sync_status: bool = True,
+        defer_save: bool = False,
+    ) -> set[str]:
         """Refresh one lock's data and return dirty entry IDs."""
         await self._initial_setup_done_event.wait()
         self._quick_refresh = False
-        self._sync_status_counter += 1
+        if advance_sync_status:
+            self._sync_status_counter += 1
         await self._clear_pending_quick_refresh()
         if self._cancel_debounced_refresh:
             self._cancel_debounced_refresh()
@@ -2363,7 +2437,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 if before_lock != self._lock_snapshot(lock_entry_id)
             )
         if dirty:
-            await self._async_save_data()
+            if defer_save:
+                self.async_schedule_save_data(dirty)
+            else:
+                await self._async_save_data(entry_ids=dirty)
         self.data = dict(self.kmlocks)
         await self._schedule_quick_refresh_if_needed()
         return dirty

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -244,6 +244,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._refresh_keepalive_unsub: Callable[[], None] | None = None
         self._pending_save_entry_ids: set[str] = set()
         self._save_lock = asyncio.Lock()
+        self._setup_completed_entry_ids: set[str] = set()
         self._stop_unsub: Callable[[], None] | None = None
         self._shutdown_complete = False
 
@@ -651,8 +652,13 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 )
                 raise
 
-    async def async_flush_pending_save_data_if_setup_complete(self) -> None:
+    async def async_flush_pending_save_data_if_setup_complete(
+        self,
+        completed_entry_id: str | None = None,
+    ) -> None:
         """Flush coalesced setup saves once every Keymaster entry has reached setup."""
+        if completed_entry_id is not None:
+            self._setup_completed_entry_ids.add(completed_entry_id)
         if not self._pending_save_entry_ids:
             return
 
@@ -660,11 +666,15 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             ConfigEntryState.LOADED,
             ConfigEntryState.MIGRATION_ERROR,
             ConfigEntryState.SETUP_ERROR,
-            ConfigEntryState.SETUP_IN_PROGRESS,
             ConfigEntryState.SETUP_RETRY,
         }
         entries = self.hass.config_entries.async_entries(DOMAIN)
-        if all(entry.disabled_by is not None or entry.state in setup_states for entry in entries):
+        if all(
+            entry.disabled_by is not None
+            or entry.state in setup_states
+            or entry.entry_id in self._setup_completed_entry_ids
+            for entry in entries
+        ):
             await self.async_flush_pending_save_data()
 
     def _sanitized_lock_dict(self, lock: object) -> dict[str, Any]:
@@ -1742,6 +1752,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     async def add_lock(self, kmlock: KeymasterLock, update: bool = False) -> None:
         """Add a new kmlock."""
         await self._initial_setup_done_event.wait()
+        self._setup_completed_entry_ids.discard(kmlock.keymaster_config_entry_id)
         if kmlock.keymaster_config_entry_id in self.kmlocks:
             if update or self.kmlocks[kmlock.keymaster_config_entry_id].pending_delete:
                 if self.kmlocks[kmlock.keymaster_config_entry_id].pending_delete:

--- a/custom_components/keymaster/entity.py
+++ b/custom_components/keymaster/entity.py
@@ -61,6 +61,20 @@ class KeymasterEntity(CoordinatorEntity[KeymasterLockCoordinator]):
         super().__init__(self.coordinator, self._attr_unique_id)
         # _LOGGER.debug(f"[Entity init] Entity created: {self.name}, device_info: {self.device_info}")
 
+    async def async_added_to_hass(self) -> None:
+        """Apply current coordinator data after the entity is added."""
+        await super().async_added_to_hass()
+
+        if (
+            self.entity_id is None
+            or self.coordinator.data is None
+            or not self.coordinator.last_update_success
+            or self._kmlock is None
+        ):
+            return
+
+        self._handle_coordinator_update()
+
     @property
     def available(self) -> bool:
         """Return whether entity is available."""

--- a/custom_components/keymaster/lock.py
+++ b/custom_components/keymaster/lock.py
@@ -250,6 +250,7 @@ class KeymasterLock:
         self.door_notifications = old.door_notifications
         self.retry_lock = old.retry_lock
         self.pending_retry_lock = old.pending_retry_lock
+        self.child_config_entry_ids = list(old.child_config_entry_ids)
         if not self.code_slots or not old.code_slots:
             # Log loudly: silent code-slot loss would drop the user's
             # PINs/schedules without any signal until they notice codes

--- a/custom_components/keymaster/lock.py
+++ b/custom_components/keymaster/lock.py
@@ -254,7 +254,7 @@ class KeymasterLock:
         self.door_notifications = old.door_notifications
         self.retry_lock = old.retry_lock
         self.pending_retry_lock = old.pending_retry_lock
-        self.child_config_entry_ids = list(old.child_config_entry_ids)
+        self.child_config_entry_ids = list(old.child_config_entry_ids or [])
         if not self.code_slots or not old.code_slots:
             # Log loudly: silent code-slot loss would drop the user's
             # PINs/schedules without any signal until they notice codes

--- a/custom_components/keymaster/lock.py
+++ b/custom_components/keymaster/lock.py
@@ -243,6 +243,10 @@ class KeymasterLock:
         """
         self.lock_state = old.lock_state
         self.door_state = old.door_state
+        if self.lock_entity_id == old.lock_entity_id:
+            self.lock_config_entry_id = old.lock_config_entry_id
+            self.connected = old.connected
+            self.provider = old.provider
         self.autolock_enabled = old.autolock_enabled
         self.autolock_min_day = old.autolock_min_day
         self.autolock_min_night = old.autolock_min_night

--- a/custom_components/keymaster/lock.py
+++ b/custom_components/keymaster/lock.py
@@ -243,7 +243,7 @@ class KeymasterLock:
         """
         self.lock_state = old.lock_state
         self.door_state = old.door_state
-        if self.lock_entity_id == old.lock_entity_id:
+        if self.lock_entity_id == old.lock_entity_id and old.connected and old.provider:
             self.lock_config_entry_id = old.lock_config_entry_id
             self.connected = old.connected
             self.provider = old.provider

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -114,7 +114,8 @@ def mock_coordinator(mock_hass) -> Any:
         # Use setattr to safely add the mock method
         setattr(coordinator, "delete_lock_by_config_entry_id", AsyncMock())
         setattr(coordinator, "async_set_updated_data", Mock())
-        setattr(coordinator, "async_schedule_global_notification", Mock())
+        setattr(coordinator, "async_schedule_all_lock_notifications", Mock())
+        setattr(coordinator, "async_schedule_keymaster_notifications", Mock())
         return coordinator
 
 
@@ -1099,7 +1100,7 @@ class TestLockStateEventHandlers:
         await mock_coordinator._lock_locked(mock_kmlock, source="manual")
 
         mock_kmlock.autolock_timer.cancel.assert_called_once()
-        mock_coordinator.async_schedule_global_notification.assert_called_once()
+        mock_coordinator.async_schedule_keymaster_notifications.assert_called_once()
 
     async def test_lock_locked_with_notifications(self, mock_coordinator, mock_kmlock):
         """Test _lock_locked sends notification when enabled."""
@@ -1140,7 +1141,7 @@ class TestLockStateEventHandlers:
         await mock_coordinator._lock_unlocked(mock_kmlock, source="manual")
 
         mock_kmlock.autolock_timer.start.assert_called_once_with(duration=300)
-        mock_coordinator.async_schedule_global_notification.assert_called_once()
+        mock_coordinator.async_schedule_keymaster_notifications.assert_called_once()
 
     async def test_lock_unlocked_no_autolock_no_data_update(self, mock_coordinator, mock_kmlock):
         """Test _lock_unlocked does not push data update when autolock is disabled."""
@@ -1154,7 +1155,7 @@ class TestLockStateEventHandlers:
 
         await mock_coordinator._lock_unlocked(mock_kmlock, source="manual")
 
-        mock_coordinator.async_schedule_global_notification.assert_not_called()
+        mock_coordinator.async_schedule_keymaster_notifications.assert_not_called()
 
     async def test_door_opened_basic_state_change(self, mock_coordinator, mock_kmlock):
         """Test _door_opened updates door state to open."""
@@ -1426,7 +1427,7 @@ class TestLockStateEventHandlers:
 
         assert mock_kmlock.lock_state == LockState.LOCKED
         mock_kmlock.autolock_timer.start.assert_called_once_with(duration=300)
-        mock_coordinator.async_schedule_global_notification.assert_called_once()
+        mock_coordinator.async_schedule_keymaster_notifications.assert_called_once()
         mock_notify.assert_not_called()
         mock_coordinator._lock_unlocked.assert_not_called()
         mock_coordinator._lock_locked.assert_not_called()
@@ -1459,7 +1460,7 @@ class TestLockStateEventHandlers:
 
         assert mock_kmlock.lock_state == LockState.UNLOCKED
         mock_kmlock.autolock_timer.cancel.assert_called_once()
-        mock_coordinator.async_schedule_global_notification.assert_called_once()
+        mock_coordinator.async_schedule_keymaster_notifications.assert_called_once()
         mock_notify.assert_not_called()
         mock_coordinator._lock_locked.assert_not_called()
         mock_coordinator._lock_unlocked.assert_not_called()
@@ -1625,7 +1626,7 @@ class TestSetupTimer:
         """Create a coordinator instance with mocked internals."""
         coordinator = KeymasterCoordinator(hass)
         coordinator.async_set_updated_data = Mock()
-        coordinator.async_schedule_global_notification = Mock()
+        coordinator.async_schedule_keymaster_notifications = Mock()
         coordinator._initial_setup_done_event.set()
         return coordinator
 
@@ -1684,7 +1685,7 @@ class TestSetupTimer:
         ):
             await mock_coordinator._setup_timer(kmlock)
 
-        mock_coordinator.async_schedule_global_notification.assert_called_once()
+        mock_coordinator.async_schedule_keymaster_notifications.assert_called_once()
 
     async def test_setup_timer_skips_if_already_attached(self, mock_coordinator):
         """Noop if the kmlock already has a timer.
@@ -3323,57 +3324,52 @@ async def test_async_shutdown(hass: HomeAssistant) -> None:
 async def test_failed_refresh_deferred_notify_preserves_failure_state(
     hass: HomeAssistant,
 ) -> None:
-    """Test failed refresh state survives deferred notify and local data updates."""
+    """Test failed refresh state survives deferred per-lock notifications."""
     coordinator = KeymasterCoordinator(hass)
     coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = KeymasterLock(
+        lock_name="test",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_1",
+    )
+    lock_coordinator = coordinator.async_get_lock_coordinator("entry_1")
     refresh_error = RuntimeError("refresh failed")
     coordinator._async_update_data = AsyncMock(side_effect=refresh_error)
-    delivered_data: list[dict[str, KeymasterLock]] = []
     listener_update_success: list[bool] = []
 
     def record_listener_state() -> None:
-        delivered_data.append(dict(coordinator.data or {}))
-        listener_update_success.append(coordinator.last_update_success)
+        listener_update_success.append(lock_coordinator.last_update_success)
 
     listener = Mock(side_effect=record_listener_state)
-    coordinator.async_add_listener(listener)
-    entity = CoordinatorEntity(coordinator)
+    lock_coordinator.async_add_listener(listener)
+    entity = CoordinatorEntity(lock_coordinator)
 
     await coordinator.async_refresh()
 
     listener.assert_not_called()
     assert coordinator.last_update_success is False
     assert coordinator.last_exception is refresh_error
-    assert entity.available is False
 
-    coordinator.kmlocks["entry_1"] = KeymasterLock(
-        lock_name="test",
-        lock_entity_id="lock.test",
-        keymaster_config_entry_id="entry_1",
-    )
-    coordinator.async_schedule_global_notification()
+    coordinator.async_schedule_keymaster_notifications(["entry_1"])
     await hass.async_block_till_done()
 
     listener.assert_called_once()
-    assert "entry_1" in delivered_data[0]
     assert listener_update_success == [False]
     assert coordinator.last_update_success is False
     assert coordinator.last_exception is refresh_error
     assert entity.available is False
 
     listener.reset_mock()
-    delivered_data.clear()
     listener_update_success.clear()
     coordinator.kmlocks["entry_2"] = KeymasterLock(
         lock_name="test2",
         lock_entity_id="lock.test2",
         keymaster_config_entry_id="entry_2",
     )
-    coordinator.async_schedule_global_notification()
+    coordinator.async_schedule_all_lock_notifications()
     await hass.async_block_till_done()
 
     listener.assert_called_once()
-    assert "entry_2" in delivered_data[0]
     assert listener_update_success == [False]
     assert coordinator.last_update_success is False
     assert coordinator.last_exception is refresh_error
@@ -3393,10 +3389,10 @@ async def test_failed_refresh_deferred_notify_preserves_failure_state(
     await coordinator.async_shutdown()
 
 
-async def test_cancel_pending_global_notification_prevents_deferred_flush(
+async def test_cancel_pending_notifications_prevents_deferred_flush(
     hass: HomeAssistant,
 ) -> None:
-    """Test unload cancellation clears pending global notification fan-out."""
+    """Test unload cancellation clears pending all-lock notification fan-out."""
     coordinator = KeymasterCoordinator(hass)
     coordinator.kmlocks["entry_1"] = KeymasterLock(
         lock_name="test",
@@ -3404,22 +3400,22 @@ async def test_cancel_pending_global_notification_prevents_deferred_flush(
         keymaster_config_entry_id="entry_1",
     )
     listener = Mock()
-    coordinator.async_add_listener(listener)
+    coordinator.async_get_lock_coordinator("entry_1").async_add_listener(listener)
 
-    coordinator.async_schedule_global_notification()
-    pending_handle = coordinator._global_notify_handle
+    coordinator.async_schedule_all_lock_notifications()
+    pending_handle = coordinator._notify_handle
 
     assert pending_handle is not None
     assert not pending_handle.cancelled()
-    assert coordinator._pending_global_notification
+    assert coordinator._pending_notify_all_entry_ids
 
-    coordinator.async_cancel_pending_global_notification()
+    coordinator.async_cancel_pending_notifications()
 
     assert pending_handle.cancelled()
-    assert coordinator._global_notify_handle is None
-    assert not coordinator._pending_global_notification
-    assert not coordinator._pending_global_data_update
-    assert not coordinator._pending_global_failed_refresh
+    assert coordinator._notify_handle is None
+    assert not coordinator._pending_notify_all_entry_ids
+    assert not coordinator._pending_notify_entry_ids
+    assert not coordinator._pending_failed_refresh
 
     await hass.async_block_till_done()
 
@@ -3427,17 +3423,17 @@ async def test_cancel_pending_global_notification_prevents_deferred_flush(
     await coordinator.async_shutdown()
 
 
-async def test_schedule_global_notification_noops_while_shutting_down(
+async def test_schedule_all_lock_notification_noops_while_shutting_down(
     hass: HomeAssistant,
 ) -> None:
     """Test local notification scheduling is ignored during shutdown."""
     coordinator = KeymasterCoordinator(hass)
     coordinator._deferred_notifications_shutting_down = True
 
-    coordinator.async_schedule_global_notification()
+    coordinator.async_schedule_all_lock_notifications()
 
-    assert coordinator._global_notify_handle is None
-    assert not coordinator._pending_global_notification
+    assert coordinator._notify_handle is None
+    assert not coordinator._pending_notify_all_entry_ids
     assert coordinator.data is None
 
     await coordinator.async_shutdown()
@@ -3451,105 +3447,111 @@ async def test_refresh_notification_noops_while_shutting_down(hass: HomeAssistan
 
     coordinator.async_update_listeners()
 
-    assert coordinator._global_notify_handle is None
-    assert not coordinator._pending_global_notification
+    assert coordinator._notify_handle is None
+    assert not coordinator._pending_notify_all_entry_ids
 
     await coordinator.async_shutdown()
 
 
-async def test_schedule_pending_global_notification_noops_during_refresh_deferral(
+async def test_schedule_pending_keymaster_notification_noops_during_refresh_deferral(
     hass: HomeAssistant,
 ) -> None:
     """Test pending flush scheduling waits until refresh deferral ends."""
     coordinator = KeymasterCoordinator(hass)
     coordinator._defer_refresh_listener_updates = True
 
-    coordinator._schedule_pending_global_notification()
+    coordinator._schedule_pending_keymaster_notifications()
 
-    assert coordinator._global_notify_handle is None
+    assert coordinator._notify_handle is None
 
     await coordinator.async_shutdown()
 
 
-async def test_schedule_pending_global_notification_creates_handle_when_not_deferring(
+async def test_schedule_pending_keymaster_notification_creates_handle_when_not_deferring(
     hass: HomeAssistant,
 ) -> None:
     """Test pending flush scheduling creates a handle outside refresh deferral."""
     coordinator = KeymasterCoordinator(hass)
 
-    coordinator._schedule_pending_global_notification()
+    coordinator._schedule_pending_keymaster_notifications()
 
-    assert coordinator._global_notify_handle is not None
+    assert coordinator._notify_handle is not None
 
     await coordinator.async_shutdown()
 
 
-async def test_flush_pending_global_notification_noops_without_pending(
+async def test_flush_pending_keymaster_notifications_noops_without_pending(
     hass: HomeAssistant,
 ) -> None:
-    """Test deferred flush exits when no global notification is pending."""
+    """Test deferred flush exits when no per-lock notification is pending."""
     coordinator = KeymasterCoordinator(hass)
     listener = Mock()
-    coordinator.async_add_listener(listener)
+    coordinator.async_get_lock_coordinator("entry_1").async_add_listener(listener)
 
-    coordinator._flush_pending_global_notification()
+    coordinator._flush_pending_keymaster_notifications()
 
     listener.assert_not_called()
-    assert coordinator._global_notify_handle is None
+    assert coordinator._notify_handle is None
 
     await coordinator.async_shutdown()
 
 
-async def test_flush_pending_global_notification_noops_while_shutting_down(
+async def test_flush_pending_keymaster_notifications_noops_while_shutting_down(
     hass: HomeAssistant,
 ) -> None:
     """Test deferred flush exits when shutdown starts before the callback runs."""
     coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["entry_1"] = KeymasterLock(
+        lock_name="test",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_1",
+    )
     listener = Mock()
-    coordinator.async_add_listener(listener)
-    coordinator._pending_global_notification = True
-    coordinator._pending_global_data_update = True
+    coordinator.async_get_lock_coordinator("entry_1").async_add_listener(listener)
+    coordinator._pending_notify_entry_ids = {"entry_1"}
     coordinator._deferred_notifications_shutting_down = True
 
-    coordinator._flush_pending_global_notification()
+    coordinator._flush_pending_keymaster_notifications()
 
     listener.assert_not_called()
-    assert coordinator._pending_global_notification
-    assert coordinator._global_notify_handle is None
+    assert coordinator._pending_notify_entry_ids == {"entry_1"}
+    assert coordinator._notify_handle is None
 
     await coordinator.async_shutdown()
 
 
-async def test_flush_pending_global_notification_waits_during_refresh_deferral(
+async def test_flush_pending_keymaster_notifications_waits_during_refresh_deferral(
     hass: HomeAssistant,
 ) -> None:
     """Test deferred flush preserves pending state while refresh defers fan-out."""
     coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["entry_1"] = KeymasterLock(
+        lock_name="test",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_1",
+    )
     listener = Mock()
-    coordinator.async_add_listener(listener)
-    coordinator._pending_global_notification = True
-    coordinator._pending_global_data_update = True
+    coordinator.async_get_lock_coordinator("entry_1").async_add_listener(listener)
+    coordinator._pending_notify_entry_ids = {"entry_1"}
     coordinator._deferred_notifications_shutting_down = False
     coordinator._defer_refresh_listener_updates = True
 
-    coordinator._flush_pending_global_notification()
+    coordinator._flush_pending_keymaster_notifications()
 
     listener.assert_not_called()
-    assert coordinator._pending_global_notification
-    assert coordinator._pending_global_data_update
-    assert coordinator._global_notify_handle is None
+    assert coordinator._pending_notify_entry_ids == {"entry_1"}
+    assert coordinator._notify_handle is None
 
     coordinator._defer_refresh_listener_updates = False
-    coordinator._flush_pending_global_notification()
+    coordinator._flush_pending_keymaster_notifications()
 
     listener.assert_called_once()
-    assert not coordinator._pending_global_notification
-    assert not coordinator._pending_global_data_update
+    assert not coordinator._pending_notify_entry_ids
 
     await coordinator.async_shutdown()
 
 
-async def test_refresh_finally_reschedules_pending_global_notification(
+async def test_refresh_finally_reschedules_pending_keymaster_notification(
     hass: HomeAssistant,
 ) -> None:
     """Test refresh finally schedules pending notification when no handle exists."""
@@ -3558,19 +3560,24 @@ async def test_refresh_finally_reschedules_pending_global_notification(
     coordinator.always_update = False
     coordinator.data = {}
     coordinator._async_update_data = AsyncMock(return_value=coordinator.data)
+    coordinator.kmlocks["entry_1"] = KeymasterLock(
+        lock_name="test",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_1",
+    )
     listener = Mock()
-    coordinator.async_add_listener(listener)
-    coordinator._pending_global_notification = True
+    coordinator.async_get_lock_coordinator("entry_1").async_add_listener(listener)
+    coordinator._pending_notify_entry_ids = {"entry_1"}
 
     await coordinator.async_refresh()
 
-    assert coordinator._global_notify_handle is not None
+    assert coordinator._notify_handle is not None
     listener.assert_not_called()
 
     await hass.async_block_till_done()
 
     listener.assert_called_once()
-    assert not coordinator._pending_global_notification
+    assert not coordinator._pending_notify_entry_ids
 
     await coordinator.async_shutdown()
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2261,6 +2261,29 @@ class TestDictToKmlocksConversion:
         # masked_code_slots is init=False, so gets its default (empty set)
         assert result.masked_code_slots == set()
 
+    def test_reload_inherits_missing_child_config_entry_ids_as_empty_list(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Stored locks missing child IDs reload without inheriting None."""
+        stored_lock = {
+            "lock_name": "Test",
+            "lock_entity_id": "lock.test",
+            "keymaster_config_entry_id": "entry_1",
+            "code_slots": {},
+        }
+        old_lock = coordinator_for_conversion._dict_to_kmlocks(stored_lock, KeymasterLock)
+        new_lock = KeymasterLock(
+            lock_name="Test",
+            lock_entity_id="lock.test",
+            keymaster_config_entry_id="entry_1",
+            code_slots={},
+        )
+
+        new_lock.inherit_state_from(old_lock)
+
+        assert new_lock.child_config_entry_ids == []
+
 
 class TestKmlocksToDict:
     """Test cases for _kmlocks_to_dict conversion method."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for the Coordinator."""
 
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime as dt, time as dt_time, timedelta
@@ -2373,6 +2374,7 @@ class TestStorageAndMigration:
             coord.hass = mock_hass
             coord.kmlocks = {}
             coord._prev_kmlocks_dict = {}
+            coord._save_lock = asyncio.Lock()
             coord._store = AsyncMock()
             return coord
 

--- a/tests/test_coordinator_code_import.py
+++ b/tests/test_coordinator_code_import.py
@@ -41,7 +41,7 @@ def mock_coordinator(mock_hass):
         coordinator.set_pin_on_lock = AsyncMock()
         coordinator.clear_pin_from_lock = AsyncMock()
         coordinator.async_set_updated_data = Mock()
-        coordinator.async_schedule_global_notification = Mock()
+        coordinator.async_schedule_keymaster_notifications = Mock()
         coordinator._initial_setup_done_event = AsyncMock()
         coordinator._initial_setup_done_event.wait = AsyncMock()
         return coordinator
@@ -290,7 +290,7 @@ class TestSetPinPassesName:
             coordinator._initial_setup_done_event = AsyncMock()
             coordinator._initial_setup_done_event.wait = AsyncMock()
             coordinator.async_set_updated_data = Mock()
-            coordinator.async_schedule_global_notification = Mock()
+            coordinator.async_schedule_keymaster_notifications = Mock()
             return coordinator
 
     async def test_set_pin_passes_name_to_provider(self, real_coordinator):

--- a/tests/test_coordinator_fanout_guard.py
+++ b/tests/test_coordinator_fanout_guard.py
@@ -44,6 +44,7 @@ from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
 import homeassistant.core as ha_core
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 LOWERED_GUARD_LIMIT = 8
 FAST_FANOUT_LISTENERS = LOWERED_GUARD_LIMIT + 1
@@ -340,6 +341,31 @@ def _register_coordinator_state_writers(
     return len(remove_listeners), remove_listeners
 
 
+def _register_lock_coordinator_state_writers(
+    hass: HomeAssistant,
+    coordinator: KeymasterCoordinator,
+    entry_id: str,
+    *,
+    listener_count: int,
+    guard_errors: list[HomeAssistantError],
+    fanout_dispatching_snapshots: list[bool] | None = None,
+) -> tuple[int, list[Callable[[], None]]]:
+    """Register synthetic state writers on one per-lock coordinator."""
+    lock_coordinator = coordinator.async_get_lock_coordinator(entry_id)
+    remove_listeners = [
+        lock_coordinator.async_add_listener(
+            _make_state_write_listener(
+                hass,
+                entity_number,
+                guard_errors,
+                fanout_dispatching_snapshots,
+            )
+        )
+        for entity_number in range(listener_count)
+    ]
+    return len(remove_listeners), remove_listeners
+
+
 def _remove_state_write_listeners(remove_listeners: list[Callable[[], None]]) -> None:
     """Remove synthetic fan-out listeners registered through the public API."""
     for remove_listener in remove_listeners:
@@ -357,7 +383,7 @@ def _exercise_nested_fanout(
     def _nested_fanout_listener(event: Event[Any]) -> None:
         dispatching_snapshots.append(hass.bus._dispatching)
         try:
-            coordinator.async_set_updated_data(dict(coordinator.kmlocks))
+            DataUpdateCoordinator.async_update_listeners(coordinator)
         except HomeAssistantError as err:
             _capture_guard_error(guard_errors, err)
             raise
@@ -374,13 +400,14 @@ def _exercise_nested_fanout(
 def _exercise_deferred_fanout(
     hass: HomeAssistant,
     coordinator: KeymasterCoordinator,
+    entry_ids: list[str],
 ) -> list[bool]:
     dispatching_snapshots: list[bool] = []
 
     @callback
     def _deferred_fanout_listener(event: Event[Any]) -> None:
         dispatching_snapshots.append(hass.bus._dispatching)
-        coordinator.async_schedule_global_notification()
+        coordinator.async_schedule_keymaster_notifications(entry_ids)
 
     remove_listener = hass.bus.async_listen(_FANOUT_TRIGGER_EVENT, _deferred_fanout_listener)
     try:
@@ -432,10 +459,10 @@ async def test_deferred_coordinator_fanout_avoids_lowered_event_bus_guard(
         _remove_state_write_listeners(raw_remove_listeners)
         await raw_coordinator.async_shutdown()
 
-    deferred_coordinator, _entries = _build_coordinator_tree(
+    deferred_coordinator, entries = _build_coordinator_tree(
         hass,
         mock_provider,
-        child_count=0,
+        child_count=1,
         slots=1,
         advanced_date_range=True,
         advanced_day_of_week=False,
@@ -443,21 +470,31 @@ async def test_deferred_coordinator_fanout_avoids_lowered_event_bus_guard(
     )
     deferred_guard_errors: list[HomeAssistantError] = []
     fanout_dispatching_snapshots: list[bool] = []
-    registered_deferred_entities, deferred_remove_listeners = _register_coordinator_state_writers(
-        hass,
-        deferred_coordinator,
-        FAST_FANOUT_LISTENERS,
-        deferred_guard_errors,
-        fanout_dispatching_snapshots,
+    registered_deferred_entities, deferred_remove_listeners = (
+        _register_lock_coordinator_state_writers(
+            hass,
+            deferred_coordinator,
+            entries[0].entry_id,
+            listener_count=FAST_FANOUT_LISTENERS,
+            guard_errors=deferred_guard_errors,
+            fanout_dispatching_snapshots=fanout_dispatching_snapshots,
+        )
     )
     assert registered_deferred_entities == FAST_FANOUT_LISTENERS
+    clean_listener = MagicMock()
+    deferred_coordinator.async_get_lock_coordinator(entries[1].entry_id).async_add_listener(
+        clean_listener
+    )
 
     try:
-        dispatching_snapshots = _exercise_deferred_fanout(hass, deferred_coordinator)
+        dispatching_snapshots = _exercise_deferred_fanout(
+            hass, deferred_coordinator, [entries[0].entry_id]
+        )
         await hass.async_block_till_done()
 
         assert dispatching_snapshots == [True]
         assert fanout_dispatching_snapshots == [False] * FAST_FANOUT_LISTENERS
+        clean_listener.assert_not_called()
         assert not deferred_guard_errors
     finally:
         _remove_state_write_listeners(deferred_remove_listeners)
@@ -497,16 +534,25 @@ async def test_deferred_realistic_parent_child_fanout_avoids_real_event_bus_guar
     assert projected_fanout_entities == intended_realistic_entities
     assert projected_fanout_entities > real_guard_limit
     guard_errors: list[HomeAssistantError] = []
-    registered_fanout_entities, remove_listeners = _register_coordinator_state_writers(
-        hass, coordinator, projected_fanout_entities, guard_errors
+    registered_fanout_entities, remove_listeners = _register_lock_coordinator_state_writers(
+        hass,
+        coordinator,
+        entries[0].entry_id,
+        listener_count=projected_fanout_entities,
+        guard_errors=guard_errors,
     )
     assert registered_fanout_entities == projected_fanout_entities
 
     try:
-        dispatching_snapshots = _exercise_deferred_fanout(hass, coordinator)
+        clean_listener = MagicMock()
+        coordinator.async_get_lock_coordinator(entries[1].entry_id).async_add_listener(
+            clean_listener
+        )
+        dispatching_snapshots = _exercise_deferred_fanout(hass, coordinator, [entries[0].entry_id])
         await hass.async_block_till_done()
 
         assert dispatching_snapshots == [True]
+        clean_listener.assert_not_called()
         assert not guard_errors
     finally:
         _remove_state_write_listeners(remove_listeners)

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -400,6 +400,63 @@ async def test_shutdown_flushes_pending_save_data(hass) -> None:
     assert coordinator._pending_save_entry_ids == set()
 
 
+async def test_shutdown_cleanup_runs_when_pending_save_flush_fails(hass) -> None:
+    """Test shutdown cleanup still runs after a failed pending-save flush."""
+    coordinator = KeymasterCoordinator(hass)
+    keepalive_unsub = MagicMock()
+    quick_refresh_unsub = MagicMock()
+    debounced_refresh_unsub = MagicMock()
+    notify_handle = MagicMock()
+    coordinator._pending_save_entry_ids = {"entry_1"}
+    coordinator._refresh_keepalive_unsub = keepalive_unsub
+    coordinator._cancel_quick_refresh = quick_refresh_unsub
+    coordinator._cancel_debounced_refresh = debounced_refresh_unsub
+    coordinator._notify_handle = notify_handle
+    coordinator._pending_notify_entry_ids = {"entry_1"}
+    coordinator._lock_coordinators["entry_1"] = MagicMock()
+    coordinator.async_flush_pending_save_data = AsyncMock(side_effect=RuntimeError("flush failed"))
+
+    await coordinator.async_shutdown()
+
+    coordinator.async_flush_pending_save_data.assert_awaited_once()
+    assert coordinator._pending_save_entry_ids == {"entry_1"}
+    notify_handle.cancel.assert_called_once()
+    keepalive_unsub.assert_called_once()
+    quick_refresh_unsub.assert_called_once()
+    debounced_refresh_unsub.assert_called_once()
+    assert coordinator._notify_handle is None
+    assert coordinator._refresh_keepalive_unsub is None
+    assert coordinator._cancel_quick_refresh is None
+    assert coordinator._cancel_debounced_refresh is None
+    assert coordinator._lock_coordinators == {}
+    assert coordinator._shutdown_requested is True
+    assert coordinator._shutdown_complete is True
+
+    await coordinator.async_shutdown()
+    coordinator.async_flush_pending_save_data.assert_awaited_once()
+
+
+async def test_shutdown_cleanup_runs_before_flush_cancellation_propagates(hass) -> None:
+    """Test shutdown cleanup runs before pending-save flush cancellation propagates."""
+    coordinator = KeymasterCoordinator(hass)
+    keepalive_unsub = MagicMock()
+    coordinator._pending_save_entry_ids = {"entry_1"}
+    coordinator._refresh_keepalive_unsub = keepalive_unsub
+    coordinator.async_flush_pending_save_data = AsyncMock(side_effect=asyncio.CancelledError)
+
+    with pytest.raises(asyncio.CancelledError):
+        await coordinator.async_shutdown()
+
+    assert coordinator._pending_save_entry_ids == {"entry_1"}
+    keepalive_unsub.assert_called_once()
+    assert coordinator._refresh_keepalive_unsub is None
+    assert coordinator._shutdown_requested is True
+    assert coordinator._shutdown_complete is True
+
+    await coordinator.async_shutdown()
+    coordinator.async_flush_pending_save_data.assert_awaited_once()
+
+
 async def test_failed_pending_save_is_retried_without_advancing_cache(hass) -> None:
     """Test failed coalesced saves remain pending and do not poison the saved cache."""
     # This asserts Keymaster's ordering contract for propagated exceptions. HA Store currently

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -26,7 +26,7 @@ from custom_components.keymaster.coordinator import KeymasterCoordinator, Keymas
 from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
 from custom_components.keymaster.providers._base import BaseLockProvider, CodeSlot
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -455,6 +455,42 @@ async def test_shutdown_cleanup_runs_before_flush_cancellation_propagates(hass) 
 
     await coordinator.async_shutdown()
     coordinator.async_flush_pending_save_data.assert_awaited_once()
+
+
+async def test_shutdown_unregisters_stop_listener_before_flush_await(hass) -> None:
+    """Test HA stop cannot re-enter shutdown while pending-save flush is awaiting."""
+    coordinator = KeymasterCoordinator(hass)
+    flush_started = asyncio.Event()
+    finish_flush = asyncio.Event()
+    original_stop_unsub = coordinator._stop_unsub
+    flush_calls = 0
+
+    async def flush_pending_save_data() -> None:
+        nonlocal flush_calls
+        flush_calls += 1
+        flush_started.set()
+        if flush_calls == 1:
+            await finish_flush.wait()
+
+    coordinator.async_flush_pending_save_data = AsyncMock(side_effect=flush_pending_save_data)
+    with patch(
+        "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.async_shutdown",
+        new_callable=AsyncMock,
+    ) as super_shutdown:
+        shutdown_task = asyncio.create_task(coordinator.async_shutdown())
+        await flush_started.wait()
+
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        finish_flush.set()
+        await shutdown_task
+
+    assert original_stop_unsub is not None
+    coordinator.async_flush_pending_save_data.assert_awaited_once()
+    super_shutdown.assert_awaited_once()
+    assert coordinator._shutdown_complete is True
 
 
 async def test_failed_pending_save_is_retried_without_advancing_cache(hass) -> None:

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -1151,7 +1151,7 @@ async def test_scoped_set_pin_notification_and_data_mirror(hass) -> None:
     await coordinator.async_shutdown()
 
 
-async def test_lock_snapshot_is_deep_sanitized_copy(hass) -> None:
+async def test_lock_snapshot_is_sanitized_copy(hass) -> None:
     """Test lock snapshots do not alias mutable live lock state."""
     coordinator = KeymasterCoordinator(hass)
     lock = _make_lock("entry_1", "lock_1")

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -255,10 +255,18 @@ async def test_restart_startup_uses_scoped_entry_refreshes(
     async def count_scoped_refresh(
         self: KeymasterCoordinator,
         entry_id: str,
+        *,
+        advance_sync_status: bool = True,
+        defer_save: bool = False,
     ) -> set[str]:
         nonlocal scoped_refresh_calls
         scoped_refresh_calls += 1
-        return await original_async_refresh_lock(self, entry_id)
+        return await original_async_refresh_lock(
+            self,
+            entry_id,
+            advance_sync_status=advance_sync_status,
+            defer_save=defer_save,
+        )
 
     async def count_update_lock_data(
         self: KeymasterCoordinator,
@@ -369,6 +377,25 @@ async def test_lock_coordinator_removal_manages_refresh_keepalive(hass):
     assert coordinator._refresh_keepalive_unsub is not None
 
     await coordinator.async_shutdown()
+
+
+async def test_shutdown_flushes_pending_save_data(hass) -> None:
+    """Test coalesced save work is flushed before coordinator shutdown."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["entry_1"] = KeymasterLock(
+        lock_name="lock_1",
+        lock_entity_id="lock.lock_1",
+        keymaster_config_entry_id="entry_1",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+    )
+    coordinator._store.async_save = AsyncMock()
+
+    coordinator.async_schedule_save_data(["entry_1"])
+
+    await coordinator.async_shutdown()
+
+    coordinator._store.async_save.assert_awaited_once()
+    assert coordinator._pending_save_entry_ids == set()
 
 
 async def test_keymaster_notification_bridge_notifies_only_lock(hass):
@@ -1104,8 +1131,15 @@ async def test_async_refresh_lock_reraises_task_cancellation(hass) -> None:
     started = asyncio.Event()
     unblock = asyncio.Event()
 
-    async def refresh_lock_data(entry_id: str) -> set[str]:
+    async def refresh_lock_data(
+        entry_id: str,
+        *,
+        advance_sync_status: bool = True,
+        defer_save: bool = False,
+    ) -> set[str]:
         assert entry_id == "entry_1"
+        assert advance_sync_status is True
+        assert defer_save is False
         started.set()
         await unblock.wait()
         return set()
@@ -1132,8 +1166,15 @@ async def test_async_refresh_lock_flushes_notifications_scheduled_during_refresh
     listener = MagicMock()
     lock_coordinator.async_add_listener(listener)
 
-    async def refresh_lock_data(entry_id: str) -> set[str]:
+    async def refresh_lock_data(
+        entry_id: str,
+        *,
+        advance_sync_status: bool = True,
+        defer_save: bool = False,
+    ) -> set[str]:
         assert entry_id == "entry_1"
+        assert advance_sync_status is True
+        assert defer_save is False
         coordinator.async_schedule_keymaster_notifications(["entry_1"])
         assert coordinator._notify_handle is None
         return set()
@@ -1476,7 +1517,11 @@ async def test_add_lock_new(mock_coordinator, mock_lock):
     mock_coordinator._update_listeners.assert_called_once_with(mock_lock)
     mock_coordinator._setup_timer.assert_called_once_with(mock_lock)
     mock_coordinator.async_refresh.assert_not_called()
-    mock_coordinator.async_refresh_lock.assert_awaited_once_with("test_entry")
+    mock_coordinator.async_refresh_lock.assert_awaited_once_with(
+        "test_entry",
+        advance_sync_status=False,
+        defer_save=True,
+    )
 
 
 async def test_add_lock_existing_update(mock_coordinator, mock_lock):
@@ -1751,6 +1796,9 @@ async def test_update_lock_inherits_notifications(hass):
     old_lock.starting_code_slot = 1
     old_lock.lock_notifications = True
     old_lock.door_notifications = True
+    old_lock.connected = True
+    old_lock.provider = MagicMock()
+    old_lock.lock_config_entry_id = "lock_config_entry"
 
     new_lock = KeymasterLock(
         lock_name="test_lock",
@@ -1772,6 +1820,9 @@ async def test_update_lock_inherits_notifications(hass):
     # Verify new_lock inherits the values from old_lock
     assert coordinator.kmlocks["entry_id"].lock_notifications is True
     assert coordinator.kmlocks["entry_id"].door_notifications is True
+    assert coordinator.kmlocks["entry_id"].connected is True
+    assert coordinator.kmlocks["entry_id"].provider is old_lock.provider
+    assert coordinator.kmlocks["entry_id"].lock_config_entry_id == "lock_config_entry"
 
 
 async def test_update_lock_rebuilds_relationships_when_parent_changes(hass):

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -8,9 +8,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.keymaster.const import DOMAIN, SYNC_STATUS_THRESHOLD
+from custom_components.keymaster.const import (
+    CONF_ADVANCED_DATE_RANGE,
+    CONF_ADVANCED_DAY_OF_WEEK,
+    CONF_DOOR_SENSOR_ENTITY_ID,
+    CONF_HIDE_PINS,
+    CONF_LOCK_ENTITY_ID,
+    CONF_LOCK_NAME,
+    CONF_SLOTS,
+    CONF_START,
+    DOMAIN,
+    SYNC_STATUS_THRESHOLD,
+)
 from custom_components.keymaster.coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
+from custom_components.keymaster.providers._base import BaseLockProvider, CodeSlot
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +69,77 @@ def _make_lock(entry_id: str = "test_entry", lock_name: str = "test_lock") -> Ke
     )
 
 
+class StartupProvider(BaseLockProvider):
+    """Provider used by startup regression coverage."""
+
+    @property
+    def domain(self) -> str:
+        """Return the provider domain."""
+        return "test"
+
+    @property
+    def supports_connection_status(self) -> bool:
+        """Return whether the provider exposes connection status."""
+        return True
+
+    async def async_connect(self) -> bool:
+        """Connect successfully."""
+        self._connected = True
+        return True
+
+    async def async_is_connected(self) -> bool:
+        """Return current connection status."""
+        return self._connected
+
+    async def async_get_usercodes(self) -> list[CodeSlot]:
+        """Return no configured user codes."""
+        return []
+
+    async def async_set_usercode(self, slot_num: int, code: str, name: str | None = None) -> bool:
+        """Set a user code successfully."""
+        return True
+
+    async def async_clear_usercode(self, slot_num: int) -> bool:
+        """Clear a user code successfully."""
+        return True
+
+
+def _make_startup_entry(hass: HomeAssistant, index: int) -> MockConfigEntry:
+    """Create a startup-style Keymaster config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=f"Entry {index}",
+        data={
+            CONF_ADVANCED_DATE_RANGE: False,
+            CONF_ADVANCED_DAY_OF_WEEK: False,
+            CONF_DOOR_SENSOR_ENTITY_ID: None,
+            CONF_HIDE_PINS: False,
+            CONF_LOCK_ENTITY_ID: f"lock.entry_{index}",
+            CONF_LOCK_NAME: f"entry_{index}",
+            CONF_SLOTS: 1,
+            CONF_START: 1,
+        },
+        version=4,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _startup_provider_factory(
+    hass: HomeAssistant,
+    lock_entity_id: str,
+    keymaster_config_entry: MockConfigEntry,
+) -> StartupProvider:
+    """Create a connected startup provider."""
+    return StartupProvider(
+        hass=hass,
+        lock_entity_id=lock_entity_id,
+        keymaster_config_entry=keymaster_config_entry,
+        device_registry=dr.async_get(hass),
+        entity_registry=er.async_get(hass),
+    )
+
+
 async def test_lock_coordinator_created_once_with_current_lock(hass):
     """Test manager creates one lock coordinator per entry with current data."""
     entry = MockConfigEntry(domain=DOMAIN, entry_id="test_entry", title="Test Lock", data={})
@@ -86,6 +173,54 @@ async def test_lock_coordinator_created_with_manager_health_state(hass):
     assert lock_coordinator.last_update_success is False
     assert lock_coordinator.last_exception is refresh_error
     await coordinator.async_shutdown()
+
+
+async def test_multi_entry_startup_entities_initialize_available(
+    hass: HomeAssistant,
+) -> None:
+    """Test every startup entry applies existing coordinator data when entities are added."""
+    entries = [_make_startup_entry(hass, index) for index in range(5)]
+
+    with (
+        patch(
+            "custom_components.keymaster.coordinator.create_provider",
+            side_effect=_startup_provider_factory,
+        ),
+        patch("custom_components.keymaster.async_generate_lovelace", new_callable=AsyncMock),
+        patch(
+            "custom_components.keymaster.async_update_large_lock_repair_issue",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.keymaster.async_update_all_large_lock_repair_issues",
+            new_callable=AsyncMock,
+        ),
+    ):
+        for entry in entries:
+            if entry.state is ConfigEntryState.NOT_LOADED:
+                assert await hass.config_entries.async_setup(entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    unavailable_by_entry: dict[str, list[str]] = {}
+    for entry in entries:
+        entity_ids = [
+            registry_entry.entity_id
+            for registry_entry in er.async_entries_for_config_entry(
+                entity_registry,
+                entry.entry_id,
+            )
+            if hass.states.get(registry_entry.entity_id) is not None
+        ]
+        assert entity_ids
+        unavailable_by_entry[entry.entry_id] = [
+            entity_id
+            for entity_id in entity_ids
+            if hass.states.get(entity_id).state == STATE_UNAVAILABLE
+        ]
+
+    assert unavailable_by_entry == {entry.entry_id: [] for entry in entries}
 
 
 async def test_lock_coordinator_refresh_same_lock_does_not_notify(hass):

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -1,13 +1,14 @@
 """Tests for KeymasterCoordinator lifecycle methods."""
 
 import asyncio
+from datetime import datetime as dt, timedelta
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.keymaster.const import DOMAIN
+from custom_components.keymaster.const import DOMAIN, SYNC_STATUS_THRESHOLD
 from custom_components.keymaster.coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
 
@@ -71,6 +72,22 @@ async def test_lock_coordinator_created_once_with_current_lock(hass):
     await coordinator.async_shutdown()
 
 
+async def test_lock_coordinator_created_with_manager_health_state(hass):
+    """Test new lock coordinators inherit the manager's current health state."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock()
+    coordinator.kmlocks["test_entry"] = lock
+    refresh_error = RuntimeError("refresh failed")
+    coordinator.last_update_success = False
+    coordinator.last_exception = refresh_error
+
+    lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
+
+    assert lock_coordinator.last_update_success is False
+    assert lock_coordinator.last_exception is refresh_error
+    await coordinator.async_shutdown()
+
+
 async def test_lock_coordinator_refresh_same_lock_does_not_notify(hass):
     """Test equal-data refresh does not notify lock coordinator listeners."""
     coordinator = KeymasterCoordinator(hass)
@@ -127,8 +144,8 @@ async def test_lock_coordinator_removal_manages_refresh_keepalive(hass):
     await coordinator.async_shutdown()
 
 
-async def test_keymaster_notification_bridge_notifies_global_and_lock(hass):
-    """Test bridge notifies manager listeners and per-lock coordinator listeners."""
+async def test_keymaster_notification_bridge_notifies_only_lock(hass):
+    """Test bridge notifies per-lock coordinator listeners but not manager listeners."""
     coordinator = KeymasterCoordinator(hass)
     lock = _make_lock()
     coordinator.kmlocks["test_entry"] = lock
@@ -140,10 +157,10 @@ async def test_keymaster_notification_bridge_notifies_global_and_lock(hass):
     coordinator.last_update_success = False
 
     coordinator.async_schedule_keymaster_notifications(["test_entry"])
-    assert coordinator._pending_global_failed_refresh is True
+    assert coordinator._pending_failed_refresh is True
     await asyncio.sleep(0)
 
-    manager_listener.assert_called_once()
+    manager_listener.assert_not_called()
     lock_listener.assert_called_once()
     assert coordinator.data == {"test_entry": lock}
     assert lock_coordinator.data is lock
@@ -159,8 +176,8 @@ async def test_keymaster_notification_bridge_notifies_global_and_lock(hass):
     await coordinator.async_shutdown()
 
 
-async def test_global_notification_conservatively_notifies_all_lock_coordinators(hass):
-    """Test global mutation notifications fan out to every per-lock coordinator."""
+async def test_all_lock_notification_conservatively_notifies_all_lock_coordinators(hass):
+    """Test all-lock notifications fan out to every per-lock coordinator."""
     coordinator = KeymasterCoordinator(hass)
     lock = _make_lock()
     other_lock = _make_lock("other_entry", "other_lock")
@@ -173,7 +190,7 @@ async def test_global_notification_conservatively_notifies_all_lock_coordinators
     lock_coordinator.async_add_listener(lock_listener)
     other_lock_coordinator.async_add_listener(other_lock_listener)
 
-    coordinator.async_schedule_global_notification()
+    coordinator.async_schedule_all_lock_notifications()
     await asyncio.sleep(0)
 
     lock_listener.assert_called_once()
@@ -183,8 +200,8 @@ async def test_global_notification_conservatively_notifies_all_lock_coordinators
     await coordinator.async_shutdown()
 
 
-async def test_global_flush_absorbs_pending_scoped_bridge(hass):
-    """Test global flush covers pending scoped notifications without double-firing."""
+async def test_all_lock_flush_absorbs_pending_scoped_bridge(hass):
+    """Test all-lock flush covers pending scoped notifications without double-firing."""
     coordinator = KeymasterCoordinator(hass)
     lock = _make_lock()
     other_lock = _make_lock("other_entry", "other_lock")
@@ -197,19 +214,19 @@ async def test_global_flush_absorbs_pending_scoped_bridge(hass):
     lock_coordinator.async_add_listener(lock_listener)
     other_lock_coordinator.async_add_listener(other_lock_listener)
 
-    coordinator.async_schedule_global_notification()
+    coordinator.async_schedule_all_lock_notifications()
     coordinator.async_schedule_keymaster_notifications(["test_entry"])
     await asyncio.sleep(0)
 
     lock_listener.assert_called_once()
     other_lock_listener.assert_called_once()
-    assert coordinator._global_notify_handle is None
     assert coordinator._notify_handle is None
+    assert coordinator._pending_notify_all_entry_ids is False
     await coordinator.async_shutdown()
 
 
-async def test_scoped_bridge_absorbs_pending_global_flush(hass):
-    """Test scoped bridge expands to all locks when a global flush is also pending."""
+async def test_scoped_bridge_absorbs_pending_all_lock_flush(hass):
+    """Test scoped bridge expands to all locks when an all-lock flush is also pending."""
     coordinator = KeymasterCoordinator(hass)
     lock = _make_lock()
     other_lock = _make_lock("other_entry", "other_lock")
@@ -223,18 +240,18 @@ async def test_scoped_bridge_absorbs_pending_global_flush(hass):
     other_lock_coordinator.async_add_listener(other_lock_listener)
 
     coordinator.async_schedule_keymaster_notifications(["test_entry"])
-    coordinator.async_schedule_global_notification()
+    coordinator.async_schedule_all_lock_notifications()
     await asyncio.sleep(0)
 
     lock_listener.assert_called_once()
     other_lock_listener.assert_called_once()
-    assert coordinator._global_notify_handle is None
     assert coordinator._notify_handle is None
+    assert coordinator._pending_notify_all_entry_ids is False
     await coordinator.async_shutdown()
 
 
-async def test_refresh_completion_notification_fans_out_to_lock_coordinators(hass):
-    """Test deferred refresh-completion notifications reach per-lock coordinators."""
+async def test_refresh_completion_notification_falls_back_to_all_lock_coordinators(hass):
+    """Test refresh completion falls back to all locks when no dirty set was recorded."""
     coordinator = KeymasterCoordinator(hass)
     lock = _make_lock()
     coordinator.kmlocks["test_entry"] = lock
@@ -252,7 +269,7 @@ async def test_refresh_completion_notification_fans_out_to_lock_coordinators(has
 
     await coordinator._async_refresh()
 
-    assert coordinator._global_notify_handle is not None
+    assert coordinator._notify_handle is not None
     await asyncio.sleep(0)
 
     lock_listener.assert_called_once()
@@ -260,18 +277,29 @@ async def test_refresh_completion_notification_fans_out_to_lock_coordinators(has
     await coordinator.async_shutdown()
 
 
-async def test_global_notification_flush_guards(hass):
-    """Test global notification flush returns while empty or refresh-deferred."""
+async def test_async_update_listeners_schedules_all_locks_outside_refresh(hass) -> None:
+    """Test manager listener updates fan out to all locks outside refresh deferral."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator.async_schedule_all_lock_notifications = MagicMock()
+
+    coordinator.async_update_listeners()
+
+    coordinator.async_schedule_all_lock_notifications.assert_called_once()
+    await coordinator.async_shutdown()
+
+
+async def test_all_lock_notification_flush_guards(hass):
+    """Test all-lock notification flush returns while empty or refresh-deferred."""
     coordinator = KeymasterCoordinator(hass)
 
-    coordinator._flush_pending_global_notification()
+    coordinator._flush_pending_keymaster_notifications()
 
-    coordinator._pending_global_notification = True
+    coordinator._pending_notify_entry_ids = {"test_entry"}
     coordinator._defer_refresh_listener_updates = True
 
-    coordinator._flush_pending_global_notification()
+    coordinator._flush_pending_keymaster_notifications()
 
-    assert coordinator._pending_global_notification is True
+    assert coordinator._pending_notify_entry_ids == {"test_entry"}
 
 
 async def test_lock_coordinator_schedule_notification_targets_own_entry(hass):
@@ -299,9 +327,7 @@ async def test_keymaster_notification_bridge_coalesces_duplicate_entries(hass):
     lock = _make_lock()
     coordinator.kmlocks["test_entry"] = lock
     lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
-    manager_listener = MagicMock()
     lock_listener = MagicMock()
-    coordinator.async_add_listener(manager_listener)
     lock_coordinator.async_add_listener(lock_listener)
 
     coordinator.async_schedule_keymaster_notifications(["test_entry"])
@@ -311,7 +337,6 @@ async def test_keymaster_notification_bridge_coalesces_duplicate_entries(hass):
     await asyncio.sleep(0)
 
     assert first_handle is not None
-    manager_listener.assert_called_once()
     lock_listener.assert_called_once()
     assert coordinator._notify_handle is None
     assert lock_coordinator.last_update_success is True
@@ -345,12 +370,12 @@ async def test_keymaster_notification_bridge_clears_failed_refresh_flag_when_hea
     lock_coordinator = coordinator.async_get_lock_coordinator("test_entry")
     lock_listener = MagicMock()
     lock_coordinator.async_add_listener(lock_listener)
-    coordinator._pending_global_failed_refresh = True
+    coordinator._pending_failed_refresh = True
     coordinator.last_update_success = True
 
     coordinator.async_schedule_keymaster_notifications(["test_entry"])
 
-    assert coordinator._pending_global_failed_refresh is False
+    assert coordinator._pending_failed_refresh is False
     await asyncio.sleep(0)
     lock_listener.assert_called_once()
     assert lock_coordinator.last_update_success is True
@@ -397,8 +422,6 @@ async def test_keymaster_notification_bridge_deferred_and_missing_lock_paths(has
 
     coordinator._defer_refresh_listener_updates = False
     coordinator._pending_notify_entry_ids = {"missing_entry", "orphan_entry"}
-    coordinator._pending_global_notification = True
-    coordinator._pending_global_data_update = True
 
     coordinator._flush_pending_keymaster_notifications()
 
@@ -447,6 +470,497 @@ async def test_keymaster_notification_bridge_shutdown_guard(hass):
     assert coordinator._pending_notify_entry_ids == set()
 
 
+async def test_refresh_completion_notifies_only_dirty_lock_coordinator(hass) -> None:
+    """Test refresh completion is deferred and scoped to the dirty lock set."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    dirty_lock = _make_lock("dirty_entry", "dirty_lock")
+    clean_lock = _make_lock("clean_entry", "clean_lock")
+    coordinator.kmlocks["dirty_entry"] = dirty_lock
+    coordinator.kmlocks["clean_entry"] = clean_lock
+    dirty_coordinator = coordinator.async_get_lock_coordinator("dirty_entry")
+    clean_coordinator = coordinator.async_get_lock_coordinator("clean_entry")
+    dirty_listener = MagicMock()
+    clean_listener = MagicMock()
+    manager_listener = MagicMock()
+    dirty_coordinator.async_add_listener(dirty_listener)
+    clean_coordinator.async_add_listener(clean_listener)
+    coordinator.async_add_listener(manager_listener)
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    async def update_lock_data(entry_id: str | None = None, **kwargs) -> None:
+        lock_entry_id = entry_id or kwargs["keymaster_config_entry_id"]
+        if lock_entry_id == "dirty_entry":
+            dirty_lock.lock_state = "locked"
+
+    coordinator._update_lock_data = update_lock_data  # type: ignore[assignment]
+
+    await coordinator._async_refresh()
+
+    dirty_listener.assert_not_called()
+    assert coordinator._notify_handle is not None
+    await asyncio.sleep(0)
+
+    dirty_listener.assert_called_once()
+    clean_listener.assert_not_called()
+    manager_listener.assert_not_called()
+    assert coordinator.data == coordinator.kmlocks
+    await coordinator.async_shutdown()
+
+
+async def test_refresh_health_recovery_notifies_all_lock_coordinators(hass) -> None:
+    """Test all lock coordinators are notified when manager refresh health recovers."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    lock_coordinator_1 = coordinator.async_get_lock_coordinator("entry_1")
+    lock_coordinator_2 = coordinator.async_get_lock_coordinator("entry_2")
+    listener_1 = MagicMock()
+    listener_2 = MagicMock()
+    lock_coordinator_1.async_add_listener(listener_1)
+    lock_coordinator_2.async_add_listener(listener_2)
+    coordinator._async_update_data = AsyncMock(side_effect=RuntimeError("refresh failed"))
+
+    await coordinator.async_refresh()
+    await asyncio.sleep(0)
+
+    assert lock_coordinator_1.last_update_success is False
+    assert lock_coordinator_2.last_update_success is False
+    assert isinstance(lock_coordinator_1.last_exception, RuntimeError)
+    assert isinstance(lock_coordinator_2.last_exception, RuntimeError)
+    listener_1.assert_called_once()
+    listener_2.assert_called_once()
+
+    listener_1.reset_mock()
+    listener_2.reset_mock()
+    coordinator._async_update_data = KeymasterCoordinator._async_update_data.__get__(coordinator)
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    await coordinator.async_refresh()
+    await asyncio.sleep(0)
+
+    assert coordinator._refresh_dirty_entry_ids == set()
+    assert lock_coordinator_1.last_update_success is True
+    assert lock_coordinator_2.last_update_success is True
+    assert lock_coordinator_1.last_exception is None
+    assert lock_coordinator_2.last_exception is None
+    listener_1.assert_called_once()
+    listener_2.assert_called_once()
+    await coordinator.async_shutdown()
+
+
+async def test_repeated_refresh_failure_does_not_fan_out_to_all_lock_coordinators(
+    hass,
+) -> None:
+    """Test a false-to-false refresh failure does not notify every lock again."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    lock_coordinator_1 = coordinator.async_get_lock_coordinator("entry_1")
+    lock_coordinator_2 = coordinator.async_get_lock_coordinator("entry_2")
+    listener_1 = MagicMock()
+    listener_2 = MagicMock()
+    lock_coordinator_1.async_add_listener(listener_1)
+    lock_coordinator_2.async_add_listener(listener_2)
+    coordinator._async_update_data = AsyncMock(side_effect=RuntimeError("refresh failed"))
+
+    await coordinator.async_refresh()
+    await asyncio.sleep(0)
+
+    listener_1.assert_called_once()
+    listener_2.assert_called_once()
+    listener_1.reset_mock()
+    listener_2.reset_mock()
+
+    await coordinator.async_refresh()
+    await asyncio.sleep(0)
+
+    assert lock_coordinator_1.last_update_success is False
+    assert lock_coordinator_2.last_update_success is False
+    listener_1.assert_not_called()
+    listener_2.assert_not_called()
+    await coordinator.async_shutdown()
+
+
+async def test_refresh_health_recovery_notifies_all_with_mixed_dirtiness(hass) -> None:
+    """Test recovery notifies clean and dirty locks because availability is global."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    dirty_lock = _make_lock("dirty_entry", "dirty_lock")
+    clean_lock = _make_lock("clean_entry", "clean_lock")
+    coordinator.kmlocks["dirty_entry"] = dirty_lock
+    coordinator.kmlocks["clean_entry"] = clean_lock
+    dirty_coordinator = coordinator.async_get_lock_coordinator("dirty_entry")
+    clean_coordinator = coordinator.async_get_lock_coordinator("clean_entry")
+    dirty_listener = MagicMock()
+    clean_listener = MagicMock()
+    dirty_coordinator.async_add_listener(dirty_listener)
+    clean_coordinator.async_add_listener(clean_listener)
+    coordinator._async_update_data = AsyncMock(side_effect=RuntimeError("refresh failed"))
+
+    await coordinator.async_refresh()
+    await asyncio.sleep(0)
+
+    dirty_listener.reset_mock()
+    clean_listener.reset_mock()
+    coordinator._async_update_data = KeymasterCoordinator._async_update_data.__get__(coordinator)
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    async def update_lock_data(entry_id: str | None = None, **kwargs) -> None:
+        lock_entry_id = entry_id or kwargs["keymaster_config_entry_id"]
+        if lock_entry_id == "dirty_entry":
+            dirty_lock.lock_state = "locked"
+
+    coordinator._update_lock_data = update_lock_data  # type: ignore[assignment]
+
+    await coordinator.async_refresh()
+    await asyncio.sleep(0)
+
+    assert coordinator._refresh_dirty_entry_ids == {"dirty_entry"}
+    assert dirty_coordinator.last_update_success is True
+    assert clean_coordinator.last_update_success is True
+    dirty_listener.assert_called_once()
+    clean_listener.assert_called_once()
+    await coordinator.async_shutdown()
+
+
+async def test_async_refresh_lock_returns_dirty_lock_and_updates_mirror(hass) -> None:
+    """Test single-lock refresh reports changed lock, saves, and updates data mirror."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    lock = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_1"] = lock
+    coordinator._sync_child_locks = AsyncMock(return_value=set())
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+    coordinator._update_door_and_lock_state = AsyncMock()
+
+    async def update_lock_data(keymaster_config_entry_id: str) -> None:
+        assert keymaster_config_entry_id == "entry_1"
+        lock.lock_state = "locked"
+
+    coordinator._update_lock_data = update_lock_data
+
+    dirty = await coordinator.async_refresh_lock("entry_1")
+
+    assert dirty == {"entry_1"}
+    coordinator._sync_child_locks.assert_awaited_once_with("entry_1")
+    coordinator._async_save_data.assert_awaited_once()
+    coordinator._schedule_quick_refresh_if_needed.assert_awaited_once()
+    assert coordinator.data == coordinator.kmlocks
+    await coordinator.async_shutdown()
+
+
+async def test_async_refresh_lock_unchanged_lock_is_not_dirty(hass) -> None:
+    """Test single-lock refresh does not report an unchanged lock as dirty."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._sync_child_locks = AsyncMock(return_value=set())
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+    coordinator._update_door_and_lock_state = AsyncMock()
+
+    dirty = await coordinator.async_refresh_lock("entry_1")
+
+    assert dirty == set()
+    coordinator._async_save_data.assert_awaited_once()
+    assert coordinator.data == coordinator.kmlocks
+    await coordinator.async_shutdown()
+
+
+async def test_async_refresh_lock_folds_child_dirty_ids(hass) -> None:
+    """Test single-lock refresh includes dirty child IDs from parent sync."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["parent_entry"] = _make_lock("parent_entry", "parent_lock")
+    coordinator.kmlocks["child_entry"] = _make_lock("child_entry", "child_lock")
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._sync_child_locks = AsyncMock(return_value={"child_entry"})
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+    coordinator._update_door_and_lock_state = AsyncMock()
+
+    dirty = await coordinator.async_refresh_lock("parent_entry")
+
+    assert dirty == {"child_entry"}
+    coordinator._async_save_data.assert_awaited_once()
+    assert coordinator.data == coordinator.kmlocks
+    await coordinator.async_shutdown()
+
+
+async def test_async_refresh_lock_cancels_debounce_and_reports_sync_status_dirty(hass) -> None:
+    """Test single-lock refresh cancels debounced refresh and reports sync status changes."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    lock = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_1"] = lock
+    coordinator._sync_status_counter = SYNC_STATUS_THRESHOLD
+    cancel_debounced_refresh = MagicMock()
+    coordinator._cancel_debounced_refresh = cancel_debounced_refresh
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._sync_child_locks = AsyncMock(return_value=set())
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    async def update_door_and_lock_state(trigger_actions_if_changed: bool = False) -> None:
+        assert trigger_actions_if_changed is True
+        lock.lock_state = "locked"
+
+    coordinator._update_door_and_lock_state = update_door_and_lock_state
+
+    dirty = await coordinator.async_refresh_lock("entry_1")
+
+    assert dirty == {"entry_1"}
+    cancel_debounced_refresh.assert_called_once()
+    assert coordinator._cancel_debounced_refresh is None
+    assert coordinator._sync_status_counter == 0
+    await coordinator.async_shutdown()
+
+
+async def test_external_dirty_entry_is_drained_into_refresh_dirty_set(hass) -> None:
+    """Test externally dirty entries are returned once and then cleared."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._sync_child_locks = AsyncMock(return_value=set())
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    await coordinator.async_request_debounced_refresh("entry_1")
+    coordinator._externally_dirty_entry_ids.add("missing_entry")
+
+    dirty = await coordinator.async_refresh_all_locks()
+
+    assert dirty == {"entry_1"}
+    assert coordinator._externally_dirty_entry_ids == set()
+
+    dirty = await coordinator.async_refresh_all_locks()
+
+    assert dirty == set()
+    await coordinator.async_shutdown()
+
+
+async def test_deleted_external_dirty_entry_is_dropped_without_notification(hass) -> None:
+    """Test deleted externally dirty entries are ignored by the next refresh."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    lock_coordinator = coordinator.async_get_lock_coordinator("entry_1")
+    listener = MagicMock()
+    lock_coordinator.async_add_listener(listener)
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    await coordinator.async_request_debounced_refresh("entry_1")
+    coordinator.kmlocks.pop("entry_1")
+
+    await coordinator.async_refresh()
+    await asyncio.sleep(0)
+
+    assert coordinator._refresh_dirty_entry_ids == set()
+    assert coordinator._externally_dirty_entry_ids == set()
+    listener.assert_not_called()
+    await coordinator.async_shutdown()
+
+
+async def test_refresh_completion_with_no_dirty_locks_notifies_no_lock_coordinators(
+    hass,
+) -> None:
+    """Test unchanged refreshes do not fan out to all per-lock coordinators."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    lock_coordinator_1 = coordinator.async_get_lock_coordinator("entry_1")
+    lock_coordinator_2 = coordinator.async_get_lock_coordinator("entry_2")
+    listener_1 = MagicMock()
+    listener_2 = MagicMock()
+    lock_coordinator_1.async_add_listener(listener_1)
+    lock_coordinator_2.async_add_listener(listener_2)
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    await coordinator._async_refresh()
+    await asyncio.sleep(0)
+
+    listener_1.assert_not_called()
+    listener_2.assert_not_called()
+    assert coordinator._notify_handle is None
+    await coordinator.async_shutdown()
+
+
+async def test_backoff_skipped_lock_is_not_dirty(hass) -> None:
+    """Test locks skipped during backoff are not included in the dirty set."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    lock = _make_lock("backoff_entry", "backoff_lock")
+    coordinator.kmlocks["backoff_entry"] = lock
+    coordinator._next_retry_time["backoff_entry"] = dt.now().astimezone() + timedelta(minutes=5)
+    coordinator._connect_and_update_lock = AsyncMock()
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    dirty = await coordinator.async_refresh_all_locks()
+
+    assert dirty == set()
+    coordinator._connect_and_update_lock.assert_not_awaited()
+    await coordinator.async_shutdown()
+
+
+async def test_refreshes_lock_data_sequentially(hass) -> None:
+    """Test manager refreshes one lock at a time."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    in_flight = 0
+    max_in_flight = 0
+    order: list[str] = []
+
+    async def update_lock_data(entry_id: str | None = None, **kwargs) -> None:
+        nonlocal in_flight, max_in_flight
+        lock_entry_id = entry_id or kwargs["keymaster_config_entry_id"]
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        order.append(lock_entry_id)
+        await asyncio.sleep(0)
+        in_flight -= 1
+
+    coordinator._update_lock_data = update_lock_data  # type: ignore[assignment]
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    await coordinator.async_refresh_all_locks()
+
+    assert max_in_flight == 1
+    assert order == ["entry_1", "entry_2"]
+    await coordinator.async_shutdown()
+
+
+async def test_async_refresh_all_locks_reports_sync_status_dirty(hass) -> None:
+    """Test all-lock refresh includes entries changed by sync status refresh."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    lock = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_1"] = lock
+    coordinator._sync_status_counter = SYNC_STATUS_THRESHOLD
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._sync_child_locks = AsyncMock(return_value=set())
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    async def update_door_and_lock_state(trigger_actions_if_changed: bool = False) -> None:
+        assert trigger_actions_if_changed is True
+        lock.lock_state = "locked"
+
+    coordinator._update_door_and_lock_state = update_door_and_lock_state
+
+    dirty = await coordinator.async_refresh_all_locks()
+
+    assert dirty == {"entry_1"}
+    assert coordinator._sync_status_counter == 0
+    await coordinator.async_shutdown()
+
+
+async def test_sync_child_locks_ignores_missing_and_empty_child_lists(hass) -> None:
+    """Test child sync returns no dirty IDs for missing locks and empty child lists."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+
+    assert await coordinator._sync_child_locks("missing_entry") == set()
+
+    parent = _make_lock("parent_entry", "parent_lock")
+    parent.connected = True
+    parent.provider = MagicMock()
+    parent.child_config_entry_ids = []
+    coordinator.kmlocks["parent_entry"] = parent
+
+    assert await coordinator._sync_child_locks("parent_entry") == set()
+    await coordinator.async_shutdown()
+
+
+async def test_sync_child_locks_reports_dirty_child_snapshots(hass) -> None:
+    """Test child sync reports child entries whose lock snapshots changed."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    parent = _make_lock("parent_entry", "parent_lock")
+    parent.connected = True
+    parent.provider = MagicMock()
+    parent.child_config_entry_ids = ["child_entry"]
+    child = _make_lock("child_entry", "child_lock")
+    coordinator.kmlocks["parent_entry"] = parent
+    coordinator.kmlocks["child_entry"] = child
+
+    async def sync_child_lock(kmlock: KeymasterLock, child_entry_id: str) -> None:
+        assert kmlock is parent
+        assert child_entry_id == "child_entry"
+        child.lock_state = "locked"
+
+    coordinator._sync_child_lock = sync_child_lock
+
+    assert await coordinator._sync_child_locks("parent_entry") == {"child_entry"}
+    await coordinator.async_shutdown()
+
+
+async def test_scoped_set_pin_notification_and_data_mirror(hass) -> None:
+    """Test set_pin_on_lock notifies only the affected lock and updates manager data."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    affected_lock = _make_lock("affected_entry", "affected_lock")
+    unaffected_lock = _make_lock("unaffected_entry", "unaffected_lock")
+    affected_lock.code_slots = {1: KeymasterCodeSlot(number=1, name="Front")}
+    provider = MagicMock()
+    provider.async_set_usercode = AsyncMock(return_value=True)
+    affected_lock.provider = provider
+    coordinator.kmlocks["affected_entry"] = affected_lock
+    coordinator.kmlocks["unaffected_entry"] = unaffected_lock
+    affected_coordinator = coordinator.async_get_lock_coordinator("affected_entry")
+    unaffected_coordinator = coordinator.async_get_lock_coordinator("unaffected_entry")
+    affected_listener = MagicMock()
+    unaffected_listener = MagicMock()
+    affected_coordinator.async_add_listener(affected_listener)
+    unaffected_coordinator.async_add_listener(unaffected_listener)
+
+    assert await coordinator.set_pin_on_lock("affected_entry", 1, "1234") is True
+    await asyncio.sleep(0)
+
+    affected_listener.assert_called_once()
+    unaffected_listener.assert_not_called()
+    assert coordinator.data == coordinator.kmlocks
+    assert affected_coordinator.data is affected_lock
+    await coordinator.async_shutdown()
+
+
+async def test_lock_snapshot_is_deep_sanitized_copy(hass) -> None:
+    """Test lock snapshots do not alias mutable live lock state."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = _make_lock("entry_1", "lock_1")
+    lock.provider = MagicMock()
+    lock.code_slots = {1: KeymasterCodeSlot(number=1, pin="1234")}
+    coordinator.kmlocks["entry_1"] = lock
+
+    snapshot = coordinator._lock_snapshot("entry_1")
+    assert snapshot is not None
+    lock.code_slots[1].pin = "5678"
+
+    assert snapshot["code_slots"][1]["pin"] == "1234"
+    assert "provider" not in snapshot
+    assert coordinator._lock_snapshot("missing_entry") is None
+    await coordinator.async_shutdown()
+
+
 async def test_lock_coordinator_proxy_methods_delegate(hass):
     """Test lock coordinator proxy methods delegate to the manager."""
     coordinator = KeymasterCoordinator(hass)
@@ -479,7 +993,7 @@ async def test_lock_coordinator_proxy_methods_delegate(hass):
     coordinator.update_slot_active_state.assert_awaited_once_with("test_entry", 1)
 
     await lock_coordinator.async_request_debounced_refresh()
-    coordinator.async_request_debounced_refresh.assert_awaited_once_with()
+    coordinator.async_request_debounced_refresh.assert_awaited_once_with("test_entry")
 
     assert lock_coordinator.autolock_duration_seconds(lock) == 123
     coordinator.autolock_duration_seconds.assert_called_once_with(lock)

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -3,6 +3,7 @@
 import asyncio
 from datetime import datetime as dt, timedelta
 import logging
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -393,6 +394,102 @@ async def test_shutdown_flushes_pending_save_data(hass) -> None:
     coordinator.async_schedule_save_data(["entry_1"])
 
     await coordinator.async_shutdown()
+
+    coordinator._store.async_save.assert_awaited_once()
+    assert coordinator._pending_save_entry_ids == set()
+
+
+async def test_failed_pending_save_is_retried_without_advancing_cache(hass) -> None:
+    """Test failed coalesced saves remain pending and do not poison the saved cache."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["entry_1"] = KeymasterLock(
+        lock_name="lock_1",
+        lock_entity_id="lock.lock_1",
+        keymaster_config_entry_id="entry_1",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+    )
+    coordinator._store.async_save = AsyncMock(side_effect=[RuntimeError("disk full"), None])
+
+    coordinator.async_schedule_save_data(["entry_1"])
+
+    with pytest.raises(RuntimeError, match="disk full"):
+        await coordinator.async_flush_pending_save_data()
+
+    assert coordinator._pending_save_entry_ids == {"entry_1"}
+
+    await coordinator.async_flush_pending_save_data()
+
+    assert coordinator._store.async_save.await_count == 2
+    assert coordinator._pending_save_entry_ids == set()
+    await coordinator.async_shutdown()
+
+
+async def test_pending_save_scheduled_during_flush_is_not_dropped(hass) -> None:
+    """Test save work queued during disk I/O is flushed by the same drain loop."""
+    coordinator = KeymasterCoordinator(hass)
+    lock = KeymasterLock(
+        lock_name="lock_1",
+        lock_entity_id="lock.lock_1",
+        keymaster_config_entry_id="entry_1",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+    )
+    coordinator.kmlocks["entry_1"] = lock
+    scheduled_during_flush = False
+
+    async def save_data(_: dict[str, object]) -> None:
+        nonlocal scheduled_during_flush
+        if not scheduled_during_flush:
+            scheduled_during_flush = True
+            lock.lock_state = "locked"
+            coordinator.async_schedule_save_data(["entry_1"])
+
+    coordinator._store.async_save = AsyncMock(side_effect=save_data)
+
+    coordinator.async_schedule_save_data(["entry_1"])
+
+    await coordinator.async_flush_pending_save_data()
+
+    assert coordinator._store.async_save.await_count == 2
+    assert coordinator._pending_save_entry_ids == set()
+    await coordinator.async_shutdown()
+
+
+async def test_setup_retry_entry_does_not_block_pending_save_flush(hass) -> None:
+    """Test retrying entries do not strand pending saves for loaded entries."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator._async_save_data = AsyncMock()
+    coordinator.async_schedule_save_data(["entry_1"])
+
+    with patch.object(
+        hass.config_entries,
+        "async_entries",
+        return_value=[
+            SimpleNamespace(disabled_by=None, state=ConfigEntryState.LOADED),
+            SimpleNamespace(disabled_by=None, state=ConfigEntryState.SETUP_RETRY),
+        ],
+    ):
+        await coordinator.async_flush_pending_save_data_if_setup_complete()
+
+    coordinator._async_save_data.assert_awaited_once_with(entry_ids={"entry_1"})
+    assert coordinator._pending_save_entry_ids == set()
+    await coordinator.async_shutdown()
+
+
+async def test_homeassistant_stop_flushes_pending_save_data(hass) -> None:
+    """Test the coordinator flushes pending saves on Home Assistant stop."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["entry_1"] = KeymasterLock(
+        lock_name="lock_1",
+        lock_entity_id="lock.lock_1",
+        keymaster_config_entry_id="entry_1",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+    )
+    coordinator._store.async_save = AsyncMock()
+    coordinator.async_schedule_save_data(["entry_1"])
+
+    hass.bus.async_fire("homeassistant_stop")
+    await hass.async_block_till_done()
 
     coordinator._store.async_save.assert_awaited_once()
     assert coordinator._pending_save_entry_ids == set()
@@ -1120,6 +1217,29 @@ async def test_async_refresh_lock_health_transition_notifies_all_locks(hass) -> 
     assert lock_coordinator_2.last_update_success is True
     listener_1.assert_called_once()
     listener_2.assert_called_once()
+    await coordinator.async_shutdown()
+
+
+async def test_scoped_refresh_keeps_shared_debounce_for_other_dirty_locks(hass) -> None:
+    """Test scoped refresh does not strand another lock's pending debounced refresh."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    cancel_debounced_refresh = MagicMock()
+    coordinator._cancel_debounced_refresh = cancel_debounced_refresh
+    coordinator._externally_dirty_entry_ids = {"entry_2"}
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._sync_child_locks = AsyncMock(return_value=set())
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    dirty = await coordinator.async_refresh_lock("entry_1")
+
+    assert dirty == set()
+    assert coordinator._externally_dirty_entry_ids == {"entry_2"}
+    assert coordinator._cancel_debounced_refresh is cancel_debounced_refresh
+    cancel_debounced_refresh.assert_not_called()
     await coordinator.async_shutdown()
 
 

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -509,6 +509,79 @@ async def test_refresh_completion_notifies_only_dirty_lock_coordinator(hass) -> 
     await coordinator.async_shutdown()
 
 
+async def test_overlapping_refreshes_union_dirty_lock_notifications(hass) -> None:
+    """Test overlapping refreshes do not drop dirty entry IDs."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    lock_coordinator_1 = coordinator.async_get_lock_coordinator("entry_1")
+    lock_coordinator_2 = coordinator.async_get_lock_coordinator("entry_2")
+    listener_1 = MagicMock()
+    listener_2 = MagicMock()
+    lock_coordinator_1.async_add_listener(listener_1)
+    lock_coordinator_2.async_add_listener(listener_2)
+    first_recorded = asyncio.Event()
+    second_recorded = asyncio.Event()
+    refresh_calls = 0
+
+    async def update_data() -> dict[str, KeymasterLock]:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        if refresh_calls == 1:
+            coordinator._record_refresh_dirty_entry_ids({"entry_1"})
+            first_recorded.set()
+            await second_recorded.wait()
+        else:
+            coordinator._record_refresh_dirty_entry_ids({"entry_2"})
+            second_recorded.set()
+        return dict(coordinator.kmlocks)
+
+    coordinator._async_update_data = update_data
+
+    refresh_1 = asyncio.create_task(coordinator._async_refresh())
+    await first_recorded.wait()
+    refresh_2 = asyncio.create_task(coordinator._async_refresh())
+    await second_recorded.wait()
+    await refresh_2
+    await refresh_1
+    await asyncio.sleep(0)
+
+    listener_1.assert_called_once()
+    listener_2.assert_called_once()
+    assert coordinator._refresh_dirty_entry_ids == set()
+    await coordinator.async_shutdown()
+
+
+async def test_refresh_completion_without_dirty_record_notifies_all_lock_coordinators(
+    hass,
+) -> None:
+    """Test an unknown refresh dirty set falls back to all-lock notifications."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    lock_coordinator_1 = coordinator.async_get_lock_coordinator("entry_1")
+    lock_coordinator_2 = coordinator.async_get_lock_coordinator("entry_2")
+    listener_1 = MagicMock()
+    listener_2 = MagicMock()
+    lock_coordinator_1.async_add_listener(listener_1)
+    lock_coordinator_2.async_add_listener(listener_2)
+
+    async def update_data() -> dict[str, KeymasterLock]:
+        return dict(coordinator.kmlocks)
+
+    coordinator._async_update_data = update_data
+
+    await coordinator._async_refresh()
+    await asyncio.sleep(0)
+
+    listener_1.assert_called_once()
+    listener_2.assert_called_once()
+    assert coordinator._refresh_dirty_entry_ids == set()
+    await coordinator.async_shutdown()
+
+
 async def test_refresh_health_recovery_notifies_all_lock_coordinators(hass) -> None:
     """Test all lock coordinators are notified when manager refresh health recovers."""
     coordinator = KeymasterCoordinator(hass)
@@ -622,7 +695,7 @@ async def test_refresh_health_recovery_notifies_all_with_mixed_dirtiness(hass) -
     await coordinator.async_refresh()
     await asyncio.sleep(0)
 
-    assert coordinator._refresh_dirty_entry_ids == {"dirty_entry"}
+    assert coordinator._refresh_dirty_entry_ids == set()
     assert dirty_coordinator.last_update_success is True
     assert clean_coordinator.last_update_success is True
     dirty_listener.assert_called_once()

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -1,6 +1,7 @@
 """Tests for KeymasterCoordinator lifecycle methods."""
 
 import asyncio
+import copy
 from datetime import datetime as dt, timedelta
 import logging
 from types import SimpleNamespace
@@ -401,6 +402,8 @@ async def test_shutdown_flushes_pending_save_data(hass) -> None:
 
 async def test_failed_pending_save_is_retried_without_advancing_cache(hass) -> None:
     """Test failed coalesced saves remain pending and do not poison the saved cache."""
+    # This asserts Keymaster's ordering contract for propagated exceptions. HA Store currently
+    # swallows some lower-level write failures; see FutureTense/keymaster#704.
     coordinator = KeymasterCoordinator(hass)
     coordinator.kmlocks["entry_1"] = KeymasterLock(
         lock_name="lock_1",
@@ -451,6 +454,101 @@ async def test_pending_save_scheduled_during_flush_is_not_dropped(hass) -> None:
 
     assert coordinator._store.async_save.await_count == 2
     assert coordinator._pending_save_entry_ids == set()
+    await coordinator.async_shutdown()
+
+
+async def test_overlapping_partial_saves_preserve_both_changes(hass) -> None:
+    """Test concurrent partial saves merge against the latest persisted cache."""
+    coordinator = KeymasterCoordinator(hass)
+    lock_a = KeymasterLock(
+        lock_name="lock_a",
+        lock_entity_id="lock.lock_a",
+        keymaster_config_entry_id="entry_a",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+    )
+    lock_b = KeymasterLock(
+        lock_name="lock_b",
+        lock_entity_id="lock.lock_b",
+        keymaster_config_entry_id="entry_b",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+    )
+    coordinator.kmlocks = {"entry_a": lock_a, "entry_b": lock_b}
+    coordinator._store.async_save = AsyncMock()
+    await coordinator._async_save_data()
+    coordinator._store.async_save.reset_mock()
+
+    persisted_configs: list[dict[str, object]] = []
+    save_b_task: asyncio.Task[None] | None = None
+    first_save = True
+
+    async def save_data(config: dict[str, object]) -> None:
+        nonlocal first_save, save_b_task
+        if first_save:
+            first_save = False
+            lock_b.lock_state = "locked"
+            save_b_task = asyncio.create_task(coordinator._async_save_data(entry_ids={"entry_b"}))
+            await asyncio.sleep(0)
+        persisted_configs.append(copy.deepcopy(config))
+
+    coordinator._store.async_save = AsyncMock(side_effect=save_data)
+    lock_a.lock_state = "locked"
+
+    await coordinator._async_save_data(entry_ids={"entry_a"})
+    assert save_b_task is not None
+    await save_b_task
+
+    final_config = persisted_configs[-1]
+    assert final_config["entry_a"]["lock_state"] == "locked"  # type: ignore[index]
+    assert final_config["entry_b"]["lock_state"] == "locked"  # type: ignore[index]
+    assert coordinator._prev_kmlocks_dict == final_config
+    await coordinator.async_shutdown()
+
+
+async def test_full_save_delete_racing_partial_save_wins(hass) -> None:
+    """Test full saves do not have deletions reverted by in-flight partial saves."""
+    coordinator = KeymasterCoordinator(hass)
+    lock_a = KeymasterLock(
+        lock_name="lock_a",
+        lock_entity_id="lock.lock_a",
+        keymaster_config_entry_id="entry_a",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+    )
+    lock_b = KeymasterLock(
+        lock_name="lock_b",
+        lock_entity_id="lock.lock_b",
+        keymaster_config_entry_id="entry_b",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+    )
+    coordinator.kmlocks = {"entry_a": lock_a, "entry_b": lock_b}
+    coordinator._store.async_save = AsyncMock()
+    await coordinator._async_save_data()
+    coordinator._store.async_save.reset_mock()
+
+    persisted_configs: list[dict[str, object]] = []
+    full_save_task: asyncio.Task[None] | None = None
+    first_save = True
+
+    async def save_data(config: dict[str, object]) -> None:
+        nonlocal first_save, full_save_task
+        if first_save:
+            first_save = False
+            coordinator.kmlocks.pop("entry_b")
+            full_save_task = asyncio.create_task(coordinator._async_save_data())
+            await asyncio.sleep(0)
+        persisted_configs.append(copy.deepcopy(config))
+
+    coordinator._store.async_save = AsyncMock(side_effect=save_data)
+    lock_a.lock_state = "locked"
+
+    await coordinator._async_save_data(entry_ids={"entry_a"})
+    assert full_save_task is not None
+    await full_save_task
+
+    final_config = persisted_configs[-1]
+    assert "entry_b" not in final_config
+    assert "entry_b" not in coordinator._prev_kmlocks_dict
+    assert final_config["entry_a"]["lock_state"] == "locked"  # type: ignore[index]
+    assert coordinator._prev_kmlocks_dict == final_config
     await coordinator.async_shutdown()
 
 

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -41,6 +41,7 @@ def mock_coordinator(hass):
     coordinator._update_listeners = AsyncMock()
     coordinator._setup_timer = AsyncMock()
     coordinator.async_refresh = AsyncMock()
+    coordinator.async_refresh_lock = AsyncMock()
     coordinator._initial_setup_done_event.set()  # Don't block
     return coordinator
 
@@ -218,6 +219,97 @@ async def test_multi_entry_startup_entities_initialize_available(
             entity_id
             for entity_id in entity_ids
             if hass.states.get(entity_id).state == STATE_UNAVAILABLE
+        ]
+
+    assert unavailable_by_entry == {entry.entry_id: [] for entry in entries}
+
+
+async def test_restart_startup_uses_scoped_entry_refreshes(
+    hass: HomeAssistant,
+) -> None:
+    """Test restart setup does not run one full all-lock refresh per entry."""
+    entries = [_make_startup_entry(hass, index) for index in range(5)]
+    stored_locks = {
+        entry.entry_id: KeymasterLock(
+            lock_name=entry.data[CONF_LOCK_NAME],
+            lock_entity_id=entry.data[CONF_LOCK_ENTITY_ID],
+            keymaster_config_entry_id=entry.entry_id,
+            number_of_code_slots=entry.data[CONF_SLOTS],
+            starting_code_slot=entry.data[CONF_START],
+            code_slots={1: KeymasterCodeSlot(number=1)},
+        )
+        for entry in entries
+    }
+    full_refresh_calls = 0
+    scoped_refresh_calls = 0
+    update_lock_data_calls = 0
+    original_async_refresh = KeymasterCoordinator.async_refresh
+    original_async_refresh_lock = KeymasterCoordinator.async_refresh_lock
+    original_update_lock_data = KeymasterCoordinator._update_lock_data
+
+    async def count_full_refresh(self: KeymasterCoordinator) -> None:
+        nonlocal full_refresh_calls
+        full_refresh_calls += 1
+        await original_async_refresh(self)
+
+    async def count_scoped_refresh(
+        self: KeymasterCoordinator,
+        entry_id: str,
+    ) -> set[str]:
+        nonlocal scoped_refresh_calls
+        scoped_refresh_calls += 1
+        return await original_async_refresh_lock(self, entry_id)
+
+    async def count_update_lock_data(
+        self: KeymasterCoordinator,
+        keymaster_config_entry_id: str,
+    ) -> None:
+        nonlocal update_lock_data_calls
+        update_lock_data_calls += 1
+        await original_update_lock_data(self, keymaster_config_entry_id)
+
+    with (
+        patch.object(
+            KeymasterCoordinator, "_async_load_data", AsyncMock(return_value=stored_locks)
+        ),
+        patch.object(KeymasterCoordinator, "async_refresh", count_full_refresh),
+        patch.object(KeymasterCoordinator, "async_refresh_lock", count_scoped_refresh),
+        patch.object(KeymasterCoordinator, "_update_lock_data", count_update_lock_data),
+        patch(
+            "custom_components.keymaster.coordinator.create_provider",
+            side_effect=_startup_provider_factory,
+        ),
+        patch("custom_components.keymaster.async_generate_lovelace", new_callable=AsyncMock),
+        patch(
+            "custom_components.keymaster.async_update_large_lock_repair_issue",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.keymaster.async_update_all_large_lock_repair_issues",
+            new_callable=AsyncMock,
+        ),
+    ):
+        for entry in entries:
+            if entry.state is ConfigEntryState.NOT_LOADED:
+                assert await hass.config_entries.async_setup(entry.entry_id)
+
+        await hass.async_block_till_done()
+
+    assert full_refresh_calls == 1
+    assert scoped_refresh_calls == len(entries)
+    assert update_lock_data_calls <= len(entries) * 2
+
+    entity_registry = er.async_get(hass)
+    unavailable_by_entry: dict[str, list[str]] = {}
+    for entry in entries:
+        unavailable_by_entry[entry.entry_id] = [
+            registry_entry.entity_id
+            for registry_entry in er.async_entries_for_config_entry(
+                entity_registry,
+                entry.entry_id,
+            )
+            if hass.states.get(registry_entry.entity_id) is not None
+            and hass.states.get(registry_entry.entity_id).state == STATE_UNAVAILABLE
         ]
 
     assert unavailable_by_entry == {entry.entry_id: [] for entry in entries}
@@ -879,7 +971,7 @@ async def test_async_refresh_lock_unchanged_lock_is_not_dirty(hass) -> None:
     dirty = await coordinator.async_refresh_lock("entry_1")
 
     assert dirty == set()
-    coordinator._async_save_data.assert_awaited_once()
+    coordinator._async_save_data.assert_not_awaited()
     assert coordinator.data == coordinator.kmlocks
     await coordinator.async_shutdown()
 
@@ -904,6 +996,30 @@ async def test_async_refresh_lock_folds_child_dirty_ids(hass) -> None:
     await coordinator.async_shutdown()
 
 
+async def test_async_refresh_lock_syncs_parent_when_refreshing_child(hass) -> None:
+    """Test child refresh also propagates parent settings back to the child tree."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["parent_entry"] = _make_lock("parent_entry", "parent_lock")
+    child_lock = _make_lock("child_entry", "child_lock")
+    child_lock.parent_config_entry_id = "parent_entry"
+    coordinator.kmlocks["child_entry"] = child_lock
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._sync_child_locks = AsyncMock(side_effect=[set(), {"child_entry"}])
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+    coordinator._update_door_and_lock_state = AsyncMock()
+
+    dirty = await coordinator.async_refresh_lock("child_entry")
+
+    assert dirty == {"child_entry"}
+    assert [args.args[0] for args in coordinator._sync_child_locks.await_args_list] == [
+        "child_entry",
+        "parent_entry",
+    ]
+    await coordinator.async_shutdown()
+
+
 async def test_async_refresh_lock_cancels_debounce_and_reports_sync_status_dirty(hass) -> None:
     """Test single-lock refresh cancels debounced refresh and reports sync status changes."""
     coordinator = KeymasterCoordinator(hass)
@@ -918,8 +1034,12 @@ async def test_async_refresh_lock_cancels_debounce_and_reports_sync_status_dirty
     coordinator._async_save_data = AsyncMock()
     coordinator._schedule_quick_refresh_if_needed = AsyncMock()
 
-    async def update_door_and_lock_state(trigger_actions_if_changed: bool = False) -> None:
+    async def update_door_and_lock_state(
+        trigger_actions_if_changed: bool = False,
+        entry_ids: object = None,
+    ) -> None:
         assert trigger_actions_if_changed is True
+        assert entry_ids is None
         lock.lock_state = "locked"
 
     coordinator._update_door_and_lock_state = update_door_and_lock_state
@@ -930,6 +1050,49 @@ async def test_async_refresh_lock_cancels_debounce_and_reports_sync_status_dirty
     cancel_debounced_refresh.assert_called_once()
     assert coordinator._cancel_debounced_refresh is None
     assert coordinator._sync_status_counter == 0
+    await coordinator.async_shutdown()
+
+
+async def test_async_refresh_lock_health_transition_notifies_all_locks(hass) -> None:
+    """Test scoped refresh keeps global manager health mirrored to every lock."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    lock_coordinator_1 = coordinator.async_get_lock_coordinator("entry_1")
+    lock_coordinator_2 = coordinator.async_get_lock_coordinator("entry_2")
+    listener_1 = MagicMock()
+    listener_2 = MagicMock()
+    lock_coordinator_1.async_add_listener(listener_1)
+    lock_coordinator_2.async_add_listener(listener_2)
+    coordinator._update_lock_data = AsyncMock(side_effect=RuntimeError("refresh failed"))
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    dirty = await coordinator.async_refresh_lock("entry_1")
+    await asyncio.sleep(0)
+
+    assert dirty == set()
+    assert coordinator.last_update_success is False
+    assert lock_coordinator_1.last_update_success is False
+    assert lock_coordinator_2.last_update_success is False
+    listener_1.assert_called_once()
+    listener_2.assert_called_once()
+
+    listener_1.reset_mock()
+    listener_2.reset_mock()
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._sync_child_locks = AsyncMock(return_value=set())
+
+    dirty = await coordinator.async_refresh_lock("entry_1")
+    await asyncio.sleep(0)
+
+    assert dirty == set()
+    assert coordinator.last_update_success is True
+    assert lock_coordinator_1.last_update_success is True
+    assert lock_coordinator_2.last_update_success is True
+    listener_1.assert_called_once()
+    listener_2.assert_called_once()
     await coordinator.async_shutdown()
 
 
@@ -1069,8 +1232,12 @@ async def test_async_refresh_all_locks_reports_sync_status_dirty(hass) -> None:
     coordinator._async_save_data = AsyncMock()
     coordinator._schedule_quick_refresh_if_needed = AsyncMock()
 
-    async def update_door_and_lock_state(trigger_actions_if_changed: bool = False) -> None:
+    async def update_door_and_lock_state(
+        trigger_actions_if_changed: bool = False,
+        entry_ids: object = None,
+    ) -> None:
         assert trigger_actions_if_changed is True
+        assert entry_ids is None
         lock.lock_state = "locked"
 
     coordinator._update_door_and_lock_state = update_door_and_lock_state
@@ -1255,7 +1422,8 @@ async def test_add_lock_new(mock_coordinator, mock_lock):
     mock_coordinator._update_door_and_lock_state.assert_called_once()
     mock_coordinator._update_listeners.assert_called_once_with(mock_lock)
     mock_coordinator._setup_timer.assert_called_once_with(mock_lock)
-    mock_coordinator.async_refresh.assert_called_once()
+    mock_coordinator.async_refresh.assert_not_called()
+    mock_coordinator.async_refresh_lock.assert_awaited_once_with("test_entry")
 
 
 async def test_add_lock_existing_update(mock_coordinator, mock_lock):
@@ -1476,6 +1644,7 @@ async def test_update_lock_unsubscribes_old_listeners(hass):
     coordinator._rebuild_lock_relationships = AsyncMock()
     coordinator._update_door_and_lock_state = AsyncMock()
     coordinator.async_refresh = AsyncMock()
+    coordinator.async_refresh_lock = AsyncMock()
 
     old_lock = KeymasterLock(
         lock_name="test_lock",
@@ -1517,6 +1686,7 @@ async def test_update_lock_inherits_notifications(hass):
     coordinator._rebuild_lock_relationships = AsyncMock()
     coordinator._update_door_and_lock_state = AsyncMock()
     coordinator.async_refresh = AsyncMock()
+    coordinator.async_refresh_lock = AsyncMock()
 
     old_lock = KeymasterLock(
         lock_name="test_lock",

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -667,6 +667,35 @@ async def test_setup_retry_entry_does_not_block_pending_save_flush(hass) -> None
     await coordinator.async_shutdown()
 
 
+async def test_setup_in_progress_entries_do_not_trigger_early_save_flush(hass) -> None:
+    """Test concurrent in-progress entries do not shrink setup save coalescing."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator._async_save_data = AsyncMock()
+    coordinator.async_schedule_save_data(["entry_1"])
+
+    entries = [
+        SimpleNamespace(
+            entry_id=f"entry_{index}",
+            disabled_by=None,
+            state=ConfigEntryState.SETUP_IN_PROGRESS,
+        )
+        for index in range(1, 4)
+    ]
+    with patch.object(hass.config_entries, "async_entries", return_value=entries):
+        await coordinator.async_flush_pending_save_data_if_setup_complete("entry_1")
+        await coordinator.async_flush_pending_save_data_if_setup_complete("entry_2")
+
+        coordinator._async_save_data.assert_not_awaited()
+        assert coordinator._pending_save_entry_ids == {"entry_1"}
+
+        await coordinator.async_flush_pending_save_data_if_setup_complete("entry_3")
+
+    coordinator._async_save_data.assert_awaited_once_with(entry_ids={"entry_1"})
+    assert coordinator._pending_save_entry_ids == set()
+    await coordinator.async_shutdown()
+
+
 async def test_homeassistant_stop_flushes_pending_save_data(hass) -> None:
     """Test the coordinator flushes pending saves on Home Assistant stop."""
     coordinator = KeymasterCoordinator(hass)

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -1096,6 +1096,59 @@ async def test_async_refresh_lock_health_transition_notifies_all_locks(hass) -> 
     await coordinator.async_shutdown()
 
 
+async def test_async_refresh_lock_reraises_task_cancellation(hass) -> None:
+    """Test scoped refresh preserves task cancellation semantics."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    started = asyncio.Event()
+    unblock = asyncio.Event()
+
+    async def refresh_lock_data(entry_id: str) -> set[str]:
+        assert entry_id == "entry_1"
+        started.set()
+        await unblock.wait()
+        return set()
+
+    coordinator._async_refresh_lock_data = refresh_lock_data
+
+    refresh_task = asyncio.create_task(coordinator.async_refresh_lock("entry_1"))
+    await started.wait()
+    refresh_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await refresh_task
+
+    assert coordinator.last_update_success is False
+    await coordinator.async_shutdown()
+
+
+async def test_async_refresh_lock_flushes_notifications_scheduled_during_refresh(hass) -> None:
+    """Test scoped refresh flushes notification work queued during deferral."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    lock_coordinator = coordinator.async_get_lock_coordinator("entry_1")
+    listener = MagicMock()
+    lock_coordinator.async_add_listener(listener)
+
+    async def refresh_lock_data(entry_id: str) -> set[str]:
+        assert entry_id == "entry_1"
+        coordinator.async_schedule_keymaster_notifications(["entry_1"])
+        assert coordinator._notify_handle is None
+        return set()
+
+    coordinator._async_refresh_lock_data = refresh_lock_data
+
+    dirty = await coordinator.async_refresh_lock("entry_1")
+
+    assert dirty == set()
+    assert coordinator._notify_handle is not None
+    await asyncio.sleep(0)
+    listener.assert_called_once()
+    await coordinator.async_shutdown()
+
+
 async def test_external_dirty_entry_is_drained_into_refresh_dirty_set(hass) -> None:
     """Test externally dirty entries are returned once and then cleared."""
     coordinator = KeymasterCoordinator(hass)
@@ -1719,3 +1772,38 @@ async def test_update_lock_inherits_notifications(hass):
     # Verify new_lock inherits the values from old_lock
     assert coordinator.kmlocks["entry_id"].lock_notifications is True
     assert coordinator.kmlocks["entry_id"].door_notifications is True
+
+
+async def test_update_lock_rebuilds_relationships_when_parent_changes(hass):
+    """Test _update_lock rebuilds parent/child links when relationship config changes."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator._rebuild_lock_relationships = AsyncMock()
+    coordinator._update_door_and_lock_state = AsyncMock()
+    coordinator._update_listeners = AsyncMock()
+    coordinator.async_refresh_lock = AsyncMock()
+
+    old_lock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_id",
+        parent_config_entry_id="old_parent",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+        number_of_code_slots=1,
+        starting_code_slot=1,
+    )
+    new_lock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id="entry_id",
+        parent_config_entry_id="new_parent",
+        code_slots={1: KeymasterCodeSlot(number=1)},
+        number_of_code_slots=1,
+        starting_code_slot=1,
+    )
+    coordinator.kmlocks["entry_id"] = old_lock
+
+    assert await coordinator._update_lock(new_lock)
+
+    coordinator._rebuild_lock_relationships.assert_awaited_once()
+    await coordinator.async_shutdown()

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -1375,6 +1375,29 @@ async def test_async_refresh_lock_reraises_task_cancellation(hass) -> None:
     await coordinator.async_shutdown()
 
 
+async def test_async_refresh_lock_reraises_internal_cancellation(hass) -> None:
+    """Test scoped refresh does not swallow CancelledError from refresh work."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+
+    async def refresh_lock_data(
+        entry_id: str,
+        *,
+        advance_sync_status: bool = True,
+        defer_save: bool = False,
+    ) -> set[str]:
+        raise asyncio.CancelledError
+
+    coordinator._async_refresh_lock_data = refresh_lock_data
+
+    with pytest.raises(asyncio.CancelledError):
+        await coordinator.async_refresh_lock("entry_1")
+
+    assert coordinator.last_update_success is False
+    await coordinator.async_shutdown()
+
+
 async def test_async_refresh_lock_flushes_notifications_scheduled_during_refresh(hass) -> None:
     """Test scoped refresh flushes notification work queued during deferral."""
     coordinator = KeymasterCoordinator(hass)

--- a/tests/test_coordinator_sync.py
+++ b/tests/test_coordinator_sync.py
@@ -889,7 +889,7 @@ class TestProviderFailureSyncReset:
             coordinator._initial_setup_done_event = AsyncMock()
             coordinator._initial_setup_done_event.wait = AsyncMock()
             coordinator.async_set_updated_data = Mock()
-            coordinator.async_schedule_global_notification = Mock()
+            coordinator.async_schedule_keymaster_notifications = Mock()
             return coordinator
 
     @pytest.fixture
@@ -990,7 +990,7 @@ class TestProviderFailureSyncReset:
         )
 
         # Should be called twice: once for ADDING state, once for OUT_OF_SYNC reset
-        assert real_coordinator.async_schedule_global_notification.call_count == 2
+        assert real_coordinator.async_schedule_keymaster_notifications.call_count == 2
 
     async def test_failed_clear_notifies_entities(self, real_coordinator, lock_with_provider):
         """On provider failure, deferred notification is scheduled for the UI."""
@@ -1005,7 +1005,7 @@ class TestProviderFailureSyncReset:
         )
 
         # Should be called twice: once for DELETING state, once for OUT_OF_SYNC reset
-        assert real_coordinator.async_schedule_global_notification.call_count == 2
+        assert real_coordinator.async_schedule_keymaster_notifications.call_count == 2
 
     async def test_clear_pin_restores_prior_pin_on_provider_failure(
         self, real_coordinator, lock_with_provider
@@ -1045,7 +1045,7 @@ class TestSyncPinStuckStateRecovery:
             coordinator._initial_setup_done_event = AsyncMock()
             coordinator._initial_setup_done_event.wait = AsyncMock()
             coordinator.async_set_updated_data = Mock()
-            coordinator.async_schedule_global_notification = Mock()
+            coordinator.async_schedule_keymaster_notifications = Mock()
             coordinator.set_pin_on_lock = AsyncMock(return_value=True)
             coordinator.clear_pin_from_lock = AsyncMock(return_value=True)
             return coordinator

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -214,7 +214,7 @@ class TestTimestampRecording:
         mock_coordinator._initial_setup_done_event = Mock()
         mock_coordinator._initial_setup_done_event.wait = AsyncMock()
         mock_coordinator.async_set_updated_data = Mock()
-        mock_coordinator.async_schedule_global_notification = Mock()
+        mock_coordinator.async_schedule_keymaster_notifications = Mock()
 
         result = await KeymasterCoordinator.set_pin_on_lock(mock_coordinator, "entry_1", 1, "5678")
 
@@ -234,7 +234,7 @@ class TestTimestampRecording:
         mock_coordinator._initial_setup_done_event = Mock()
         mock_coordinator._initial_setup_done_event.wait = AsyncMock()
         mock_coordinator.async_set_updated_data = Mock()
-        mock_coordinator.async_schedule_global_notification = Mock()
+        mock_coordinator.async_schedule_keymaster_notifications = Mock()
 
         result = await KeymasterCoordinator.clear_pin_from_lock(mock_coordinator, "entry_1", 1)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -375,6 +375,41 @@ async def test_setup_failure_after_add_lock_flushes_pending_save(hass):
     coordinator.async_flush_pending_save_data_if_setup_complete.assert_awaited_once()
 
 
+async def test_setup_failure_flush_error_does_not_mask_original_error(hass):
+    """Test a failed deferred-save flush does not replace the setup failure."""
+    entry_data = _build_entry_data("front_door", "lock.front_door")
+    entry = MockConfigEntry(domain=DOMAIN, title="Front Door", data=entry_data, version=4)
+    entry.add_to_hass(hass)
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = Mock()
+    coordinator.kmlocks = {}
+    coordinator.add_lock = AsyncMock()
+    coordinator.async_get_lock_coordinator = Mock(return_value=Mock())
+    coordinator.async_flush_pending_save_data_if_setup_complete = AsyncMock(
+        side_effect=RuntimeError("flush failed")
+    )
+    hass.data[DOMAIN][COORDINATOR] = coordinator
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch("custom_components.keymaster.dr.async_get"),
+        patch("custom_components.keymaster.async_update_large_lock_repair_issue"),
+        patch(
+            "custom_components.keymaster.async_update_all_large_lock_repair_issues",
+            new_callable=AsyncMock,
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("platform failed"),
+        ),
+        pytest.raises(RuntimeError, match="platform failed"),
+    ):
+        await async_setup_entry(hass, entry)
+
+
 async def test_unload_vs_remove_lock_preservation(
     hass,
     mock_async_call_later,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -274,6 +274,7 @@ async def test_parent_title_resolves_to_parent_entry_id_during_setup(hass):
         mock_coordinator.last_update_success = True
         mock_coordinator.kmlocks = {}
         mock_coordinator.add_lock = AsyncMock()
+        mock_coordinator.async_flush_pending_save_data_if_setup_complete = AsyncMock()
 
         mock_device_registry = Mock()
         mock_device_registry.async_get_or_create = Mock()
@@ -324,6 +325,7 @@ async def test_setup_entry_calls_add_lock_with_update_true_for_existing_lock(has
         mock_coordinator.last_update_success = True
         mock_coordinator.add_lock = AsyncMock()
         mock_coordinator.kmlocks = {entry.entry_id: Mock()}
+        mock_coordinator.async_flush_pending_save_data_if_setup_complete = AsyncMock()
 
         mock_device_registry = Mock()
         mock_device_registry.async_get_or_create = Mock()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -372,7 +372,9 @@ async def test_setup_failure_after_add_lock_flushes_pending_save(hass):
         await async_setup_entry(hass, entry)
 
     coordinator.add_lock.assert_awaited_once()
-    coordinator.async_flush_pending_save_data_if_setup_complete.assert_awaited_once()
+    coordinator.async_flush_pending_save_data_if_setup_complete.assert_awaited_once_with(
+        entry.entry_id
+    )
 
 
 async def test_setup_failure_flush_error_does_not_mask_original_error(hass):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,6 +28,7 @@ from custom_components.keymaster.const import (
     LOCK_COORDINATORS,
 )
 from custom_components.keymaster.coordinator import KeymasterCoordinator, KeymasterLockCoordinator
+from custom_components.keymaster.lock import KeymasterLock
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.util.dt import utcnow
@@ -153,7 +154,7 @@ async def test_unload_entry(
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == baseline
 
 
-async def test_unload_entry_preserves_pending_global_notification(hass) -> None:
+async def test_unload_entry_preserves_pending_all_lock_notification(hass) -> None:
     """Test unloading one entry does not drop shared coordinator notifications."""
     entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3)
     other_entry = MockConfigEntry(
@@ -165,10 +166,15 @@ async def test_unload_entry_preserves_pending_global_notification(hass) -> None:
     entry.add_to_hass(hass)
     other_entry.add_to_hass(hass)
     coordinator = KeymasterCoordinator(hass)
+    coordinator.kmlocks[entry.entry_id] = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.frontdoor",
+        keymaster_config_entry_id=entry.entry_id,
+    )
     listener = Mock()
-    coordinator.async_add_listener(listener)
-    coordinator.async_schedule_global_notification()
-    pending_handle = coordinator._global_notify_handle
+    coordinator.async_get_lock_coordinator(entry.entry_id).async_add_listener(listener)
+    coordinator.async_schedule_all_lock_notifications()
+    pending_handle = coordinator._notify_handle
     assert pending_handle is not None
     hass.data.setdefault(DOMAIN, {})[COORDINATOR] = coordinator
 
@@ -193,7 +199,7 @@ async def test_unload_entry_preserves_pending_global_notification(hass) -> None:
     await hass.async_block_till_done()
 
     listener.assert_called_once()
-    assert not coordinator._pending_global_notification
+    assert not coordinator._pending_notify_all_entry_ids
     await coordinator.async_shutdown()
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -339,6 +339,42 @@ async def test_setup_entry_calls_add_lock_with_update_true_for_existing_lock(has
     assert add_lock_kwargs["update"] is True
 
 
+async def test_setup_failure_after_add_lock_flushes_pending_save(hass):
+    """Test deferred save work is flushed when post-add setup fails."""
+    entry_data = _build_entry_data("front_door", "lock.front_door")
+    entry = MockConfigEntry(domain=DOMAIN, title="Front Door", data=entry_data, version=4)
+    entry.add_to_hass(hass)
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = Mock()
+    coordinator.kmlocks = {}
+    coordinator.add_lock = AsyncMock()
+    coordinator.async_get_lock_coordinator = Mock(return_value=Mock())
+    coordinator.async_flush_pending_save_data_if_setup_complete = AsyncMock()
+    hass.data[DOMAIN][COORDINATOR] = coordinator
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch("custom_components.keymaster.dr.async_get"),
+        patch("custom_components.keymaster.async_update_large_lock_repair_issue"),
+        patch(
+            "custom_components.keymaster.async_update_all_large_lock_repair_issues",
+            new_callable=AsyncMock,
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("platform failed"),
+        ),
+        pytest.raises(RuntimeError, match="platform failed"),
+    ):
+        await async_setup_entry(hass, entry)
+
+    coordinator.add_lock.assert_awaited_once()
+    coordinator.async_flush_pending_save_data_if_setup_complete.assert_awaited_once()
+
+
 async def test_unload_vs_remove_lock_preservation(
     hass,
     mock_async_call_later,

--- a/tests/test_large_lock_repairs.py
+++ b/tests/test_large_lock_repairs.py
@@ -593,6 +593,7 @@ async def test_setup_uses_loaded_provider_connection_status(hass: Any) -> None:
         kmlocks={},
         add_lock=AsyncMock(side_effect=add_lock_with_provider),
         async_get_lock_coordinator=Mock(),
+        async_flush_pending_save_data_if_setup_complete=AsyncMock(),
     )
     hass.data[DOMAIN][COORDINATOR] = fake_coordinator
 
@@ -629,6 +630,7 @@ async def test_setup_continues_when_add_lock_times_out(
         kmlocks={},
         add_lock=AsyncMock(side_effect=asyncio.CancelledError()),
         async_get_lock_coordinator=Mock(),
+        async_flush_pending_save_data_if_setup_complete=AsyncMock(),
     )
     caplog.set_level(logging.ERROR)
 

--- a/tests/test_lock_dataclass.py
+++ b/tests/test_lock_dataclass.py
@@ -140,3 +140,26 @@ def test_inherit_state_does_not_carry_provider_identity_to_different_lock_entity
     assert new_lock.connected is False
     assert new_lock.provider is None
     assert new_lock.lock_config_entry_id is None
+
+
+def test_inherit_state_does_not_resurrect_disconnected_provider_on_reload():
+    """Test reload recovery starts with a fresh provider after a failed connection."""
+    old_lock = KeymasterLock(
+        lock_name="Old Lock",
+        lock_entity_id="lock.same",
+        keymaster_config_entry_id="entry_id",
+        connected=False,
+        lock_config_entry_id="old_lock_config_entry",
+    )
+    old_lock.provider = cast(Any, object())
+    new_lock = KeymasterLock(
+        lock_name="New Lock",
+        lock_entity_id="lock.same",
+        keymaster_config_entry_id="entry_id",
+    )
+
+    new_lock.inherit_state_from(old_lock)
+
+    assert new_lock.connected is False
+    assert new_lock.provider is None
+    assert new_lock.lock_config_entry_id is None

--- a/tests/test_lock_dataclass.py
+++ b/tests/test_lock_dataclass.py
@@ -1,6 +1,7 @@
 """Tests for KeymasterLock dataclass integrity."""
 
 from dataclasses import fields
+from typing import Any, cast
 
 from custom_components.keymaster.lock import (
     KeymasterCodeSlot,
@@ -116,3 +117,26 @@ def test_code_slots_dict_operations():
     assert slot5._lock_ref is not None
     assert slot5._lock_ref() is lock
     assert slots[5] is slot5
+
+
+def test_inherit_state_does_not_carry_provider_identity_to_different_lock_entity():
+    """Test provider identity is only inherited for the same lock entity."""
+    old_lock = KeymasterLock(
+        lock_name="Old Lock",
+        lock_entity_id="lock.old",
+        keymaster_config_entry_id="entry_id",
+        connected=True,
+        lock_config_entry_id="old_lock_config_entry",
+    )
+    old_lock.provider = cast(Any, object())
+    new_lock = KeymasterLock(
+        lock_name="New Lock",
+        lock_entity_id="lock.new",
+        keymaster_config_entry_id="entry_id",
+    )
+
+    new_lock.inherit_state_from(old_lock)
+
+    assert new_lock.connected is False
+    assert new_lock.provider is None
+    assert new_lock.lock_config_entry_id is None

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,5 +1,6 @@
 """Tests for keymaster Switch platform."""
 
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -189,6 +190,52 @@ async def test_switch_async_turn_on(hass: HomeAssistant, switch_config_entry, co
     # Defaults should be set on first enable
     assert kmlock.autolock_min_day == DEFAULT_AUTOLOCK_MIN_DAY
     assert kmlock.autolock_min_night == DEFAULT_AUTOLOCK_MIN_NIGHT
+
+
+async def test_plain_switch_setter_notifies_scoped_lock_coordinator(
+    hass: HomeAssistant, switch_config_entry, coordinator
+):
+    """Test a plain switch setter notifies immediately and during debounced refresh."""
+    manager = coordinator.manager
+    manager._initial_setup_done_event.set()
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=switch_config_entry.entry_id,
+        connected=True,
+        lock_notifications=False,
+    )
+    manager.kmlocks[switch_config_entry.entry_id] = kmlock
+    listener = Mock()
+    coordinator.async_add_listener(listener)
+
+    entity_description = KeymasterSwitchEntityDescription(
+        key="switch.lock_notifications",
+        name="Lock Notifications",
+        icon="mdi:bell",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=switch_config_entry,
+        coordinator=coordinator,
+    )
+    entity = KeymasterSwitch(entity_description=entity_description)
+    entity.async_write_ha_state = Mock()
+
+    await entity.async_turn_on()
+    await asyncio.sleep(0)
+
+    assert kmlock.lock_notifications is True
+    listener.assert_called_once()
+    listener.reset_mock()
+    manager._update_lock_data = AsyncMock()
+    manager._async_save_data = AsyncMock()
+    manager._schedule_quick_refresh_if_needed = AsyncMock()
+
+    await manager.async_refresh()
+    await asyncio.sleep(0)
+
+    listener.assert_called_once()
+    await manager.async_shutdown()
 
 
 async def test_switch_autolock_user_values_persist_after_disable_reenable(


### PR DESCRIPTION
## Summary

Issue #670 exposed an event-loop storm in large Keymaster deployments: one
global coordinator fanned every refresh and mutation out to roughly
12k-49k entities, tripping Home Assistant 2026.7's
`_MAX_QUEUED_EVENT_DISPATCHES = 10_000` guard.

This PR completes the issue #682 refresh pipeline refactor by routing refresh
completion and mutation notifications through dirty per-lock scopes. It builds
on merged #680, which introduced per-lock coordinators, and #681, which rebound
entities to those coordinators.

## Details

- Detects changed lock data from sanitized before/after snapshots and notifies
  only the per-lock coordinators whose entry data changed.
- Splits `_async_update_data()` into `async_refresh_all_locks()` and
  `async_refresh_lock()`, returning dirty config entry IDs from refreshes.
- Removes the manager's global listener notification leg and collapses the two
  pending notification handles into one scoped handle.
- Scopes all mutation call sites to the affected config entry IDs.
- Keeps refreshes sequential and keeps `coordinator.data` as a dict mirror of
  `kmlocks`.

Two correctness paths are deliberately not scoped:

- Refresh health transitions still fan out to all lock coordinators because
  availability is global, not per-lock data.
- Locally-mutated entries are marked externally dirty so a later debounced
  refresh cannot overwrite a local entity-setter change.

## Validation

- `ruff check custom_components/ tests/`
- `ruff format custom_components/ tests/`
- `mypy custom_components/keymaster/`
- `pytest tests/` — 1029 tests passing

Closes #682
