### PR TITLE
docs: update support matrix key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,16 @@ provider:
 | **[Schlage WiFi](https://www.home-assistant.io/integrations/schlage/)** | `schlage` | Wi-Fi | ❌ | ✅ | Virtual slot mapping by prefixing tags to code names. |
 | **[Local Akuvox](https://github.com/firstof9/ha-local-akuvox)** | `local_akuvox` | LAN | ✅ | ✅ | Virtual slot mapping by tagging door controller user names. |
 | **[Matter](https://www.home-assistant.io/integrations/matter/)** | `matter` | Matter | ⏳ | ⏳ | Standardized Matter Lock Cluster PIN credential management. |
-| **[Nuki](https://www.home-assistant.io/integrations/nuki/)** | `nuki` | Local API | ⏳ | ⏳ | Nuki Keypad PIN management. |
-| **[Tedee](https://www.home-assistant.io/integrations/tedee/)** | `tedee` | Cloud/Local | ⏳ | ⏳ | Tedee Keypad PIN management. |
+| **[Nuki](https://www.home-assistant.io/integrations/nuki/)** | `nuki` | Local API | 🚫 | 🚫 | Nuki Keypad PIN management (Not planned due to lack of hardware for testing). |
+| **[Tedee](https://www.home-assistant.io/integrations/tedee/)** | `tedee` | Cloud/Local | 🚫 | 🚫 | Tedee Keypad PIN management (Not planned due to lack of hardware for testing). |
 <!-- markdownlint-enable MD013 -->
+
+**Key:**
+
+- ✅ Fully Supported
+- ❌ Not Supported
+- ⏳ Planned / Work in Progress
+- 🚫 Not Planned (due to lack of hardware for testing)
 
 ## Installation
 


### PR DESCRIPTION
# Summary

Update the Supported Lock Providers matrix in `README.md` to add a key entry for "Not Planned" (due to lack of hardware for testing) and update the Nuki and Tedee integration statuses accordingly.

## Proposed change

Adds a legend key entry for `- 🚫 Not Planned (due to lack of hardware for testing)` and updates the Nuki and Tedee rows in the Support Matrix table to status `🚫` with notes clarifying they are not planned due to lack of testing hardware.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
