### PR TITLE
fix(zigbee2mqtt): prefer device friendly name for topic and handle keypad action vocabulary

### DIFF
--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -79,9 +79,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         if not device_entry:
             return None
 
-        # Prefer device_entry.name_by_user / device_entry.name if set to a string
-        if isinstance(device_entry.name_by_user, str) and device_entry.name_by_user:
-            return f"zigbee2mqtt/{device_entry.name_by_user}"
+        # Prefer device_entry.name if set to a string
         if isinstance(device_entry.name, str) and device_entry.name:
             return f"zigbee2mqtt/{device_entry.name}"
 

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -423,7 +423,8 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         if not isinstance(slot_num, int):
             return
 
-        payload = payload or {}
+        if not isinstance(payload, dict):
+            payload = {}
         action_source_name = payload.get("action_source_name")
         action_source = payload.get("action_source")
         is_keypad = (

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -74,22 +74,25 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
 
     @property
     def base_topic(self) -> str | None:
-        """Get the base topic dynamically from the device identifiers or name."""
+        """Get the base topic dynamically from the device name or identifiers."""
         device_entry = self.get_device_entry()
         if not device_entry:
             return None
 
-        # Extract the original Z2M friendly name from device identifiers to support device renaming
+        # Prefer device_entry.name_by_user / device_entry.name if set to a string
+        if isinstance(device_entry.name_by_user, str) and device_entry.name_by_user:
+            return f"zigbee2mqtt/{device_entry.name_by_user}"
+        if isinstance(device_entry.name, str) and device_entry.name:
+            return f"zigbee2mqtt/{device_entry.name}"
+
+        # Fallback to extracting friendly name from device identifiers if available
         for domain, identifier in device_entry.identifiers:
             if domain == MQTT_DOMAIN and identifier.startswith("zigbee2mqtt_"):
                 friendly_name = identifier[len("zigbee2mqtt_") :]
                 if friendly_name:
                     return f"zigbee2mqtt/{friendly_name}"
 
-        name = device_entry.name
-        if not name:
-            return None
-        return f"zigbee2mqtt/{name}"
+        return None
 
     @property
     def set_topic(self) -> str | None:
@@ -179,7 +182,9 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
             action = payload.get("action")
             action_slot_num = payload.get("action_user")
             if action or action_slot_num:
-                self.hass.async_create_task(self._async_handle_action(action, action_slot_num))
+                self.hass.async_create_task(
+                    self._async_handle_action(action, action_slot_num, payload)
+                )
 
             # Parse bulk users list if available.
             if "users" in payload and isinstance(payload["users"], dict):
@@ -411,15 +416,26 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         )
         return True
 
-    async def _async_handle_action(self, action: Any, slot_num: Any) -> None:
+    async def _async_handle_action(
+        self, action: Any, slot_num: Any, payload: dict[str, Any] | None = None
+    ) -> None:
         """Handle keypad action events."""
         if not isinstance(slot_num, int):
             return
 
+        payload = payload or {}
+        action_source_name = payload.get("action_source_name")
+        action_source = payload.get("action_source")
+        is_keypad = (
+            action_source_name == "keypad"
+            or action_source == 0
+            or (isinstance(action, str) and action.startswith("keypad_"))
+        )
+
         if self._lock_event_callback:
-            if action == "keypad_unlock":
+            if is_keypad and action in ("keypad_unlock", "unlock"):
                 await self._lock_event_callback(slot_num, "Unlocked via Keypad", 1)
-            elif action == "keypad_lock":
+            elif is_keypad and action in ("keypad_lock", "lock"):
                 await self._lock_event_callback(slot_num, "Keypad Lock", 5)
 
         if action in ("pin_code_added", "pin_code_deleted"):

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -83,12 +83,12 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         if isinstance(device_entry.name, str) and device_entry.name:
             return f"zigbee2mqtt/{device_entry.name}"
 
-        # Fallback to extracting friendly name from device identifiers if available
+        # Fallback to extracting IEEE address identifier suffix if available
         for domain, identifier in device_entry.identifiers:
             if domain == MQTT_DOMAIN and identifier.startswith("zigbee2mqtt_"):
-                friendly_name = identifier[len("zigbee2mqtt_") :]
-                if friendly_name:
-                    return f"zigbee2mqtt/{friendly_name}"
+                ieee_suffix = identifier[len("zigbee2mqtt_") :]
+                if ieee_suffix:
+                    return f"zigbee2mqtt/{ieee_suffix}"
 
         return None
 

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -1028,6 +1028,19 @@ class TestCoverageExtra:
         await provider._async_handle_action("lock", 2, payload)
         callback.assert_called_once_with(2, "Keypad Lock", 5)
 
+    async def test_async_handle_action_with_non_dict_payload(self, provider):
+        """Test _async_handle_action handles non-dict payloads without crashing."""
+        callback = AsyncMock()
+        provider._lock_event_callback = callback
+
+        # Pass invalid payload types (None, list, int)
+        await provider._async_handle_action("keypad_unlock", 1, None)
+        callback.assert_called_once_with(1, "Unlocked via Keypad", 1)
+        callback.reset_mock()
+
+        await provider._async_handle_action("keypad_lock", 2, "not a dict")
+        callback.assert_called_once_with(2, "Keypad Lock", 5)
+
     async def test_base_topic_prefers_name_by_user(self, provider, mock_hass):
         """Test that base_topic prefers device_entry.name_by_user when set."""
         setup_successful_connect(

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -1027,3 +1027,30 @@ class TestCoverageExtra:
         }
         await provider._async_handle_action("lock", 2, payload)
         callback.assert_called_once_with(2, "Keypad Lock", 5)
+
+    async def test_base_topic_prefers_name_by_user(self, provider, mock_hass):
+        """Test that base_topic prefers device_entry.name_by_user when set."""
+        setup_successful_connect(
+            provider,
+            mock_hass,
+            device_name="Front Door Lock",
+            identifiers={("mqtt", "zigbee2mqtt_0x000d6f001933df17")},
+        )
+        device_entry = provider.device_registry.async_get.return_value
+        device_entry.name_by_user = "Custom User Name"
+        assert provider.base_topic == "zigbee2mqtt/Custom User Name"
+
+    async def test_base_topic_fallback_to_identifier_when_device_name_empty(
+        self, provider, mock_hass
+    ):
+        """Test fallback to identifier when device name and name_by_user are empty."""
+        setup_successful_connect(
+            provider,
+            mock_hass,
+            device_name=None,
+            identifiers={("mqtt", "zigbee2mqtt_0x000d6f001933df17")},
+        )
+        device_entry = provider.device_registry.async_get.return_value
+        device_entry.name_by_user = None
+        device_entry.name = None
+        assert provider.base_topic == "zigbee2mqtt/0x000d6f001933df17"

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -1041,6 +1041,28 @@ class TestCoverageExtra:
         await provider._async_handle_action("keypad_lock", 2, "not a dict")
         callback.assert_called_once_with(2, "Keypad Lock", 5)
 
+    async def test_async_handle_action_ignores_non_keypad_source(self, provider):
+        """Test that RF/app-sourced unlock does not raise a keypad event."""
+        callback = AsyncMock()
+        provider._lock_event_callback = callback
+
+        payload = {
+            "action": "unlock",
+            "action_source": 1,
+            "action_source_name": "rf",
+            "action_user": 1,
+        }
+        await provider._async_handle_action("unlock", 1, payload)
+        callback.assert_not_called()
+
+    async def test_async_handle_action_ignores_bare_action_without_source(self, provider):
+        """Test that a bare unlock with no source information is not attributed."""
+        callback = AsyncMock()
+        provider._lock_event_callback = callback
+
+        await provider._async_handle_action("unlock", 1, {"action": "unlock", "action_user": 1})
+        callback.assert_not_called()
+
     async def test_base_topic_prefers_name_by_user(self, provider, mock_hass):
         """Test that base_topic prefers device_entry.name_by_user when set."""
         setup_successful_connect(

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -1063,8 +1063,8 @@ class TestCoverageExtra:
         await provider._async_handle_action("unlock", 1, {"action": "unlock", "action_user": 1})
         callback.assert_not_called()
 
-    async def test_base_topic_prefers_name_by_user(self, provider, mock_hass):
-        """Test that base_topic prefers device_entry.name_by_user when set."""
+    async def test_base_topic_ignores_name_by_user(self, provider, mock_hass):
+        """Test that an HA-side rename (name_by_user) does not change the topic."""
         setup_successful_connect(
             provider,
             mock_hass,
@@ -1073,7 +1073,7 @@ class TestCoverageExtra:
         )
         device_entry = provider.device_registry.async_get.return_value
         device_entry.name_by_user = "Custom User Name"
-        assert provider.base_topic == "zigbee2mqtt/Custom User Name"
+        assert provider.base_topic == "zigbee2mqtt/Front Door Lock"
 
     async def test_base_topic_fallback_to_identifier_when_device_name_empty(
         self, provider, mock_hass

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -173,12 +173,12 @@ class TestConnect:
 
         assert provider.base_topic == "zigbee2mqtt/new_lock_name"
 
-        # 2. Without zigbee2mqtt identifier: renaming name DOES change topics
-        device_entry.identifiers = {("mqtt", "some_other_id")}
-        assert provider.base_topic == "zigbee2mqtt/new_lock_name"
-        assert provider.set_topic == "zigbee2mqtt/new_lock_name/set"
-        assert provider.get_topic == "zigbee2mqtt/new_lock_name/get"
-        assert provider.state_topic == "zigbee2mqtt/new_lock_name"
+        # 2. When device_entry.name is None/empty, fallback to zigbee2mqtt identifier suffix
+        device_entry.name = None
+        assert provider.base_topic == "zigbee2mqtt/my_lock"
+        assert provider.set_topic == "zigbee2mqtt/my_lock/set"
+        assert provider.get_topic == "zigbee2mqtt/my_lock/get"
+        assert provider.state_topic == "zigbee2mqtt/my_lock"
 
     async def test_connect_entity_not_found(self, provider):
         """Test connection fails when lock entity is not found in Entity Registry."""

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -164,14 +164,14 @@ class TestConnect:
 
     async def test_connect_success_rename_device(self, provider, mock_hass):
         """Test that device rename behavior handles identifiers and name fallbacks."""
-        # 1. With zigbee2mqtt identifier: renaming name does NOT change topics
+        # 1. With device_entry.name set, base_topic reflects the device's friendly name
         await connect_provider(provider, mock_hass)
         assert provider.base_topic == "zigbee2mqtt/my_lock"
 
         device_entry = provider.device_registry.async_get.return_value
         device_entry.name = "new_lock_name"
 
-        assert provider.base_topic == "zigbee2mqtt/my_lock"
+        assert provider.base_topic == "zigbee2mqtt/new_lock_name"
 
         # 2. Without zigbee2mqtt identifier: renaming name DOES change topics
         device_entry.identifiers = {("mqtt", "some_other_id")}
@@ -990,3 +990,40 @@ class TestCoverageExtra:
             pytest.raises(CustomBaseException),
         ):
             await provider.async_get_usercodes()
+
+    async def test_base_topic_prefers_device_name_over_ieee_identifier(self, provider, mock_hass):
+        """Test that base_topic prefers device_entry.name over identifier suffix."""
+        setup_successful_connect(
+            provider,
+            mock_hass,
+            device_name="Front Door Lock",
+            identifiers={("mqtt", "zigbee2mqtt_0x000d6f001933df17")},
+        )
+        assert provider.base_topic == "zigbee2mqtt/Front Door Lock"
+
+    async def test_async_handle_action_with_action_source_name(self, provider):
+        """Test _async_handle_action handling action: unlock with action_source_name: keypad."""
+        callback = AsyncMock()
+        provider._lock_event_callback = callback
+
+        payload = {
+            "action": "unlock",
+            "action_source": 0,
+            "action_source_name": "keypad",
+            "action_user": 1,
+        }
+        await provider._async_handle_action("unlock", 1, payload)
+        callback.assert_called_once_with(1, "Unlocked via Keypad", 1)
+
+    async def test_async_handle_action_with_action_source_lock(self, provider):
+        """Test _async_handle_action handling action: lock with action_source: 0."""
+        callback = AsyncMock()
+        provider._lock_event_callback = callback
+
+        payload = {
+            "action": "lock",
+            "action_source": 0,
+            "action_user": 2,
+        }
+        await provider._async_handle_action("lock", 2, payload)
+        callback.assert_called_once_with(2, "Keypad Lock", 5)


### PR DESCRIPTION
### Summary of Changes
- Fix `base_topic` derivation in `Zigbee2MQTTLockProvider` to prefer `device_entry.name` (the Z2M friendly name) over IEEE identifier parsing.
- Update `_async_handle_action` to inspect `action_source_name` / `action_source` payloads for keypad lock/unlock actions (e.g. `action: "unlock"` with `action_source_name: "keypad"`).
- Add unit test coverage in `tests/providers/test_zigbee2mqtt.py`.

Ref #699