### PR TITLE
fix(coordinator): prioritize event label intent and sync push provider lock state

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1370,8 +1370,6 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     await self._send_global_unlock_notification(kmlock, 0, event_label)
             return
 
-        self._pending_provider_unlock_event.discard(kmlock.keymaster_config_entry_id)
-
         if not self._throttle.is_allowed(
             "lock_unlocked",
             kmlock.keymaster_config_entry_id,
@@ -1379,6 +1377,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         ):
             _LOGGER.debug("[lock_unlocked] %s: Throttled. source: %s", kmlock.lock_name, source)
             return
+
+        self._pending_provider_unlock_event.discard(kmlock.keymaster_config_entry_id)
 
         kmlock.lock_state = LockState.UNLOCKED
         self._throttle.reset("lock_locked", kmlock.keymaster_config_entry_id)
@@ -1913,6 +1913,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self.kmlocks.pop(kmlock.keymaster_config_entry_id, None)
         self._last_unlock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
         self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
+        self._pending_provider_unlock_event.discard(kmlock.keymaster_config_entry_id)
+        self._pending_provider_lock_event.discard(kmlock.keymaster_config_entry_id)
         self._cancel_pending_keypad_unlock_notification(kmlock)
         await self._rebuild_lock_relationships()
         await self._async_save_data()

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -923,12 +923,15 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         #   back to `new_state` in that case would drop the event.
         # - If the label is ambiguous, fall back to new_state.
         label_lower = event_label.lower() if event_label else ""
-        if "unlock" in label_lower:
+        state_changed = (
+            new_state in (LockState.LOCKED, LockState.UNLOCKED) and new_state != kmlock.lock_state
+        )
+        if state_changed:
+            inferred_action = new_state
+        elif "unlock" in label_lower:
             inferred_action = LockState.UNLOCKED
         elif "lock" in label_lower and "jam" not in label_lower:
             inferred_action = LockState.LOCKED
-        elif new_state in (LockState.LOCKED, LockState.UNLOCKED) and new_state != kmlock.lock_state:
-            inferred_action = new_state
         else:
             inferred_action = new_state
 
@@ -1017,6 +1020,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         self._state_change_autolock_started.add(kmlock.keymaster_config_entry_id)
                         self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                     kmlock.lock_state = LockState.UNLOCKED
+                    self._last_unlock_code_slot[kmlock.keymaster_config_entry_id] = 0
         elif new_state == LockState.LOCKED:
             if old_state != LockState.LOCKED:
                 if not uses_provider_lock_events:

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -923,12 +923,15 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         #   back to `new_state` in that case would drop the event.
         # - If the label is ambiguous, fall back to new_state.
         label_lower = event_label.lower() if event_label else ""
-        if "unlock" in label_lower:
+        state_changed = (
+            new_state in (LockState.LOCKED, LockState.UNLOCKED) and new_state != kmlock.lock_state
+        )
+        if state_changed:
+            inferred_action = new_state
+        elif "unlock" in label_lower:
             inferred_action = LockState.UNLOCKED
         elif "lock" in label_lower and "jam" not in label_lower:
             inferred_action = LockState.LOCKED
-        elif new_state in (LockState.LOCKED, LockState.UNLOCKED) and new_state != kmlock.lock_state:
-            inferred_action = new_state
         else:
             inferred_action = new_state
 
@@ -1031,9 +1034,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     or kmlock.lock_state != LockState.LOCKED
                 ) and kmlock.autolock_timer:
                     await kmlock.autolock_timer.cancel()
-                    self._state_change_autolock_started.discard(
-                        kmlock.keymaster_config_entry_id
-                    )
+                    self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
                     self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                 if uses_provider_lock_events:
                     kmlock.lock_state = LockState.LOCKED

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -228,6 +228,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._cancel_debounced_refresh: Callable | None = None
         self._pending_keypad_unlock_notifications: dict[str, Callable[[], None]] = {}
         self._state_change_autolock_started: set[str] = set()
+        self._pending_provider_unlock_event: set[str] = set()
+        self._pending_provider_lock_event: set[str] = set()
         self._consecutive_failures: dict[str, int] = {}
         self._next_retry_time: dict[str, dt] = {}
         self._deferred_notifications_shutting_down = False
@@ -1019,8 +1021,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     self._state_change_autolock_started.add(kmlock.keymaster_config_entry_id)
                     self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                 if uses_provider_lock_events:
-                    kmlock.lock_state = LockState.UNLOCKED
-                    self._last_unlock_code_slot[kmlock.keymaster_config_entry_id] = 0
+                    if kmlock.lock_state != LockState.UNLOCKED:
+                        kmlock.lock_state = LockState.UNLOCKED
+                        self._last_unlock_code_slot.setdefault(kmlock.keymaster_config_entry_id, 0)
+                        self._pending_provider_unlock_event.add(kmlock.keymaster_config_entry_id)
+                    self._pending_provider_lock_event.discard(kmlock.keymaster_config_entry_id)
         elif new_state == LockState.LOCKED:
             if old_state != LockState.LOCKED:
                 if not uses_provider_lock_events:
@@ -1037,7 +1042,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
                     self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                 if uses_provider_lock_events:
-                    kmlock.lock_state = LockState.LOCKED
+                    if kmlock.lock_state != LockState.LOCKED:
+                        kmlock.lock_state = LockState.LOCKED
+                        self._pending_provider_lock_event.add(kmlock.keymaster_config_entry_id)
+                    self._pending_provider_unlock_event.discard(kmlock.keymaster_config_entry_id)
 
     async def _handle_door_state_change(
         self,
@@ -1326,7 +1334,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         # Check for supersede condition before throttle: when the lock is already
         # unlocked with slot=0 and a more informative slot>0 event arrives, we
         # must let it through regardless of throttle state.
-        if kmlock.lock_state == LockState.UNLOCKED:
+        pending_provider_event = (
+            kmlock.keymaster_config_entry_id in self._pending_provider_unlock_event
+        )
+        if kmlock.lock_state == LockState.UNLOCKED and not pending_provider_event:
             prior_slot = self._last_unlock_code_slot.get(kmlock.keymaster_config_entry_id)
             if isinstance(code_slot_num, int) and code_slot_num > 0 and prior_slot == 0:
                 # A more informative event arrived after an initial slot=0 unlock.
@@ -1358,6 +1369,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 ):
                     await self._send_global_unlock_notification(kmlock, 0, event_label)
             return
+
+        self._pending_provider_unlock_event.discard(kmlock.keymaster_config_entry_id)
 
         if not self._throttle.is_allowed(
             "lock_unlocked",
@@ -1457,7 +1470,14 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("[lock_locked] %s: Throttled. source: %s", kmlock.lock_name, source)
             return
 
-        if kmlock.lock_state == LockState.LOCKED and not kmlock.pending_retry_lock:
+        pending_provider_event = (
+            kmlock.keymaster_config_entry_id in self._pending_provider_lock_event
+        )
+        if (
+            kmlock.lock_state == LockState.LOCKED
+            and not kmlock.pending_retry_lock
+            and not pending_provider_event
+        ):
             if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
                 if kmlock.autolock_timer:
                     await kmlock.autolock_timer.cancel()
@@ -1465,6 +1485,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
             self._cancel_pending_keypad_unlock_notification(kmlock)
             return
+
+        self._pending_provider_lock_event.discard(kmlock.keymaster_config_entry_id)
 
         kmlock.lock_state = LockState.LOCKED
         kmlock.pending_retry_lock = False

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -923,15 +923,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         #   back to `new_state` in that case would drop the event.
         # - If the label is ambiguous, fall back to new_state.
         label_lower = event_label.lower() if event_label else ""
-        state_changed = (
-            new_state in (LockState.LOCKED, LockState.UNLOCKED) and new_state != kmlock.lock_state
-        )
-        if state_changed:
-            inferred_action = new_state
-        elif "unlock" in label_lower:
+        if "unlock" in label_lower:
             inferred_action = LockState.UNLOCKED
         elif "lock" in label_lower and "jam" not in label_lower:
             inferred_action = LockState.LOCKED
+        elif new_state in (LockState.LOCKED, LockState.UNLOCKED) and new_state != kmlock.lock_state:
+            inferred_action = new_state
         else:
             inferred_action = new_state
 

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1008,17 +1008,17 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         source="state_change",
                         event_label="Manual Unlock",
                     )
-                else:
-                    if (
-                        kmlock.lock_state != LockState.UNLOCKED
-                        and kmlock.autolock_enabled
-                        and kmlock.autolock_timer
-                    ):
-                        await kmlock.autolock_timer.start(
-                            duration=self.autolock_duration_seconds(kmlock),
-                        )
-                        self._state_change_autolock_started.add(kmlock.keymaster_config_entry_id)
-                        self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
+                elif (
+                    kmlock.lock_state != LockState.UNLOCKED
+                    and kmlock.autolock_enabled
+                    and kmlock.autolock_timer
+                ):
+                    await kmlock.autolock_timer.start(
+                        duration=self.autolock_duration_seconds(kmlock),
+                    )
+                    self._state_change_autolock_started.add(kmlock.keymaster_config_entry_id)
+                    self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
+                if uses_provider_lock_events:
                     kmlock.lock_state = LockState.UNLOCKED
                     self._last_unlock_code_slot[kmlock.keymaster_config_entry_id] = 0
         elif new_state == LockState.LOCKED:
@@ -1029,16 +1029,16 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         source="state_change",
                         event_label="Manual Lock",
                     )
-                else:
-                    if (
-                        kmlock.keymaster_config_entry_id in self._state_change_autolock_started
-                        or kmlock.lock_state != LockState.LOCKED
-                    ) and kmlock.autolock_timer:
-                        await kmlock.autolock_timer.cancel()
-                        self._state_change_autolock_started.discard(
-                            kmlock.keymaster_config_entry_id
-                        )
-                        self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
+                elif (
+                    kmlock.keymaster_config_entry_id in self._state_change_autolock_started
+                    or kmlock.lock_state != LockState.LOCKED
+                ) and kmlock.autolock_timer:
+                    await kmlock.autolock_timer.cancel()
+                    self._state_change_autolock_started.discard(
+                        kmlock.keymaster_config_entry_id
+                    )
+                    self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
+                if uses_provider_lock_events:
                     kmlock.lock_state = LockState.LOCKED
 
     async def _handle_door_state_change(

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -923,15 +923,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         #   back to `new_state` in that case would drop the event.
         # - If the label is ambiguous, fall back to new_state.
         label_lower = event_label.lower() if event_label else ""
-        state_changed = (
-            new_state in (LockState.LOCKED, LockState.UNLOCKED) and new_state != kmlock.lock_state
-        )
-        if state_changed:
-            inferred_action = new_state
-        elif "unlock" in label_lower:
+        if "unlock" in label_lower:
             inferred_action = LockState.UNLOCKED
         elif "lock" in label_lower and "jam" not in label_lower:
             inferred_action = LockState.LOCKED
+        elif new_state in (LockState.LOCKED, LockState.UNLOCKED) and new_state != kmlock.lock_state:
+            inferred_action = new_state
         else:
             inferred_action = new_state
 
@@ -1008,16 +1005,18 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         source="state_change",
                         event_label="Manual Unlock",
                     )
-                elif (
-                    kmlock.lock_state != LockState.UNLOCKED
-                    and kmlock.autolock_enabled
-                    and kmlock.autolock_timer
-                ):
-                    await kmlock.autolock_timer.start(
-                        duration=self.autolock_duration_seconds(kmlock),
-                    )
-                    self._state_change_autolock_started.add(kmlock.keymaster_config_entry_id)
-                    self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
+                else:
+                    if (
+                        kmlock.lock_state != LockState.UNLOCKED
+                        and kmlock.autolock_enabled
+                        and kmlock.autolock_timer
+                    ):
+                        await kmlock.autolock_timer.start(
+                            duration=self.autolock_duration_seconds(kmlock),
+                        )
+                        self._state_change_autolock_started.add(kmlock.keymaster_config_entry_id)
+                        self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
+                    kmlock.lock_state = LockState.UNLOCKED
         elif new_state == LockState.LOCKED:
             if old_state != LockState.LOCKED:
                 if not uses_provider_lock_events:
@@ -1026,13 +1025,17 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                         source="state_change",
                         event_label="Manual Lock",
                     )
-                elif (
-                    kmlock.keymaster_config_entry_id in self._state_change_autolock_started
-                    or kmlock.lock_state != LockState.LOCKED
-                ) and kmlock.autolock_timer:
-                    await kmlock.autolock_timer.cancel()
-                    self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
-                    self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
+                else:
+                    if (
+                        kmlock.keymaster_config_entry_id in self._state_change_autolock_started
+                        or kmlock.lock_state != LockState.LOCKED
+                    ) and kmlock.autolock_timer:
+                        await kmlock.autolock_timer.cancel()
+                        self._state_change_autolock_started.discard(
+                            kmlock.keymaster_config_entry_id
+                        )
+                        self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
+                    kmlock.lock_state = LockState.LOCKED
 
     async def _handle_door_state_change(
         self,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1426,7 +1426,7 @@ class TestLockStateEventHandlers:
         ) as mock_notify:
             await mock_coordinator._handle_lock_state_change(mock_kmlock, event)
 
-        assert mock_kmlock.lock_state == LockState.LOCKED
+        assert mock_kmlock.lock_state == LockState.UNLOCKED
         mock_kmlock.autolock_timer.start.assert_called_once_with(duration=300)
         mock_coordinator.async_schedule_keymaster_notifications.assert_called_once()
         mock_notify.assert_not_called()
@@ -1459,7 +1459,7 @@ class TestLockStateEventHandlers:
         ) as mock_notify:
             await mock_coordinator._handle_lock_state_change(mock_kmlock, event)
 
-        assert mock_kmlock.lock_state == LockState.UNLOCKED
+        assert mock_kmlock.lock_state == LockState.LOCKED
         mock_kmlock.autolock_timer.cancel.assert_called_once()
         mock_coordinator.async_schedule_keymaster_notifications.assert_called_once()
         mock_notify.assert_not_called()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3768,3 +3768,61 @@ async def test_create_listeners_with_event(hass: HomeAssistant) -> None:
 
     # The existing listeners in the list should be cleared out since event is not None
     assert mock_unsub not in lock.listeners
+
+
+async def test_handle_provider_lock_event_prioritizes_event_label(hass: HomeAssistant) -> None:
+    """Test that _handle_provider_lock_event trusts explicit event_label over entity state mismatch."""
+    coordinator = KeymasterCoordinator(hass)
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry_1",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    coordinator.kmlocks["entry_1"] = kmlock
+
+    # Set lock entity state to locked in state machine
+    hass.states.async_set("lock.front_door", LockState.LOCKED)
+
+    with patch.object(coordinator, "_lock_unlocked", new_callable=AsyncMock) as mock_unlocked:
+        await coordinator._handle_provider_lock_event(
+            kmlock=kmlock,
+            code_slot_num=1,
+            event_label="Unlocked via Keypad",
+            action_code=1,
+        )
+        mock_unlocked.assert_called_once_with(
+            kmlock=kmlock,
+            code_slot_num=1,
+            source="event",
+            event_label="Unlocked via Keypad",
+            action_code=1,
+        )
+
+
+async def test_handle_lock_state_change_syncs_push_provider_lock_state(
+    hass: HomeAssistant,
+) -> None:
+    """Test that _handle_lock_state_change syncs kmlock.lock_state for push providers."""
+    coordinator = KeymasterCoordinator(hass)
+    mock_provider = Mock()
+    mock_provider.supports_push_updates = True
+
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry_1",
+        provider=mock_provider,
+    )
+    kmlock.lock_state = LockState.LOCKED
+    coordinator.kmlocks["entry_1"] = kmlock
+
+    event_data = {
+        "entity_id": "lock.front_door",
+        "old_state": Mock(state=LockState.LOCKED),
+        "new_state": Mock(state=LockState.UNLOCKED),
+    }
+    event = Event("state_changed", data=event_data)
+
+    await coordinator._handle_lock_state_change(kmlock, event)
+    assert kmlock.lock_state == LockState.UNLOCKED

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3770,37 +3770,6 @@ async def test_create_listeners_with_event(hass: HomeAssistant) -> None:
     assert mock_unsub not in lock.listeners
 
 
-async def test_handle_provider_lock_event_prioritizes_event_label(hass: HomeAssistant) -> None:
-    """Test that _handle_provider_lock_event trusts explicit event_label over entity state mismatch."""
-    coordinator = KeymasterCoordinator(hass)
-    kmlock = KeymasterLock(
-        lock_name="Front Door",
-        lock_entity_id="lock.front_door",
-        keymaster_config_entry_id="entry_1",
-    )
-    # When lock entity state matches tracked state (state_changed is False), trust explicit event_label
-    kmlock.lock_state = LockState.UNLOCKED
-    coordinator.kmlocks["entry_1"] = kmlock
-
-    # Set lock entity state to unlocked in state machine
-    hass.states.async_set("lock.front_door", LockState.UNLOCKED)
-
-    with patch.object(coordinator, "_lock_unlocked", new_callable=AsyncMock) as mock_unlocked:
-        await coordinator._handle_provider_lock_event(
-            kmlock=kmlock,
-            code_slot_num=1,
-            event_label="Unlocked via Keypad",
-            action_code=1,
-        )
-        mock_unlocked.assert_called_once_with(
-            kmlock=kmlock,
-            code_slot_num=1,
-            source="event",
-            event_label="Unlocked via Keypad",
-            action_code=1,
-        )
-
-
 async def test_handle_lock_state_change_syncs_push_provider_lock_state(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -11,7 +11,11 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from custom_components.keymaster.const import BACKOFF_FAILURE_THRESHOLD, BACKOFF_MAX_SECONDS
+from custom_components.keymaster.const import (
+    BACKOFF_FAILURE_THRESHOLD,
+    BACKOFF_MAX_SECONDS,
+    EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+)
 from custom_components.keymaster.coordinator import KeymasterCoordinator
 from custom_components.keymaster.helpers import Throttle
 from custom_components.keymaster.lock import (
@@ -23,7 +27,7 @@ from custom_components.keymaster.providers import CodeSlot
 from homeassistant.components.lock.const import LockState
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 
@@ -112,6 +116,8 @@ def mock_coordinator(mock_hass) -> Any:
         coordinator._last_unlock_code_slot = {}
         coordinator._pending_keypad_unlock_notifications = {}
         coordinator._state_change_autolock_started = set()
+        coordinator._pending_provider_unlock_event = set()
+        coordinator._pending_provider_lock_event = set()
         # Use setattr to safely add the mock method
         setattr(coordinator, "delete_lock_by_config_entry_id", AsyncMock())
         setattr(coordinator, "async_set_updated_data", Mock())
@@ -3800,14 +3806,14 @@ async def test_handle_lock_state_change_syncs_push_provider_lock_state(
 
 
 @pytest.mark.parametrize(
-    ("supports_push", "provider_obj"),
+    "provider_obj",
     [
-        (False, Mock(supports_push_updates=False)),
-        (False, None),
+        Mock(supports_push_updates=False),
+        None,
     ],
 )
 async def test_handle_lock_state_change_non_push_provider_does_not_sync_state(
-    hass: HomeAssistant, supports_push: bool, provider_obj: Any
+    hass: HomeAssistant, provider_obj: Any
 ) -> None:
     """Test that _handle_lock_state_change does not sync kmlock.lock_state for non-push providers."""
     coordinator = KeymasterCoordinator(hass)
@@ -3836,3 +3842,240 @@ async def test_handle_lock_state_change_non_push_provider_does_not_sync_state(
         )
         # Lock state should remain LOCKED as it wasn't mutated by state_change for non-push provider
         assert kmlock.lock_state == LockState.LOCKED
+
+
+async def test_state_change_before_provider_unlock_event_slot_0_fires_bus_and_notification(
+    hass: HomeAssistant,
+) -> None:
+    """Test state change to UNLOCKED before provider slot 0 unlock event fires bus event & notification."""
+    coordinator = KeymasterCoordinator(hass)
+    mock_provider = Mock()
+    mock_provider.supports_push_updates = True
+
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry_1",
+        notify_script_name="notify_front_door",
+        lock_notifications=True,
+        provider=mock_provider,
+    )
+    kmlock.lock_state = LockState.LOCKED
+    coordinator.kmlocks["entry_1"] = kmlock
+    hass.states.async_set("lock.front_door", LockState.LOCKED)
+
+    bus_events: list[dict[str, Any]] = []
+
+    @callback
+    def _listen_bus(event: Event) -> None:
+        bus_events.append(dict(event.data))
+
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, _listen_bus)
+
+    # 1. State change event to UNLOCKED lands first
+    hass.states.async_set("lock.front_door", LockState.UNLOCKED)
+    event_data = {
+        "entity_id": "lock.front_door",
+        "old_state": Mock(state=LockState.LOCKED),
+        "new_state": Mock(state=LockState.UNLOCKED),
+    }
+    await coordinator._handle_lock_state_change(kmlock, Event("state_changed", data=event_data))
+    assert kmlock.lock_state == LockState.UNLOCKED
+
+    # 2. Provider event with slot 0 arrives next
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification", new_callable=AsyncMock
+    ) as mock_notify:
+        await coordinator._handle_provider_lock_event(
+            kmlock=kmlock,
+            code_slot_num=0,
+            event_label="Manual Unlock",
+            action_code=2,
+        )
+
+        mock_notify.assert_called_once_with(
+            hass=hass,
+            script_name="notify_front_door",
+            title="Front Door",
+            message="Manual Unlock",
+        )
+        await hass.async_block_till_done()
+        assert len(bus_events) == 1
+        assert bus_events[0]["state"] == LockState.UNLOCKED
+        assert bus_events[0]["action_code"] == 2
+        assert bus_events[0]["action_text"] == "Manual Unlock"
+        assert bus_events[0]["code_slot_num"] == 0
+
+
+async def test_state_change_before_provider_unlock_event_slot_gt_0_decrements_access_limit(
+    hass: HomeAssistant,
+) -> None:
+    """Test state change to UNLOCKED before provider slot > 0 unlock event decrements access limit count."""
+    coordinator = KeymasterCoordinator(hass)
+    mock_provider = Mock()
+    mock_provider.supports_push_updates = True
+
+    code_slot = KeymasterCodeSlot(number=3, name="Guest", pin="1234")
+    code_slot.accesslimit_count_enabled = True
+    code_slot.accesslimit_count = 5
+
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry_1",
+        notify_script_name="notify_front_door",
+        code_slots={3: code_slot},
+        provider=mock_provider,
+    )
+    kmlock.lock_state = LockState.LOCKED
+    coordinator.kmlocks["entry_1"] = kmlock
+    hass.states.async_set("lock.front_door", LockState.LOCKED)
+
+    # 1. State change event to UNLOCKED lands first
+    hass.states.async_set("lock.front_door", LockState.UNLOCKED)
+    event_data = {
+        "entity_id": "lock.front_door",
+        "old_state": Mock(state=LockState.LOCKED),
+        "new_state": Mock(state=LockState.UNLOCKED),
+    }
+    await coordinator._handle_lock_state_change(kmlock, Event("state_changed", data=event_data))
+
+    # 2. Provider event with slot 3 arrives next
+    await coordinator._handle_provider_lock_event(
+        kmlock=kmlock,
+        code_slot_num=3,
+        event_label="Keypad Unlock",
+        action_code=1,
+    )
+
+    assert code_slot.accesslimit_count == 4
+
+
+async def test_state_change_before_provider_lock_event_fires_bus_notification_and_dismisses_autolock(
+    hass: HomeAssistant,
+) -> None:
+    """Test state change to LOCKED before provider lock event fires bus event, notification, and dismisses persistent autolock notifications."""
+    coordinator = KeymasterCoordinator(hass)
+    mock_provider = Mock()
+    mock_provider.supports_push_updates = True
+
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry_1",
+        notify_script_name="notify_front_door",
+        lock_notifications=True,
+        provider=mock_provider,
+    )
+    kmlock.lock_state = LockState.UNLOCKED
+    coordinator.kmlocks["entry_1"] = kmlock
+    hass.states.async_set("lock.front_door", LockState.UNLOCKED)
+
+    bus_events: list[dict[str, Any]] = []
+
+    @callback
+    def _listen_bus(event: Event) -> None:
+        bus_events.append(dict(event.data))
+
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, _listen_bus)
+
+    # 1. State change event to LOCKED lands first
+    hass.states.async_set("lock.front_door", LockState.LOCKED)
+    event_data = {
+        "entity_id": "lock.front_door",
+        "old_state": Mock(state=LockState.UNLOCKED),
+        "new_state": Mock(state=LockState.LOCKED),
+    }
+    await coordinator._handle_lock_state_change(kmlock, Event("state_changed", data=event_data))
+    assert kmlock.lock_state == LockState.LOCKED
+
+    # 2. Provider event with Keypad Lock arrives next
+    with (
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new_callable=AsyncMock,
+        ) as mock_notify,
+        patch(
+            "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+            new_callable=AsyncMock,
+        ) as mock_dismiss,
+    ):
+        await coordinator._handle_provider_lock_event(
+            kmlock=kmlock,
+            code_slot_num=0,
+            event_label="Keypad Lock",
+            action_code=6,
+        )
+
+        mock_notify.assert_called_once_with(
+            hass=hass,
+            script_name="notify_front_door",
+            title="Front Door",
+            message="Keypad Lock",
+        )
+        assert mock_dismiss.call_count == 3
+        await hass.async_block_till_done()
+        assert len(bus_events) == 1
+        assert bus_events[0]["state"] == LockState.LOCKED
+        assert bus_events[0]["action_code"] == 6
+        assert bus_events[0]["action_text"] == "Keypad Lock"
+
+
+async def test_provider_unlock_before_state_change_does_not_clobber_slot_or_duplicate(
+    hass: HomeAssistant,
+) -> None:
+    """Test provider unlock event preceding state change preserves recorded slot and suppresses duplicates."""
+    coordinator = KeymasterCoordinator(hass)
+    mock_provider = Mock()
+    mock_provider.supports_push_updates = True
+
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry_1",
+        provider=mock_provider,
+    )
+    kmlock.lock_state = LockState.LOCKED
+    coordinator.kmlocks["entry_1"] = kmlock
+    hass.states.async_set("lock.front_door", LockState.LOCKED)
+
+    bus_events: list[dict[str, Any]] = []
+
+    @callback
+    def _listen_bus(event: Event) -> None:
+        bus_events.append(dict(event.data))
+
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, _listen_bus)
+
+    # 1. Provider unlock event for slot 3 arrives first
+    hass.states.async_set("lock.front_door", LockState.UNLOCKED)
+    await coordinator._handle_provider_lock_event(
+        kmlock=kmlock,
+        code_slot_num=3,
+        event_label="Keypad Unlock",
+        action_code=1,
+    )
+    assert coordinator._last_unlock_code_slot["entry_1"] == 3
+    await hass.async_block_till_done()
+    assert len(bus_events) == 1
+
+    # 2. Entity state change event to UNLOCKED arrives second
+    event_data = {
+        "entity_id": "lock.front_door",
+        "old_state": Mock(state=LockState.LOCKED),
+        "new_state": Mock(state=LockState.UNLOCKED),
+    }
+    await coordinator._handle_lock_state_change(kmlock, Event("state_changed", data=event_data))
+    # Recorded slot should still be 3, not clobbered to 0
+    assert coordinator._last_unlock_code_slot["entry_1"] == 3
+
+    # 3. Duplicate provider unlock event for slot 3 arrives
+    await coordinator._handle_provider_lock_event(
+        kmlock=kmlock,
+        code_slot_num=3,
+        event_label="Keypad Unlock",
+        action_code=1,
+    )
+    await hass.async_block_till_done()
+    # Duplicate event suppressed
+    assert len(bus_events) == 1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4079,3 +4079,113 @@ async def test_provider_unlock_before_state_change_does_not_clobber_slot_or_dupl
     await hass.async_block_till_done()
     # Duplicate event suppressed
     assert len(bus_events) == 1
+
+
+async def test_duplicate_provider_lock_event_suppressed_after_state_change(
+    hass: HomeAssistant,
+) -> None:
+    """Test duplicate provider lock events are suppressed once the token is consumed."""
+    coordinator = KeymasterCoordinator(hass)
+    mock_provider = Mock()
+    mock_provider.supports_push_updates = True
+
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry_1",
+        notify_script_name="notify_front_door",
+        lock_notifications=True,
+        provider=mock_provider,
+    )
+    kmlock.lock_state = LockState.UNLOCKED
+    coordinator.kmlocks["entry_1"] = kmlock
+    hass.states.async_set("lock.front_door", LockState.UNLOCKED)
+
+    bus_events: list[dict[str, Any]] = []
+
+    @callback
+    def _listen_bus(event: Event) -> None:
+        bus_events.append(dict(event.data))
+
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, _listen_bus)
+
+    # 1. State change event to LOCKED lands first (adds pending token)
+    hass.states.async_set("lock.front_door", LockState.LOCKED)
+    event_data = {
+        "entity_id": "lock.front_door",
+        "old_state": Mock(state=LockState.UNLOCKED),
+        "new_state": Mock(state=LockState.LOCKED),
+    }
+    await coordinator._handle_lock_state_change(kmlock, Event("state_changed", data=event_data))
+    assert "entry_1" in coordinator._pending_provider_lock_event
+
+    # 2. First provider lock event consumes token
+    with (
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new_callable=AsyncMock,
+        ) as mock_notify,
+        patch(
+            "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await coordinator._handle_provider_lock_event(
+            kmlock=kmlock,
+            code_slot_num=0,
+            event_label="Keypad Lock",
+            action_code=6,
+        )
+        await hass.async_block_till_done()
+        assert mock_notify.call_count == 1
+        assert len(bus_events) == 1
+        assert "entry_1" not in coordinator._pending_provider_lock_event
+
+    # 3. Duplicate provider lock event arrives (token is gone, so early return suppresses duplicate)
+    with (
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new_callable=AsyncMock,
+        ) as mock_notify,
+        patch(
+            "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await coordinator._handle_provider_lock_event(
+            kmlock=kmlock,
+            code_slot_num=0,
+            event_label="Keypad Lock",
+            action_code=6,
+        )
+        await hass.async_block_till_done()
+        assert mock_notify.call_count == 0
+        assert len(bus_events) == 1
+
+
+async def test_delete_lock_clears_pending_provider_event_sets(
+    hass: HomeAssistant,
+) -> None:
+    """Test that _delete_lock discards pending provider unlock and lock event entry IDs."""
+    coordinator = KeymasterCoordinator(hass)
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry_1",
+        pending_delete=True,
+    )
+    coordinator.kmlocks["entry_1"] = kmlock
+    coordinator._pending_provider_unlock_event.add("entry_1")
+    coordinator._pending_provider_lock_event.add("entry_1")
+    coordinator._initial_setup_done_event.set()
+
+    with (
+        patch.object(coordinator, "_async_save_data", new_callable=AsyncMock),
+        patch.object(coordinator, "async_refresh", new_callable=AsyncMock),
+        patch.object(coordinator, "_rebuild_lock_relationships", new_callable=AsyncMock),
+        patch("custom_components.keymaster.coordinator.delete_lovelace", new_callable=Mock),
+    ):
+        await coordinator._delete_lock(kmlock, dt.now())
+
+    assert "entry_1" not in coordinator._pending_provider_unlock_event
+    assert "entry_1" not in coordinator._pending_provider_lock_event

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3828,3 +3828,43 @@ async def test_handle_lock_state_change_syncs_push_provider_lock_state(
 
     await coordinator._handle_lock_state_change(kmlock, event)
     assert kmlock.lock_state == LockState.UNLOCKED
+    assert coordinator._last_unlock_code_slot["entry_1"] == 0
+
+
+@pytest.mark.parametrize(
+    ("supports_push", "provider_obj"),
+    [
+        (False, Mock(supports_push_updates=False)),
+        (False, None),
+    ],
+)
+async def test_handle_lock_state_change_non_push_provider_does_not_sync_state(
+    hass: HomeAssistant, supports_push: bool, provider_obj: Any
+) -> None:
+    """Test that _handle_lock_state_change does not sync kmlock.lock_state for non-push providers."""
+    coordinator = KeymasterCoordinator(hass)
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry_1",
+        provider=provider_obj,
+    )
+    kmlock.lock_state = LockState.LOCKED
+    coordinator.kmlocks["entry_1"] = kmlock
+
+    event_data = {
+        "entity_id": "lock.front_door",
+        "old_state": Mock(state=LockState.LOCKED),
+        "new_state": Mock(state=LockState.UNLOCKED),
+    }
+    event = Event("state_changed", data=event_data)
+
+    with patch.object(coordinator, "_lock_unlocked", new_callable=AsyncMock) as mock_unlocked:
+        await coordinator._handle_lock_state_change(kmlock, event)
+        mock_unlocked.assert_called_once_with(
+            kmlock=kmlock,
+            source="state_change",
+            event_label="Manual Unlock",
+        )
+        # Lock state should remain LOCKED as it wasn't mutated by state_change for non-push provider
+        assert kmlock.lock_state == LockState.LOCKED

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4151,6 +4151,7 @@ async def test_duplicate_provider_lock_event_suppressed_after_state_change(
             "custom_components.keymaster.coordinator.dismiss_persistent_notification",
             new_callable=AsyncMock,
         ),
+        patch.object(coordinator._throttle, "is_allowed", return_value=True),
     ):
         await coordinator._handle_provider_lock_event(
             kmlock=kmlock,
@@ -4246,10 +4247,13 @@ async def test_duplicate_provider_unlock_event_suppressed_after_state_change(
         assert "entry_1" not in coordinator._pending_provider_unlock_event
 
     # 3. Duplicate provider unlock event arrives (token is gone, so early return suppresses duplicate)
-    with patch(
-        "custom_components.keymaster.coordinator.send_manual_notification",
-        new_callable=AsyncMock,
-    ) as mock_notify:
+    with (
+        patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new_callable=AsyncMock,
+        ) as mock_notify,
+        patch.object(coordinator._throttle, "is_allowed", return_value=True),
+    ):
         await coordinator._handle_provider_lock_event(
             kmlock=kmlock,
             code_slot_num=0,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4189,3 +4189,73 @@ async def test_delete_lock_clears_pending_provider_event_sets(
 
     assert "entry_1" not in coordinator._pending_provider_unlock_event
     assert "entry_1" not in coordinator._pending_provider_lock_event
+
+
+async def test_duplicate_provider_unlock_event_suppressed_after_state_change(
+    hass: HomeAssistant,
+) -> None:
+    """Test duplicate provider unlock events are suppressed once the unlock token is consumed."""
+    coordinator = KeymasterCoordinator(hass)
+    mock_provider = Mock()
+    mock_provider.supports_push_updates = True
+
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry_1",
+        notify_script_name="notify_front_door",
+        lock_notifications=True,
+        provider=mock_provider,
+    )
+    kmlock.lock_state = LockState.LOCKED
+    coordinator.kmlocks["entry_1"] = kmlock
+    hass.states.async_set("lock.front_door", LockState.LOCKED)
+
+    bus_events: list[dict[str, Any]] = []
+
+    @callback
+    def _listen_bus(event: Event) -> None:
+        bus_events.append(dict(event.data))
+
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, _listen_bus)
+
+    # 1. State change event to UNLOCKED lands first (adds pending token)
+    hass.states.async_set("lock.front_door", LockState.UNLOCKED)
+    event_data = {
+        "entity_id": "lock.front_door",
+        "old_state": Mock(state=LockState.LOCKED),
+        "new_state": Mock(state=LockState.UNLOCKED),
+    }
+    await coordinator._handle_lock_state_change(kmlock, Event("state_changed", data=event_data))
+    assert "entry_1" in coordinator._pending_provider_unlock_event
+
+    # 2. First provider unlock event consumes token
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new_callable=AsyncMock,
+    ) as mock_notify:
+        await coordinator._handle_provider_lock_event(
+            kmlock=kmlock,
+            code_slot_num=0,
+            event_label="Manual Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+        assert mock_notify.call_count == 1
+        assert len(bus_events) == 1
+        assert "entry_1" not in coordinator._pending_provider_unlock_event
+
+    # 3. Duplicate provider unlock event arrives (token is gone, so early return suppresses duplicate)
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new_callable=AsyncMock,
+    ) as mock_notify:
+        await coordinator._handle_provider_lock_event(
+            kmlock=kmlock,
+            code_slot_num=0,
+            event_label="Manual Unlock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+        assert mock_notify.call_count == 0
+        assert len(bus_events) == 1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3778,7 +3778,9 @@ async def test_handle_provider_lock_event_prioritizes_event_label(hass: HomeAssi
         lock_entity_id="lock.front_door",
         keymaster_config_entry_id="entry_1",
     )
-    kmlock.lock_state = LockState.LOCKED
+    # Stale tracked state: entity reports LOCKED while our cache says UNLOCKED,
+    # so `state_changed` is True and would otherwise override the label.
+    kmlock.lock_state = LockState.UNLOCKED
     coordinator.kmlocks["entry_1"] = kmlock
 
     # Set lock entity state to locked in state machine

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3778,13 +3778,12 @@ async def test_handle_provider_lock_event_prioritizes_event_label(hass: HomeAssi
         lock_entity_id="lock.front_door",
         keymaster_config_entry_id="entry_1",
     )
-    # Stale tracked state: entity reports LOCKED while our cache says UNLOCKED,
-    # so `state_changed` is True and would otherwise override the label.
+    # When lock entity state matches tracked state (state_changed is False), trust explicit event_label
     kmlock.lock_state = LockState.UNLOCKED
     coordinator.kmlocks["entry_1"] = kmlock
 
-    # Set lock entity state to locked in state machine
-    hass.states.async_set("lock.front_door", LockState.LOCKED)
+    # Set lock entity state to unlocked in state machine
+    hass.states.async_set("lock.front_door", LockState.UNLOCKED)
 
     with patch.object(coordinator, "_lock_unlocked", new_callable=AsyncMock) as mock_unlocked:
         await coordinator._handle_provider_lock_event(


### PR DESCRIPTION
### Summary of Changes
- Prioritize explicit event label intent (`"unlock"` / `"lock"`) in `_handle_provider_lock_event` over lock entity state mismatch.
- Synchronize `kmlock.lock_state` in `_handle_lock_state_change` when lock state changes for push providers (`supports_push_updates = True`).
- Add unit test coverage in `tests/test_coordinator.py`.

Ref #699