### PR TITLE
fix(init): register lovelace strategy resource during async_setup_entry

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -156,6 +156,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # _LOGGER.debug(f"[init async_setup_entry] updated config_entry.data: {config_entry.data}")
 
     await async_setup_services(hass)
+    await async_register_strategy_resource(hass)
 
     if COORDINATOR not in hass.data[DOMAIN]:
         coordinator: KeymasterCoordinator = KeymasterCoordinator(hass)

--- a/custom_components/keymaster/resources.py
+++ b/custom_components/keymaster/resources.py
@@ -30,8 +30,11 @@ def get_lovelace_resources(
 async def async_register_strategy_resource(hass: HomeAssistant) -> None:
     """Register the Lovelace strategy resource when supported."""
     resources = get_lovelace_resources(hass)
+    domain_data = hass.data.setdefault(DOMAIN, {})
     if not resources:
-        _LOGGER.warning(
+        log = _LOGGER.debug if domain_data.get("resources_warned") else _LOGGER.warning
+        domain_data["resources_warned"] = True
+        log(
             "Lovelace integration not available; skipping strategy module "
             "registration. The keymaster dashboard strategy will not work "
             "until Lovelace is loaded and Home Assistant is restarted."
@@ -50,7 +53,9 @@ async def async_register_strategy_resource(hass: HomeAssistant) -> None:
         return
 
     if isinstance(resources, ResourceYAMLCollection):
-        _LOGGER.warning(
+        log = _LOGGER.debug if domain_data.get("yaml_warned") else _LOGGER.warning
+        domain_data["yaml_warned"] = True
+        log(
             "Strategy module can't automatically be registered because this "
             "Home Assistant instance is running in YAML mode for resources. "
             "Please add a new entry in the list under the resources key in "

--- a/custom_components/keymaster/resources.py
+++ b/custom_components/keymaster/resources.py
@@ -95,4 +95,5 @@ async def async_cleanup_strategy_resource(hass: HomeAssistant, hass_data: dict[s
         return
 
     await resources.async_delete_item(resource_id)
+    hass_data["resources"] = False
     _LOGGER.debug("Removed strategy module (resource ID %s)", resource_id)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -535,9 +535,6 @@ async def test_async_setup_entry_setup_success_false(hass) -> None:
 async def test_async_setup_entry_registers_strategy_resource(
     hass,
     lock_kwikset_910,
-    mock_zwavejs_get_usercodes,
-    mock_zwavejs_clear_usercode,
-    mock_zwavejs_set_usercode,
     integration,
 ) -> None:
     """Test that async_setup_entry calls async_register_strategy_resource."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,7 @@
 """Test keymaster init."""
 
 import logging
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -26,9 +26,12 @@ from custom_components.keymaster.const import (
     DEFAULT_ADVANCED_DAY_OF_WEEK,
     DOMAIN,
     LOCK_COORDINATORS,
+    STRATEGY_PATH,
 )
 from custom_components.keymaster.coordinator import KeymasterCoordinator, KeymasterLockCoordinator
 from custom_components.keymaster.lock import KeymasterLock
+from homeassistant.components.lovelace.const import DOMAIN as LOVELACE_DOMAIN
+from homeassistant.components.lovelace.resources import ResourceStorageCollection
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.util.dt import utcnow
@@ -532,18 +535,43 @@ async def test_async_setup_entry_setup_success_false(hass) -> None:
         assert COORDINATOR not in hass.data[DOMAIN]
 
 
-async def test_async_setup_entry_registers_strategy_resource(
+@pytest.fixture(name="fake_lovelace_resources")
+def fake_lovelace_resources_fixture(hass):
+    """Install a fake Lovelace resource storage collection."""
+    items: list[dict] = []
+    resources = MagicMock(spec=ResourceStorageCollection)
+    resources.loaded = True
+    resources.async_items.side_effect = lambda: list(items)
+
+    async def _create(data):
+        item = {"id": f"res{len(items)}", **data}
+        items.append(item)
+        return item
+
+    async def _delete(item_id):
+        items[:] = [i for i in items if i["id"] != item_id]
+
+    resources.async_create_item = AsyncMock(side_effect=_create)
+    resources.async_delete_item = AsyncMock(side_effect=_delete)
+    hass.data[LOVELACE_DOMAIN] = MagicMock()
+    hass.data[LOVELACE_DOMAIN].resources = resources
+    return items
+
+
+async def test_reload_preserves_strategy_resource(
     hass,
     lock_kwikset_910,
     integration,
+    fake_lovelace_resources,
 ) -> None:
-    """Test that async_setup_entry calls async_register_strategy_resource."""
+    """Reloading the only keymaster entry must leave the strategy resource registered."""
     entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3)
     entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+    assert [i for i in fake_lovelace_resources if i["url"] == STRATEGY_PATH]
 
-    with patch(
-        "custom_components.keymaster.async_register_strategy_resource", new_callable=AsyncMock
-    ) as mock_register:
-        assert await hass.config_entries.async_setup(entry.entry_id) is True
-        await hass.async_block_till_done()
-        mock_register.assert_awaited()
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert [i for i in fake_lovelace_resources if i["url"] == STRATEGY_PATH]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -530,3 +530,23 @@ async def test_async_setup_entry_setup_success_false(hass) -> None:
             await async_setup_entry(hass, entry)
 
         assert COORDINATOR not in hass.data[DOMAIN]
+
+
+async def test_async_setup_entry_registers_strategy_resource(
+    hass,
+    lock_kwikset_910,
+    mock_zwavejs_get_usercodes,
+    mock_zwavejs_clear_usercode,
+    mock_zwavejs_set_usercode,
+    integration,
+) -> None:
+    """Test that async_setup_entry calls async_register_strategy_resource."""
+    entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA, version=3)
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.keymaster.async_register_strategy_resource", new_callable=AsyncMock
+    ) as mock_register:
+        assert await hass.config_entries.async_setup(entry.entry_id) is True
+        await hass.async_block_till_done()
+        mock_register.assert_awaited()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -150,6 +150,40 @@ async def test_register_strategy_resource_no_resources(hass: HomeAssistant, capl
     assert "Lovelace integration not available" in caplog.text
 
 
+async def test_register_strategy_resource_no_resources_subsequent_debug(
+    hass: HomeAssistant, caplog
+):
+    """Test subsequent registration calls when no resources available log as debug."""
+    hass.data[DOMAIN] = {}
+
+    await async_register_strategy_resource(hass)
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        await async_register_strategy_resource(hass)
+
+    assert "Lovelace integration not available" in caplog.text
+    assert len([rec for rec in caplog.records if rec.levelno == logging.WARNING]) == 0
+
+
+async def test_register_strategy_resource_yaml_mode_subsequent_debug(
+    hass: HomeAssistant, mock_yaml_resources, caplog
+):
+    """Test subsequent registration calls in YAML mode log as debug."""
+    hass.data[LOVELACE_DOMAIN] = MagicMock()
+    hass.data[LOVELACE_DOMAIN].resources = mock_yaml_resources
+    hass.data[DOMAIN] = {}
+
+    await async_register_strategy_resource(hass)
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        await async_register_strategy_resource(hass)
+
+    assert "YAML mode" in caplog.text
+    assert len([rec for rec in caplog.records if rec.levelno == logging.WARNING]) == 0
+
+
 async def test_cleanup_strategy_resource_removes(hass: HomeAssistant, mock_storage_resources):
     """Test cleaning up strategy resource."""
     mock_storage_resources.async_items.return_value = [{"id": "resource_id", "url": STRATEGY_PATH}]


### PR DESCRIPTION
### Summary of Changes
- Ensure `async_register_strategy_resource(hass)` is called during `async_setup_entry` so reloading an integration config entry re-registers/preserves the Lovelace strategy resource.
- Add unit test coverage in `tests/test_init.py`.

Ref #699