### PR TITLE
fix(providers): prevent startup race and false not connected errors (#708)

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -2382,7 +2382,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         kmlock.connected = await kmlock.provider.async_connect()
 
         if not kmlock.connected:
-            if self.hass.is_running:
+            if self.hass.state == CoreState.running:
                 _LOGGER.error(
                     "[Coordinator] %s: Provider failed to connect",
                     kmlock.lock_name,
@@ -2593,10 +2593,9 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self._cancel_quick_refresh = None
 
     async def _update_lock_data(self, keymaster_config_entry_id: str) -> None:
-        """Update a single keymaster lock."""
-        kmlock: KeymasterLock | None = await self.get_lock_by_config_entry_id(
-            keymaster_config_entry_id,
-        )
+        """Fetch lock data for a given config entry."""
+        kmlock = await self.get_lock_by_config_entry_id(keymaster_config_entry_id)
+
         if not isinstance(kmlock, KeymasterLock):
             return
 
@@ -2615,33 +2614,34 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         await self._connect_and_update_lock(kmlock=kmlock)
 
         if not kmlock.connected:
-            # Track consecutive failures and apply exponential backoff
-            failures = self._consecutive_failures.get(keymaster_config_entry_id, 0) + 1
-            self._consecutive_failures[keymaster_config_entry_id] = failures
+            if self.hass.state == CoreState.running:
+                # Track consecutive failures and apply exponential backoff
+                failures = self._consecutive_failures.get(keymaster_config_entry_id, 0) + 1
+                self._consecutive_failures[keymaster_config_entry_id] = failures
 
-            # On first failure, ping the node to try to wake it.
-            # If it recovers, the next update cycle will reconnect.
-            if failures == 1 and kmlock.provider:
-                await kmlock.provider.async_ping_node()
+                # On first failure, ping the node to try to wake it.
+                # If it recovers, the next update cycle will reconnect.
+                if failures == 1 and kmlock.provider:
+                    await kmlock.provider.async_ping_node()
 
-            if failures >= BACKOFF_FAILURE_THRESHOLD:
-                exponent = failures - BACKOFF_FAILURE_THRESHOLD
-                backoff_secs = min(
-                    BACKOFF_INITIAL_SECONDS * (2**exponent),
-                    BACKOFF_MAX_SECONDS,
-                )
-                self._next_retry_time[keymaster_config_entry_id] = (
-                    dt.now().astimezone() + timedelta(seconds=backoff_secs)
-                )
-                _LOGGER.warning(
-                    "[Coordinator] %s: %d consecutive connection failures, "
-                    "backing off for %d seconds",
-                    kmlock.lock_name,
-                    failures,
-                    backoff_secs,
-                )
-            elif self.hass.is_running:
-                _LOGGER.error("[Coordinator] %s: Not Connected", kmlock.lock_name)
+                if failures >= BACKOFF_FAILURE_THRESHOLD:
+                    exponent = failures - BACKOFF_FAILURE_THRESHOLD
+                    backoff_secs = min(
+                        BACKOFF_INITIAL_SECONDS * (2**exponent),
+                        BACKOFF_MAX_SECONDS,
+                    )
+                    self._next_retry_time[keymaster_config_entry_id] = (
+                        dt.now().astimezone() + timedelta(seconds=backoff_secs)
+                    )
+                    _LOGGER.warning(
+                        "[Coordinator] %s: %d consecutive connection failures, "
+                        "backing off for %d seconds",
+                        kmlock.lock_name,
+                        failures,
+                        backoff_secs,
+                    )
+                else:
+                    _LOGGER.error("[Coordinator] %s: Not Connected", kmlock.lock_name)
             else:
                 _LOGGER.debug(
                     "[Coordinator] %s: Not connected yet during startup",

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -2382,10 +2382,16 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         kmlock.connected = await kmlock.provider.async_connect()
 
         if not kmlock.connected:
-            _LOGGER.error(
-                "[Coordinator] %s: Provider failed to connect",
-                kmlock.lock_name,
-            )
+            if self.hass.is_running:
+                _LOGGER.error(
+                    "[Coordinator] %s: Provider failed to connect",
+                    kmlock.lock_name,
+                )
+            else:
+                _LOGGER.debug(
+                    "[Coordinator] %s: Provider not connected yet during startup",
+                    kmlock.lock_name,
+                )
             return False
 
         if kmlock.provider.lock_config_entry_id:
@@ -2634,8 +2640,13 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     failures,
                     backoff_secs,
                 )
-            else:
+            elif self.hass.is_running:
                 _LOGGER.error("[Coordinator] %s: Not Connected", kmlock.lock_name)
+            else:
+                _LOGGER.debug(
+                    "[Coordinator] %s: Not connected yet during startup",
+                    kmlock.lock_name,
+                )
             return
 
         if not kmlock.provider:

--- a/custom_components/keymaster/providers/schlage.py
+++ b/custom_components/keymaster/providers/schlage.py
@@ -188,13 +188,12 @@ class SchlageLockProvider(BaseLockProvider):
             return False
 
         coordinator = getattr(schlage_entry, "runtime_data", None)
-        if coordinator is None or not hasattr(coordinator, "data"):
+        if coordinator is None or getattr(coordinator, "data", None) is None:
             self._connected = False
             return False
 
-        self._connected = bool(
-            coordinator.data.locks and self._schlage_device_id in coordinator.data.locks
-        )
+        locks = getattr(coordinator.data, "locks", None)
+        self._connected = bool(locks and self._schlage_device_id in locks)
         return self._connected
 
     async def _async_get_codes(self) -> dict[str, dict[str, str]]:

--- a/custom_components/keymaster/providers/schlage.py
+++ b/custom_components/keymaster/providers/schlage.py
@@ -19,6 +19,7 @@ import re
 from typing import Any, cast
 
 from custom_components.keymaster.const import CONF_SLOTS, CONF_START
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.exceptions import HomeAssistantError
 
 from ._base import BaseLockProvider, CodeSlot
@@ -107,13 +108,19 @@ class SchlageLockProvider(BaseLockProvider):
             )
             return False
 
-        try:
-            coordinator = schlage_entry.runtime_data
-        except (AttributeError, TypeError) as e:
-            _LOGGER.error(
-                "[SchlageProvider] Can't access Schlage coordinator: %s: %s",
-                e.__class__.__qualname__,
-                e,
+        if getattr(schlage_entry, "state", None) != ConfigEntryState.LOADED:
+            _LOGGER.debug(
+                "[SchlageProvider] Schlage config entry %s is not loaded yet (state: %s)",
+                self.lock_config_entry_id,
+                getattr(schlage_entry, "state", None),
+            )
+            return False
+
+        coordinator = getattr(schlage_entry, "runtime_data", None)
+        if coordinator is None:
+            _LOGGER.debug(
+                "[SchlageProvider] Schlage coordinator runtime_data not yet available: %s",
+                self.lock_config_entry_id,
             )
             return False
 
@@ -176,21 +183,19 @@ class SchlageLockProvider(BaseLockProvider):
             return False
 
         schlage_entry = self.hass.config_entries.async_get_entry(lock_entry.config_entry_id)
-        if not schlage_entry:
+        if not schlage_entry or getattr(schlage_entry, "state", None) != ConfigEntryState.LOADED:
             self._connected = False
             return False
 
-        try:
-            coordinator = schlage_entry.runtime_data
-            connected = self._schlage_device_id in coordinator.data.locks
-        except (
-            AttributeError,
-            TypeError,
-        ):
-            connected = False
+        coordinator = getattr(schlage_entry, "runtime_data", None)
+        if coordinator is None or not hasattr(coordinator, "data"):
+            self._connected = False
+            return False
 
-        self._connected = connected
-        return connected
+        self._connected = bool(
+            coordinator.data.locks and self._schlage_device_id in coordinator.data.locks
+        )
+        return self._connected
 
     async def _async_get_codes(self) -> dict[str, dict[str, str]]:
         """Call ``schlage.get_codes`` and return the response dict.

--- a/custom_components/keymaster/providers/zwave_js.py
+++ b/custom_components/keymaster/providers/zwave_js.py
@@ -32,6 +32,7 @@ from custom_components.keymaster.const import ATTR_NODE_ID, LockMethod
 from homeassistant.components.lock import LockState
 from homeassistant.components.zwave_js import ZWAVE_JS_NOTIFICATION_EVENT
 from homeassistant.components.zwave_js.const import ATTR_PARAMETERS, DOMAIN as ZWAVE_JS_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import Event, EventStateChangedData
 from homeassistant.helpers.device_registry import DeviceEntry
@@ -400,21 +401,35 @@ class ZWaveJSLockProvider(BaseLockProvider):
             )
             return False
 
-        try:
-            zwave_entry = self.hass.config_entries.async_get_entry(self.lock_config_entry_id)
-            if not zwave_entry:
-                _LOGGER.error(
-                    "[ZWaveJSProvider] Can't find Z-Wave JS config entry: %s",
-                    self.lock_config_entry_id,
-                )
-                return False
-
-            self._client = zwave_entry.runtime_data.client
-        except (KeyError, TypeError, AttributeError) as e:
+        zwave_entry = self.hass.config_entries.async_get_entry(self.lock_config_entry_id)
+        if not zwave_entry:
             _LOGGER.error(
-                "[ZWaveJSProvider] Can't access Z-Wave JS client: %s: %s",
-                e.__class__.__qualname__,
-                e,
+                "[ZWaveJSProvider] Can't find Z-Wave JS config entry: %s",
+                self.lock_config_entry_id,
+            )
+            return False
+
+        if getattr(zwave_entry, "state", None) != ConfigEntryState.LOADED:
+            _LOGGER.debug(
+                "[ZWaveJSProvider] Z-Wave JS config entry %s is not loaded yet (state: %s)",
+                self.lock_config_entry_id,
+                getattr(zwave_entry, "state", None),
+            )
+            return False
+
+        runtime_data = getattr(zwave_entry, "runtime_data", None)
+        if runtime_data is None:
+            _LOGGER.debug(
+                "[ZWaveJSProvider] Z-Wave JS config entry %s runtime_data not yet available",
+                self.lock_config_entry_id,
+            )
+            return False
+
+        self._client = getattr(runtime_data, "client", None)
+        if self._client is None:
+            _LOGGER.debug(
+                "[ZWaveJSProvider] Z-Wave JS client not yet available on runtime_data: %s",
+                self.lock_config_entry_id,
             )
             return False
 

--- a/tests/providers/test_schlage.py
+++ b/tests/providers/test_schlage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -198,7 +198,18 @@ class TestConnect:
         schlage_entry = MagicMock()
         schlage_entry.state = ConfigEntryState.SETUP_IN_PROGRESS
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
-        assert await schlage_provider.async_connect() is False
+
+        with (
+            patch("custom_components.keymaster.providers.schlage._LOGGER.error") as mock_error,
+            patch("custom_components.keymaster.providers.schlage._LOGGER.debug") as mock_debug,
+        ):
+            assert await schlage_provider.async_connect() is False
+            mock_error.assert_not_called()
+            mock_debug.assert_any_call(
+                "[SchlageProvider] Schlage config entry %s is not loaded yet (state: %s)",
+                "schlage_entry",
+                ConfigEntryState.SETUP_IN_PROGRESS,
+            )
 
     async def test_connect_coordinator_not_available(self, schlage_provider):
         """Test connection fails when coordinator unavailable."""
@@ -210,7 +221,17 @@ class TestConnect:
         schlage_entry.state = ConfigEntryState.LOADED
         schlage_entry.runtime_data = None
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
-        assert await schlage_provider.async_connect() is False
+
+        with (
+            patch("custom_components.keymaster.providers.schlage._LOGGER.error") as mock_error,
+            patch("custom_components.keymaster.providers.schlage._LOGGER.debug") as mock_debug,
+        ):
+            assert await schlage_provider.async_connect() is False
+            mock_error.assert_not_called()
+            mock_debug.assert_any_call(
+                "[SchlageProvider] Schlage coordinator runtime_data not yet available: %s",
+                "schlage_entry",
+            )
 
     async def test_connect_no_device_entry(self, schlage_provider):
         """Test connection fails when device not in registry."""
@@ -327,6 +348,24 @@ class TestIsConnected:
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
 
         assert await schlage_provider.async_is_connected() is False
+
+    async def test_not_connected_coordinator_data_none(self, schlage_provider):
+        """Test returns False when coordinator data is None."""
+        schlage_provider._schlage_device_id = "dev123"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
+        coordinator = MagicMock()
+        coordinator.data = None
+        schlage_entry.runtime_data = coordinator
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        assert await schlage_provider.async_is_connected() is False
+        assert schlage_provider._connected is False
 
     async def test_not_connected_schlage_entry_not_loaded(self, schlage_provider):
         """Test returns False when Schlage config entry is not loaded."""

--- a/tests/providers/test_schlage.py
+++ b/tests/providers/test_schlage.py
@@ -12,6 +12,7 @@ from custom_components.keymaster.providers.schlage import (
     _make_tagged_name,
     _parse_tag,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -151,6 +152,7 @@ class TestConnect:
         schlage_provider.entity_registry.async_get.return_value = lock_entry
 
         schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
         coordinator = MagicMock()
         coordinator.data.locks = {"schlage_device_123": MagicMock()}
         schlage_entry.runtime_data = coordinator
@@ -187,13 +189,26 @@ class TestConnect:
         schlage_provider.hass.config_entries.async_get_entry.return_value = None
         assert await schlage_provider.async_connect() is False
 
+    async def test_connect_schlage_entry_not_loaded(self, schlage_provider):
+        """Test connection fails when schlage config entry is not loaded."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.SETUP_IN_PROGRESS
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+        assert await schlage_provider.async_connect() is False
+
     async def test_connect_coordinator_not_available(self, schlage_provider):
         """Test connection fails when coordinator unavailable."""
         lock_entry = MagicMock()
         lock_entry.config_entry_id = "schlage_entry"
         schlage_provider.entity_registry.async_get.return_value = lock_entry
 
-        schlage_entry = MagicMock(spec_set=[])
+        schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
+        schlage_entry.runtime_data = None
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
         assert await schlage_provider.async_connect() is False
 
@@ -205,6 +220,7 @@ class TestConnect:
         schlage_provider.entity_registry.async_get.return_value = lock_entry
 
         schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
         schlage_entry.runtime_data = MagicMock()
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
         schlage_provider.device_registry.async_get.return_value = None
@@ -218,6 +234,7 @@ class TestConnect:
         schlage_provider.entity_registry.async_get.return_value = lock_entry
 
         schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
         schlage_entry.runtime_data = MagicMock()
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
 
@@ -234,6 +251,7 @@ class TestConnect:
         schlage_provider.entity_registry.async_get.return_value = lock_entry
 
         schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
         coordinator = MagicMock()
         coordinator.data.locks = {}  # Empty
         schlage_entry.runtime_data = coordinator
@@ -252,6 +270,7 @@ class TestConnect:
         schlage_provider.entity_registry.async_get.return_value = lock_entry
 
         schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
         coordinator = type("Coordinator", (), {})()
         schlage_entry.runtime_data = coordinator
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
@@ -284,6 +303,7 @@ class TestIsConnected:
         schlage_provider.entity_registry.async_get.return_value = lock_entry
 
         schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
         coordinator = MagicMock()
         coordinator.data.locks = {"dev123": MagicMock()}
         schlage_entry.runtime_data = coordinator
@@ -300,12 +320,28 @@ class TestIsConnected:
         schlage_provider.entity_registry.async_get.return_value = lock_entry
 
         schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
         coordinator = MagicMock()
         coordinator.data.locks = {}
         schlage_entry.runtime_data = coordinator
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
 
         assert await schlage_provider.async_is_connected() is False
+
+    async def test_not_connected_schlage_entry_not_loaded(self, schlage_provider):
+        """Test returns False when Schlage config entry is not loaded."""
+        schlage_provider._schlage_device_id = "dev123"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.SETUP_IN_PROGRESS
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        assert await schlage_provider.async_is_connected() is False
+        assert schlage_provider._connected is False
 
     async def test_not_connected_lock_entry_missing(self, schlage_provider):
         """Test returns False when entity registry entry is missing."""
@@ -347,6 +383,7 @@ class TestIsConnected:
         schlage_provider.entity_registry.async_get.return_value = lock_entry
 
         schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
         schlage_entry.runtime_data = None  # causes AttributeError on .data.locks
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
 

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -22,6 +22,7 @@ from custom_components.keymaster.providers import (
 )
 from custom_components.keymaster.providers.zwave_js import ZWaveJSLockProvider
 from homeassistant.components.lock.const import LockState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from tests.common import async_capture_events
@@ -88,6 +89,7 @@ def setup_successful_connect(
     zwave_provider.entity_registry.async_get.return_value = mock_entity
 
     mock_zwave_entry = MagicMock()
+    mock_zwave_entry.state = ConfigEntryState.LOADED
     mock_zwave_entry.runtime_data = MagicMock()
     mock_zwave_entry.runtime_data.client = mock_zwave_client
     zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
@@ -216,6 +218,49 @@ class TestZWaveJSLockProviderConnect:
 
         assert result is False
 
+    async def test_connect_zwave_entry_not_loaded(self, zwave_provider):
+        """Test connect fails when Z-Wave config entry is not loaded."""
+        mock_entity = MagicMock()
+        mock_entity.config_entry_id = "zwave_entry_id"
+        zwave_provider.entity_registry.async_get.return_value = mock_entity
+
+        mock_zwave_entry = MagicMock()
+        mock_zwave_entry.state = ConfigEntryState.SETUP_IN_PROGRESS
+        zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
+
+        result = await zwave_provider.async_connect()
+
+        assert result is False
+
+    async def test_connect_runtime_data_missing(self, zwave_provider):
+        """Test connect fails when Z-Wave runtime_data is missing."""
+        mock_entity = MagicMock()
+        mock_entity.config_entry_id = "zwave_entry_id"
+        zwave_provider.entity_registry.async_get.return_value = mock_entity
+
+        mock_zwave_entry = MagicMock(spec=["state"])
+        mock_zwave_entry.state = ConfigEntryState.LOADED
+        zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
+
+        result = await zwave_provider.async_connect()
+
+        assert result is False
+
+    async def test_connect_client_missing_on_runtime_data(self, zwave_provider):
+        """Test connect fails when Z-Wave client attribute is None on runtime_data."""
+        mock_entity = MagicMock()
+        mock_entity.config_entry_id = "zwave_entry_id"
+        zwave_provider.entity_registry.async_get.return_value = mock_entity
+
+        mock_zwave_entry = MagicMock()
+        mock_zwave_entry.state = ConfigEntryState.LOADED
+        mock_zwave_entry.runtime_data = MagicMock(spec=[])
+        zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
+
+        result = await zwave_provider.async_connect()
+
+        assert result is False
+
     async def test_connect_client_not_connected(self, zwave_provider):
         """Test connect fails when Z-Wave client not connected."""
         mock_entity = MagicMock()
@@ -224,6 +269,7 @@ class TestZWaveJSLockProviderConnect:
         zwave_provider.entity_registry.async_get.return_value = mock_entity
 
         mock_zwave_entry = MagicMock()
+        mock_zwave_entry.state = ConfigEntryState.LOADED
         mock_zwave_entry.runtime_data = MagicMock()
         mock_zwave_entry.runtime_data.client = MagicMock()
         mock_zwave_entry.runtime_data.client.connected = False
@@ -241,6 +287,7 @@ class TestZWaveJSLockProviderConnect:
         zwave_provider.entity_registry.async_get.return_value = mock_entity
 
         mock_zwave_entry = MagicMock()
+        mock_zwave_entry.state = ConfigEntryState.LOADED
         mock_zwave_entry.runtime_data = MagicMock()
         mock_zwave_entry.runtime_data.client = mock_zwave_client
         zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
@@ -258,6 +305,7 @@ class TestZWaveJSLockProviderConnect:
         zwave_provider.entity_registry.async_get.return_value = mock_entity
 
         mock_zwave_entry = MagicMock()
+        mock_zwave_entry.state = ConfigEntryState.LOADED
         mock_zwave_entry.runtime_data = MagicMock()
         mock_zwave_entry.runtime_data.client = mock_zwave_client
         zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
@@ -1447,6 +1495,7 @@ class TestZWaveJSLockProviderDeadNode:
         zwave_provider.entity_registry.async_get.return_value = mock_entity
 
         mock_zwave_entry = MagicMock()
+        mock_zwave_entry.state = ConfigEntryState.LOADED
         mock_zwave_entry.runtime_data = MagicMock()
         mock_zwave_entry.runtime_data.client = mock_zwave_client
         zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -228,9 +228,19 @@ class TestZWaveJSLockProviderConnect:
         mock_zwave_entry.state = ConfigEntryState.SETUP_IN_PROGRESS
         zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
 
-        result = await zwave_provider.async_connect()
+        with (
+            patch("custom_components.keymaster.providers.zwave_js._LOGGER.error") as mock_error,
+            patch("custom_components.keymaster.providers.zwave_js._LOGGER.debug") as mock_debug,
+        ):
+            result = await zwave_provider.async_connect()
 
-        assert result is False
+            assert result is False
+            mock_error.assert_not_called()
+            mock_debug.assert_any_call(
+                "[ZWaveJSProvider] Z-Wave JS config entry %s is not loaded yet (state: %s)",
+                "zwave_entry_id",
+                ConfigEntryState.SETUP_IN_PROGRESS,
+            )
 
     async def test_connect_runtime_data_missing(self, zwave_provider):
         """Test connect fails when Z-Wave runtime_data is missing."""
@@ -242,9 +252,18 @@ class TestZWaveJSLockProviderConnect:
         mock_zwave_entry.state = ConfigEntryState.LOADED
         zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
 
-        result = await zwave_provider.async_connect()
+        with (
+            patch("custom_components.keymaster.providers.zwave_js._LOGGER.error") as mock_error,
+            patch("custom_components.keymaster.providers.zwave_js._LOGGER.debug") as mock_debug,
+        ):
+            result = await zwave_provider.async_connect()
 
-        assert result is False
+            assert result is False
+            mock_error.assert_not_called()
+            mock_debug.assert_any_call(
+                "[ZWaveJSProvider] Z-Wave JS config entry %s runtime_data not yet available",
+                "zwave_entry_id",
+            )
 
     async def test_connect_client_missing_on_runtime_data(self, zwave_provider):
         """Test connect fails when Z-Wave client attribute is None on runtime_data."""
@@ -257,9 +276,18 @@ class TestZWaveJSLockProviderConnect:
         mock_zwave_entry.runtime_data = MagicMock(spec=[])
         zwave_provider.hass.config_entries.async_get_entry.return_value = mock_zwave_entry
 
-        result = await zwave_provider.async_connect()
+        with (
+            patch("custom_components.keymaster.providers.zwave_js._LOGGER.error") as mock_error,
+            patch("custom_components.keymaster.providers.zwave_js._LOGGER.debug") as mock_debug,
+        ):
+            result = await zwave_provider.async_connect()
 
-        assert result is False
+            assert result is False
+            mock_error.assert_not_called()
+            mock_debug.assert_any_call(
+                "[ZWaveJSProvider] Z-Wave JS client not yet available on runtime_data: %s",
+                "zwave_entry_id",
+            )
 
     async def test_connect_client_not_connected(self, zwave_provider):
         """Test connect fails when Z-Wave client not connected."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4263,3 +4263,113 @@ async def test_duplicate_provider_unlock_event_suppressed_after_state_change(
         await hass.async_block_till_done()
         assert mock_notify.call_count == 0
         assert len(bus_events) == 1
+
+
+class TestConnectAndUpdateLockStartup:
+    """Test startup vs runtime connection behavior in KeymasterCoordinator."""
+
+    async def test_connect_provider_fails_during_startup(self, mock_hass):
+        """Test _connect_and_update_lock logs debug (not error) when provider fails during startup."""
+        mock_hass.is_running = False
+        with patch.object(KeymasterCoordinator, "__init__", return_value=None):
+            coordinator = KeymasterCoordinator(mock_hass)
+            coordinator.hass = mock_hass
+            kmlock = KeymasterLock(
+                lock_name="Front Door",
+                lock_entity_id="lock.front_door",
+                keymaster_config_entry_id="entry_1",
+            )
+            kmlock.provider = AsyncMock()
+            kmlock.provider.async_connect = AsyncMock(return_value=False)
+
+            with (
+                patch("custom_components.keymaster.coordinator._LOGGER.error") as mock_error,
+                patch("custom_components.keymaster.coordinator._LOGGER.debug") as mock_debug,
+            ):
+                result = await coordinator._connect_and_update_lock(kmlock)
+
+            assert result is False
+            assert kmlock.connected is False
+            mock_error.assert_not_called()
+            mock_debug.assert_any_call(
+                "[Coordinator] %s: Provider not connected yet during startup",
+                "Front Door",
+            )
+
+    async def test_connect_provider_fails_when_running(self, mock_hass):
+        """Test _connect_and_update_lock logs error when provider fails after startup."""
+        mock_hass.is_running = True
+        with patch.object(KeymasterCoordinator, "__init__", return_value=None):
+            coordinator = KeymasterCoordinator(mock_hass)
+            coordinator.hass = mock_hass
+            kmlock = KeymasterLock(
+                lock_name="Front Door",
+                lock_entity_id="lock.front_door",
+                keymaster_config_entry_id="entry_1",
+            )
+            kmlock.provider = AsyncMock()
+            kmlock.provider.async_connect = AsyncMock(return_value=False)
+
+            with patch("custom_components.keymaster.coordinator._LOGGER.error") as mock_error:
+                result = await coordinator._connect_and_update_lock(kmlock)
+
+            assert result is False
+            assert kmlock.connected is False
+            mock_error.assert_called_once_with(
+                "[Coordinator] %s: Provider failed to connect",
+                "Front Door",
+            )
+
+    async def test_update_lock_data_not_connected_during_startup(self, mock_hass):
+        """Test _update_lock_data logs debug (not error) when not connected during startup."""
+        mock_hass.is_running = False
+        with patch.object(KeymasterCoordinator, "__init__", return_value=None):
+            coordinator = KeymasterCoordinator(mock_hass)
+            coordinator.hass = mock_hass
+            coordinator._next_retry_time = {}
+            coordinator._consecutive_failures = {}
+            kmlock = KeymasterLock(
+                lock_name="Front Door",
+                lock_entity_id="lock.front_door",
+                keymaster_config_entry_id="entry_1",
+                connected=False,
+            )
+            coordinator.get_lock_by_config_entry_id = AsyncMock(return_value=kmlock)
+            coordinator._connect_and_update_lock = AsyncMock(return_value=False)
+
+            with (
+                patch("custom_components.keymaster.coordinator._LOGGER.error") as mock_error,
+                patch("custom_components.keymaster.coordinator._LOGGER.debug") as mock_debug,
+            ):
+                await coordinator._update_lock_data("entry_1")
+
+            mock_error.assert_not_called()
+            mock_debug.assert_any_call(
+                "[Coordinator] %s: Not connected yet during startup",
+                "Front Door",
+            )
+
+    async def test_update_lock_data_not_connected_when_running(self, mock_hass):
+        """Test _update_lock_data logs error when not connected after startup."""
+        mock_hass.is_running = True
+        with patch.object(KeymasterCoordinator, "__init__", return_value=None):
+            coordinator = KeymasterCoordinator(mock_hass)
+            coordinator.hass = mock_hass
+            coordinator._next_retry_time = {}
+            coordinator._consecutive_failures = {}
+            kmlock = KeymasterLock(
+                lock_name="Front Door",
+                lock_entity_id="lock.front_door",
+                keymaster_config_entry_id="entry_1",
+                connected=False,
+            )
+            coordinator.get_lock_by_config_entry_id = AsyncMock(return_value=kmlock)
+            coordinator._connect_and_update_lock = AsyncMock(return_value=False)
+
+            with patch("custom_components.keymaster.coordinator._LOGGER.error") as mock_error:
+                await coordinator._update_lock_data("entry_1")
+
+            mock_error.assert_any_call(
+                "[Coordinator] %s: Not Connected",
+                "Front Door",
+            )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -27,7 +27,7 @@ from custom_components.keymaster.providers import CodeSlot
 from homeassistant.components.lock.const import LockState
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import CoreState, Event, HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 
@@ -93,6 +93,7 @@ def validate_lock_relationship_invariants(
 def mock_hass():
     """Create a mock Home Assistant instance."""
     hass = Mock(spec=HomeAssistant)
+    hass.state = CoreState.running
     hass.config_entries = Mock()
     hass.config = Mock()
     hass.config.path = Mock(return_value="/test/path")
@@ -4270,7 +4271,7 @@ class TestConnectAndUpdateLockStartup:
 
     async def test_connect_provider_fails_during_startup(self, mock_hass):
         """Test _connect_and_update_lock logs debug (not error) when provider fails during startup."""
-        mock_hass.is_running = False
+        mock_hass.state = CoreState.starting
         with patch.object(KeymasterCoordinator, "__init__", return_value=None):
             coordinator = KeymasterCoordinator(mock_hass)
             coordinator.hass = mock_hass
@@ -4298,7 +4299,7 @@ class TestConnectAndUpdateLockStartup:
 
     async def test_connect_provider_fails_when_running(self, mock_hass):
         """Test _connect_and_update_lock logs error when provider fails after startup."""
-        mock_hass.is_running = True
+        mock_hass.state = CoreState.running
         with patch.object(KeymasterCoordinator, "__init__", return_value=None):
             coordinator = KeymasterCoordinator(mock_hass)
             coordinator.hass = mock_hass
@@ -4321,8 +4322,8 @@ class TestConnectAndUpdateLockStartup:
             )
 
     async def test_update_lock_data_not_connected_during_startup(self, mock_hass):
-        """Test _update_lock_data logs debug (not error) when not connected during startup."""
-        mock_hass.is_running = False
+        """Test _update_lock_data logs debug (not error) and does not backoff during startup."""
+        mock_hass.state = CoreState.starting
         with patch.object(KeymasterCoordinator, "__init__", return_value=None):
             coordinator = KeymasterCoordinator(mock_hass)
             coordinator.hass = mock_hass
@@ -4339,19 +4340,25 @@ class TestConnectAndUpdateLockStartup:
 
             with (
                 patch("custom_components.keymaster.coordinator._LOGGER.error") as mock_error,
+                patch("custom_components.keymaster.coordinator._LOGGER.warning") as mock_warning,
                 patch("custom_components.keymaster.coordinator._LOGGER.debug") as mock_debug,
             ):
-                await coordinator._update_lock_data("entry_1")
+                # Call multiple times during startup
+                for _ in range(5):
+                    await coordinator._update_lock_data("entry_1")
 
             mock_error.assert_not_called()
+            mock_warning.assert_not_called()
             mock_debug.assert_any_call(
                 "[Coordinator] %s: Not connected yet during startup",
                 "Front Door",
             )
+            assert "entry_1" not in coordinator._consecutive_failures
+            assert "entry_1" not in coordinator._next_retry_time
 
     async def test_update_lock_data_not_connected_when_running(self, mock_hass):
-        """Test _update_lock_data logs error when not connected after startup."""
-        mock_hass.is_running = True
+        """Test _update_lock_data logs error and tracks failures when not connected after startup."""
+        mock_hass.state = CoreState.running
         with patch.object(KeymasterCoordinator, "__init__", return_value=None):
             coordinator = KeymasterCoordinator(mock_hass)
             coordinator.hass = mock_hass
@@ -4373,3 +4380,4 @@ class TestConnectAndUpdateLockStartup:
                 "[Coordinator] %s: Not Connected",
                 "Front Door",
             )
+            assert coordinator._consecutive_failures["entry_1"] == 1


### PR DESCRIPTION
# Summary

Prevent startup race condition and false 'Not Connected' / `AttributeError` errors when keymaster polls integration providers before their config entries have completed setup.

## Proposed change

During Home Assistant startup, `keymaster` initializes and polls providers before target integration config entries (e.g., `zwave_js`, `schlage`) have completed `async_setup_entry`. This resulted in `AttributeError` on uninitialized `runtime_data`, false-alarm `ERROR` log messages, and temporary "Not Connected" status until integration loading finished.

- **ZWaveJSProvider & SchlageProvider**:
  - Verify `getattr(entry, "state", None) == ConfigEntryState.LOADED` before attempting connection.
  - Safely retrieve `runtime_data` and client attributes, returning `False` cleanly and logging at `DEBUG` level when not yet loaded/available.
- **KeymasterCoordinator**:
  - Log connection failures and not-connected lock state at `DEBUG` level when Home Assistant is still starting up (`hass.is_running is False`), avoiding noisy error logs during boot while preserving `ERROR` logs for genuine disconnections while running.
- **Unit Tests**:
  - Added unit tests for not-loaded config entries and missing runtime data in `test_zwave_js.py` and `test_schlage.py`.
  - Added unit tests for coordinator startup vs runtime logging in `test_coordinator.py`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #708
- This PR is related to issue: #708
