### PR TITLE
docs: add agent skills, AGENTS.md, and CONTRIBUTING.md

### DIFF
--- a/.agents/skills/coordinator-lifecycle/SKILL.md
+++ b/.agents/skills/coordinator-lifecycle/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: coordinator-lifecycle
+description: >-
+  Architectural patterns and lifecycle instructions for KeymasterCoordinator,
+  child entity platforms (switch, sensor, number, text, datetime, button), and
+  migration handlers.
+---
+
+# Keymaster Coordinator & Entity Lifecycle Guide
+
+This skill guides modifications to `KeymasterCoordinator`
+(`custom_components/keymaster/coordinator.py`), entity platforms, and
+migration logic (`migrate.py`).
+
+## Coordinator State Machine Architecture
+
+`KeymasterCoordinator` is the central orchestrator responsible for:
+
+- Polling and listening for lock code updates from the active
+  `BaseLockProvider`.
+- Managing per-slot configuration and runtime states (`enabled`, `pin`, `name`,
+  `sync_status`, `schedule_date_range`, `schedule_time_range`).
+- Coordinating child entities registered across entity platforms:
+  - `switch.py`: Slot enable/disable, notifications, schedule toggles.
+  - `text.py` / `number.py`: PIN configuration, slot count, autolock
+    parameters.
+  - `datetime.py` / `time.py`: Access schedule date and time limits.
+  - `sensor.py` / `binary_sensor.py`: Active PIN status, connection state, slot
+    status sensors.
+  - `button.py`: Manual sync/clear/reset triggers.
+  - `event.py`: Doorbell/unlock event logging.
+
+## Guidelines for Modifying Coordinator Logic
+
+1. **State Synchronization**:
+   - Always verify slot synchronization status (`CONNECTED`, `DISCONNECTED`,
+     `SYNCING`, `IN_SYNC`) before and after provider code changes.
+   - Dispatch updates via `async_set_updated_data` or specific entity callbacks.
+
+2. **Autolock Integration**:
+   - `autolock/` logic interacts with lock state changes and door sensors.
+     Ensure timer cancellations and rescheduled locks are clean upon entity
+     removal or coordinator unload.
+
+3. **Storage & Migrations**:
+   - Persistent data is managed in `migrate.py`.
+   - When modifying storage schemas, bump the version and ensure backward
+     compatibility for existing HA installs upgrading from prior schema
+     revisions.

--- a/.agents/skills/coordinator-lifecycle/SKILL.md
+++ b/.agents/skills/coordinator-lifecycle/SKILL.md
@@ -2,28 +2,49 @@
 name: coordinator-lifecycle
 description: >-
   Architectural patterns and lifecycle instructions for KeymasterCoordinator,
-  child entity platforms (switch, sensor, number, text, datetime, button), and
-  migration handlers.
+  KeymasterLockCoordinator, fan-out notification architecture, child entity
+  platforms, and storage migrations.
 ---
 
 # Keymaster Coordinator & Entity Lifecycle Guide
 
-This skill guides modifications to `KeymasterCoordinator`
-(`custom_components/keymaster/coordinator.py`), entity platforms, and
-migration logic (`migrate.py`).
+This skill guides modifications to `KeymasterCoordinator`,
+`KeymasterLockCoordinator` (`custom_components/keymaster/coordinator.py`),
+entity platforms, and migration logic (`migrate.py`). For full design details,
+refer to `docs/keymaster-fanout-architecture.md`.
 
-## Coordinator State Machine Architecture
+## Coordinator Architecture & Fan-out Design
 
-`KeymasterCoordinator` is the central orchestrator responsible for:
+Keymaster separates durable storage and refresh ownership from entity-facing
+runtime notifications to prevent event loop exhaustion on large installations:
 
-- Polling and listening for lock code updates from the active
-  `BaseLockProvider`.
-- Managing per-slot configuration and runtime states (`enabled`, `pin`, `name`,
-  `sync_status`, `schedule_date_range`, `schedule_time_range`).
-- Coordinating child entities registered across entity platforms:
+| Component | Lifetime | Role | Target |
+| :--- | :--- | :--- | :--- |
+| `KeymasterCoordinator` | Runtime | Owns locks, storage, refresh | Keepalive |
+| `KeymasterLockCoordinator` | Per lock | Mirrors one lock entry | Entities |
+
+- **Entity Binding**:
+  - Entities bind to `KeymasterLockCoordinator`
+    (`CoordinatorEntity[KeymasterLockCoordinator]`), resolved via
+    `manager.async_get_lock_coordinator(config_entry.entry_id)`.
+  - Entities do NOT listen directly to `KeymasterCoordinator`.
+
+- **Notification Dispatch**:
+  - Manager state changes call
+    `async_schedule_keymaster_notifications(entry_ids, *, all_entry_ids=False)`.
+  - Flushes are deferred with `hass.loop.call_soon` to coalesce updates and
+    prevent nested event-queue overflow.
+  - Updates are pushed to per-lock coordinators via
+    `lock_coordinator.async_set_updated_data(lock)`.
+
+- **Parent-to-Child Sync**:
+  - Batched inside `async with self._parent_sync_transaction():` so multi-slot
+    child sync operations emit a single coalesced notification flush upon
+    outermost exit.
+
+- **Child Entity Platforms**:
   - `switch.py`: Slot enable/disable, notifications, schedule toggles.
-  - `text.py` / `number.py`: PIN configuration, slot count, autolock
-    parameters.
+  - `text.py` / `number.py`: PIN configuration, slot count, autolock parameters.
   - `datetime.py` / `time.py`: Access schedule date and time limits.
   - `sensor.py` / `binary_sensor.py`: Active PIN status, connection state, slot
     status sensors.
@@ -32,18 +53,28 @@ migration logic (`migrate.py`).
 
 ## Guidelines for Modifying Coordinator Logic
 
-1. **State Synchronization**:
-   - Always verify slot synchronization status (`CONNECTED`, `DISCONNECTED`,
-     `SYNCING`, `IN_SYNC`) before and after provider code changes.
-   - Dispatch updates via `async_set_updated_data` or specific entity callbacks.
+1. **State Synchronization (`Synced` Enum)**:
+   - Use the canonical states defined in `custom_components/keymaster/const.py`:
+     - `Synced.ADDING` (`"Adding"`)
+     - `Synced.DELETING` (`"Deleting"`)
+     - `Synced.DISCONNECTED` (`"Disconnected"`)
+     - `Synced.OUT_OF_SYNC` (`"Out of Sync"`)
+     - `Synced.SYNCED` (`"Synced"`)
 
-2. **Autolock Integration**:
+2. **Scheduling Notifications**:
+   - Always route updates through
+     `async_schedule_keymaster_notifications([entry_id])` rather than calling
+     entity callbacks or `async_set_updated_data` directly on the manager.
+
+3. **Autolock Integration**:
    - `autolock/` logic interacts with lock state changes and door sensors.
      Ensure timer cancellations and rescheduled locks are clean upon entity
      removal or coordinator unload.
 
-3. **Storage & Migrations**:
-   - Persistent data is managed in `migrate.py`.
+4. **Storage & Migrations**:
+   - Runtime storage is coordinator-owned via
+     `Store(hass, STORAGE_VERSION, STORAGE_KEY)`.
+   - `migrate.py` handles schema migrations only when loading legacy storage
+     formats.
    - When modifying storage schemas, bump the version and ensure backward
-     compatibility for existing HA installs upgrading from prior schema
-     revisions.
+     compatibility for prior schema revisions.

--- a/.agents/skills/ha-code-quality/SKILL.md
+++ b/.agents/skills/ha-code-quality/SKILL.md
@@ -2,8 +2,8 @@
 name: ha-code-quality
 description: >-
   Standards and commands for linting, code formatting, typing validation (Ruff,
-  MyPy, ESLint, Pre-commit), and adherence to Home Assistant Python 3.14
-  standards in Keymaster.
+  MyPy, Codespell, ESLint, Pre-commit/Prek, Tox), and adherence to Home Assistant
+  Python 3.14 standards in Keymaster.
 ---
 
 # Code Quality & Standards Guide for Keymaster
@@ -11,7 +11,18 @@ description: >-
 This skill guides linting, formatting, and static typing enforcement across the
 repository.
 
-## Python Code Quality (Ruff & MyPy)
+## Automated Quality Suite (Tox)
+
+Run the full CI lint environment:
+
+```bash
+tox -e lint
+```
+
+This runs Ruff linting, Ruff formatting check, MyPy across the entire repo
+(`mypy .`), and Codespell.
+
+## Individual Quality Tools
 
 Configuration is defined in `pyproject.toml`.
 
@@ -31,7 +42,14 @@ ruff format .
 ### Type Checking (MyPy)
 
 ```bash
-mypy custom_components/keymaster
+# Check both custom_components and tests
+mypy .
+```
+
+### Spell Checking (Codespell)
+
+```bash
+codespell custom_components/keymaster tests
 ```
 
 ## TypeScript / Frontend Linting
@@ -44,11 +62,15 @@ yarn lint
 yarn lint:fix
 ```
 
-## Pre-commit Hooks
+## Pre-commit / Prek Hooks
 
-Run pre-commit hooks before finalizing changes:
+Run pre-commit checks locally before committing:
 
 ```bash
+# Using prek (fast drop-in runner):
+prek run --all-files
+
+# Or using pre-commit:
 pre-commit run --all-files
 ```
 
@@ -57,6 +79,8 @@ pre-commit run --all-files
 - **Python Target**: Configured for Python 3.14 (`target-version = "py314"`).
   Use modern typing syntax (e.g. `list[str]`, `X | Y`,
   `from __future__ import annotations`).
+- **Line Length**: Strictly adhere to the **100-character line limit** configured
+  in `pyproject.toml`.
 - **Async Hygiene**: Use `async_create_task` or HA core async helpers; avoid
   blocking synchronous calls in the event loop.
 - **Docstrings & Comments**: Preserve existing docstrings and write clear

--- a/.agents/skills/ha-code-quality/SKILL.md
+++ b/.agents/skills/ha-code-quality/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: ha-code-quality
+description: >-
+  Standards and commands for linting, code formatting, typing validation (Ruff,
+  MyPy, ESLint, Pre-commit), and adherence to Home Assistant Python 3.14
+  standards in Keymaster.
+---
+
+# Code Quality & Standards Guide for Keymaster
+
+This skill guides linting, formatting, and static typing enforcement across the
+repository.
+
+## Python Code Quality (Ruff & MyPy)
+
+Configuration is defined in `pyproject.toml`.
+
+### Ruff Formatting & Linting
+
+```bash
+# Check linting errors
+ruff check .
+
+# Automatically apply safe fixes
+ruff check --fix .
+
+# Format code
+ruff format .
+```
+
+### Type Checking (MyPy)
+
+```bash
+mypy custom_components/keymaster
+```
+
+## TypeScript / Frontend Linting
+
+```bash
+# Check ESLint
+yarn lint
+
+# Fix ESLint issues
+yarn lint:fix
+```
+
+## Pre-commit Hooks
+
+Run pre-commit hooks before finalizing changes:
+
+```bash
+pre-commit run --all-files
+```
+
+## Guidelines
+
+- **Python Target**: Configured for Python 3.14 (`target-version = "py314"`).
+  Use modern typing syntax (e.g. `list[str]`, `X | Y`,
+  `from __future__ import annotations`).
+- **Async Hygiene**: Use `async_create_task` or HA core async helpers; avoid
+  blocking synchronous calls in the event loop.
+- **Docstrings & Comments**: Preserve existing docstrings and write clear
+  docstrings for new public methods and classes.

--- a/.agents/skills/ha-integration-testing/SKILL.md
+++ b/.agents/skills/ha-integration-testing/SKILL.md
@@ -2,7 +2,7 @@
 name: ha-integration-testing
 description: >-
   Workflows, conventions, and commands for writing and running async Home
-  Assistant unit and integration tests using pytest,
+  Assistant unit and integration tests using pytest, tox,
   pytest-homeassistant-custom-component, and coverage tools.
 ---
 
@@ -14,35 +14,43 @@ This skill provides patterns and commands for executing and writing tests in
 ## Running Tests
 
 Pytest options are configured in `pyproject.toml`. By default, tests filter out
-`slow` and `perf` markers.
+`slow` and `perf` markers (`addopts = "-m 'not slow and not perf'"`).
 
 ### Standard Test Execution Commands
 
 ```bash
-# Run all standard tests
+# Run all standard tests via pytest
 pytest
 
 # Run tests with verbose output
 pytest -v
 
-# Run a specific test file
-pytest tests/test_coordinator.py
+# Run targeted test file (use --cov-fail-under=0 so global 80% threshold
+# does not fail targeted run)
+pytest tests/test_coordinator.py --cov-fail-under=0
 
 # Run a specific test function
-pytest tests/test_coordinator.py::test_coordinator_update
+pytest tests/test_coordinator.py::test_coordinator_update --cov-fail-under=0
 
 # Run provider-specific tests
-pytest tests/providers/ -v
+pytest tests/providers/ -v --cov-fail-under=0
 
-# Run including slow/perf tests if explicitly needed
+# Run all tests including slow and perf tests
 pytest -m ""
+
+# Run test suite via tox (as run in CI)
+tox -e py314
 ```
 
 ### Coverage Requirements
 
-- Target coverage threshold is **80%** (enforced by `--cov-fail-under=80` in CI).
-- Review uncovered lines with
-  `pytest --cov=custom_components/keymaster --cov-report=term-missing`.
+- Target coverage threshold is **80%** (configured in `pyproject.toml` under
+  `[tool.coverage.report] fail_under = 80`).
+- Review uncovered lines with:
+
+  ```bash
+  pytest --cov=custom_components/keymaster --cov-report=term-missing
+  ```
 
 ## Key Test Patterns & Fixtures
 

--- a/.agents/skills/ha-integration-testing/SKILL.md
+++ b/.agents/skills/ha-integration-testing/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: ha-integration-testing
+description: >-
+  Workflows, conventions, and commands for writing and running async Home
+  Assistant unit and integration tests using pytest,
+  pytest-homeassistant-custom-component, and coverage tools.
+---
+
+# Home Assistant Integration Testing Guide for Keymaster
+
+This skill provides patterns and commands for executing and writing tests in
+`tests/`.
+
+## Running Tests
+
+Pytest options are configured in `pyproject.toml`. By default, tests filter out
+`slow` and `perf` markers.
+
+### Standard Test Execution Commands
+
+```bash
+# Run all standard tests
+pytest
+
+# Run tests with verbose output
+pytest -v
+
+# Run a specific test file
+pytest tests/test_coordinator.py
+
+# Run a specific test function
+pytest tests/test_coordinator.py::test_coordinator_update
+
+# Run provider-specific tests
+pytest tests/providers/ -v
+
+# Run including slow/perf tests if explicitly needed
+pytest -m ""
+```
+
+### Coverage Requirements
+
+- Target coverage threshold is **80%** (enforced by `--cov-fail-under=80` in CI).
+- Review uncovered lines with
+  `pytest --cov=custom_components/keymaster --cov-report=term-missing`.
+
+## Key Test Patterns & Fixtures
+
+1. **Async Tests**:
+   - `pytest.ini_options` sets `asyncio_mode = "auto"`. Use standard
+     `async def test_...` functions.
+
+2. **Home Assistant Fixtures**:
+   - Utilize `hass` fixture from `pytest-homeassistant-custom-component`.
+   - Setup mock config entries via
+     `pytest_homeassistant_custom_component.common.MockConfigEntry`.
+
+3. **Coordinator & Mock Providers**:
+   - Use mock providers (e.g. mocking `BaseLockProvider`) to simulate lock
+     state transitions, slot sync, and network disconnections.
+   - Advance time using `async_fire_time_changed` when testing autolock timers
+     or scheduled pin access windows.

--- a/.agents/skills/ha-lock-provider/SKILL.md
+++ b/.agents/skills/ha-lock-provider/SKILL.md
@@ -9,7 +9,8 @@ description: >-
 # Keymaster Lock Provider Development Guide
 
 This skill guides the implementation, extension, and testing of lock platform
-providers in `custom_components/keymaster/providers/`.
+providers in `custom_components/keymaster/providers/`. For general provider
+documentation, see `custom_components/keymaster/providers/PROVIDERS.md`.
 
 ## Architecture Overview
 
@@ -25,7 +26,8 @@ custom_components/keymaster/providers/
 ├── zha.py           # ZHA implementation
 ├── schlage.py       # Schlage implementation
 ├── akuvox.py        # Akuvox implementation
-└── const.py         # Provider-specific constants
+├── const.py         # Provider-specific constants
+└── PROVIDERS.md     # Integration provider documentation
 ```
 
 ## Implementing `BaseLockProvider`
@@ -35,10 +37,10 @@ When creating or modifying a provider:
 1. **Inherit from `BaseLockProvider`**:
 
    ```python
-   from dataclasses import dataclass, field
+   from dataclasses import dataclass
    from typing import TYPE_CHECKING
-   from homeassistant.core import Event
-   from ._base import BaseLockProvider, CodeSlot, LockEventCallback
+   from collections.abc import Callable
+   from ._base import BaseLockProvider, CodeSlot, LockEventCallback, ConnectionCallback
 
    if TYPE_CHECKING:
        from ..lock import KeymasterLock
@@ -54,21 +56,30 @@ When creating or modifying a provider:
    ```
 
 2. **Implement Required Abstract Methods**:
+   - `@property def domain(self) -> str`
+   - `async def async_connect(self) -> bool`
    - `async def async_is_connected(self) -> bool`
-   - `async def async_get_usercodes(self) -> dict[int, CodeSlot]`
+   - `async def async_get_usercodes(self) -> list[CodeSlot]`
    - `async def async_set_usercode(`
-     `self, code_slot: int, usercode: str, name: str | None = None) -> bool`
-   - `async def async_clear_usercode(self, code_slot: int) -> bool`
-   - `async def async_subscribe_events(`
-     `self, callback: LockEventCallback) -> CALLBACK_TYPE`
+     `self, slot_num: int, code: str, name: str | None = None) -> bool`
+   - `async def async_clear_usercode(self, slot_num: int) -> bool`
 
-3. **Register the Provider**:
+3. **Optional Event Subscriptions**:
+   - `subscribe_lock_events(kmlock, callback) -> Callable[[], None]`
+   - `subscribe_connection_events(callback) -> Callable[[], None]`
+
+4. **Register the Provider**:
    - In `custom_components/keymaster/providers/__init__.py`, import the
      provider class and map it in `PROVIDER_MAP`.
 
-4. **Error Handling**:
-   - Wrap platform-specific exceptions into `ProviderError` (or appropriate
-     custom exceptions from `custom_components/keymaster/exceptions.py`).
+5. **Error Handling**:
+   - Raise appropriate exceptions from `custom_components/keymaster/exceptions.py`:
+     - `LockDisconnected`
+     - `LockOperationFailed`
+     - `NotFoundError`
+     - `NotSupportedError`
+     - `NoNodeSpecifiedError`
+     - `ProviderNotConfiguredError`
    - Never allow unhandled third-party integration exceptions to crash the
      coordinator refresh loop.
 

--- a/.agents/skills/ha-lock-provider/SKILL.md
+++ b/.agents/skills/ha-lock-provider/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: ha-lock-provider
+description: >-
+  Guide for developing, testing, and maintaining lock platform providers
+  (e.g., zwave_js, zigbee2mqtt, zha, schlage, akuvox) implementing
+  BaseLockProvider in Keymaster.
+---
+
+# Keymaster Lock Provider Development Guide
+
+This skill guides the implementation, extension, and testing of lock platform
+providers in `custom_components/keymaster/providers/`.
+
+## Architecture Overview
+
+All lock providers must inherit from `BaseLockProvider` in
+`custom_components/keymaster/providers/_base.py`.
+
+```text
+custom_components/keymaster/providers/
+├── __init__.py      # Provider registry and factory
+├── _base.py         # BaseLockProvider ABC and CodeSlot dataclass
+├── zwave_js.py      # Z-Wave JS implementation
+├── zigbee2mqtt.py   # Zigbee2MQTT implementation
+├── zha.py           # ZHA implementation
+├── schlage.py       # Schlage implementation
+├── akuvox.py        # Akuvox implementation
+└── const.py         # Provider-specific constants
+```
+
+## Implementing `BaseLockProvider`
+
+When creating or modifying a provider:
+
+1. **Inherit from `BaseLockProvider`**:
+
+   ```python
+   from dataclasses import dataclass, field
+   from typing import TYPE_CHECKING
+   from homeassistant.core import Event
+   from ._base import BaseLockProvider, CodeSlot, LockEventCallback
+
+   if TYPE_CHECKING:
+       from ..lock import KeymasterLock
+
+   @dataclass
+   class CustomLockProvider(BaseLockProvider):
+       """Custom lock provider implementation."""
+
+       @property
+       def domain(self) -> str:
+           """Return the integration domain."""
+           return "custom_domain"
+   ```
+
+2. **Implement Required Abstract Methods**:
+   - `async def async_is_connected(self) -> bool`
+   - `async def async_get_usercodes(self) -> dict[int, CodeSlot]`
+   - `async def async_set_usercode(`
+     `self, code_slot: int, usercode: str, name: str | None = None) -> bool`
+   - `async def async_clear_usercode(self, code_slot: int) -> bool`
+   - `async def async_subscribe_events(`
+     `self, callback: LockEventCallback) -> CALLBACK_TYPE`
+
+3. **Register the Provider**:
+   - In `custom_components/keymaster/providers/__init__.py`, import the
+     provider class and map it in `PROVIDER_MAP`.
+
+4. **Error Handling**:
+   - Wrap platform-specific exceptions into `ProviderError` (or appropriate
+     custom exceptions from `custom_components/keymaster/exceptions.py`).
+   - Never allow unhandled third-party integration exceptions to crash the
+     coordinator refresh loop.
+
+## Testing Lock Providers
+
+- Provider unit tests live under `tests/providers/test_<provider>.py`.
+- Mock platform services/events rather than running live platform network
+  fixtures.
+- Test the following scenarios:
+  - Successful code slot set & clear
+  - Handling invalid/out-of-range slot numbers
+  - Disconnected platform state handling
+  - Event callback invocation on unlock/lock/pin events

--- a/.agents/skills/lovelace-strategy/SKILL.md
+++ b/.agents/skills/lovelace-strategy/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: lovelace-strategy
+description: >-
+  Workflows for developing, building, bundling, and testing the TypeScript / Lit
+  Lovelace dashboard strategy in lovelace_strategy/.
+---
+
+# Keymaster Lovelace Strategy Development Guide
+
+This skill guides development on the TypeScript/Lit custom strategy located in
+`lovelace_strategy/`.
+
+## Directory Layout & Assets
+
+- `lovelace_strategy/`: TypeScript source files for the Lovelace strategy.
+- `custom_components/keymaster/www/`: Destination directory for built
+  JavaScript bundle distribution.
+- `vitest.config.ts`: Vitest test runner configuration.
+- `rollup.config.js`: Rollup bundling configuration.
+- `scripts/compare_lovelace_output.py`: Verifies generated Lovelace dashboard
+  views.
+
+## Commands
+
+All frontend operations should be executed via `yarn`:
+
+```bash
+# Install dependencies
+yarn install
+
+# Run build / Rollup compilation
+yarn build
+
+# Run unit tests using Vitest
+yarn test
+
+# Run tests with coverage
+yarn test:coverage
+
+# Run ESLint on TypeScript files
+yarn lint
+
+# Auto-fix ESLint formatting/lint issues
+yarn lint:fix
+```
+
+## Testing Dashboard Generation
+
+When altering card definitions or view strategies:
+
+1. Run `yarn test` to verify Vitest unit specs.
+2. Build the bundle with `yarn build`.
+3. If applicable, run Python strategy comparison:
+
+   ```bash
+   python3 scripts/compare_lovelace_output.py
+   ```

--- a/.agents/skills/patch-coverage/SKILL.md
+++ b/.agents/skills/patch-coverage/SKILL.md
@@ -42,19 +42,22 @@ git diff upstream/main...HEAD custom_components/
 
 ### 2. Run Targeted Tests with Missing Line Reporting
 
-When running targeted tests on a single file or module, include `--cov-fail-under=0`
-so pytest does not fail due to the global 80% total coverage threshold:
+When running targeted tests on a single file or module, override `addopts` and
+pass `--cov-fail-under=0` so pytest scopes the terminal table to the target
+module without failing on the global 80% project threshold:
 
 ```bash
 # Example for provider modifications:
 pytest tests/providers/test_<provider>.py \
-  --cov=custom_components/keymaster/providers/<provider>.py \
+  -o addopts="-m 'not slow and not perf'" \
+  --cov=custom_components.keymaster.providers.<provider> \
   --cov-report=term-missing \
   --cov-fail-under=0
 
 # Example for coordinator modifications:
 pytest tests/test_coordinator.py \
-  --cov=custom_components/keymaster/coordinator.py \
+  -o addopts="-m 'not slow and not perf'" \
+  --cov=custom_components.keymaster.coordinator \
   --cov-report=term-missing \
   --cov-fail-under=0
 ```

--- a/.agents/skills/patch-coverage/SKILL.md
+++ b/.agents/skills/patch-coverage/SKILL.md
@@ -89,7 +89,9 @@ newly added or edited line numbers in your diff are left uncovered.
 ### 4. Assert Diagnostic Logging with `caplog`
 
 When testing diagnostic logging (especially `DEBUG` or `WARNING` messages),
-ensure `caplog.set_level` is set appropriately:
+ensure `caplog.set_level` is set appropriately. Note that provider-specific
+fixtures (such as `zwave_provider` and `mock_zwave_node`) are defined within
+their respective test modules (e.g. `tests/providers/test_zwave_js.py`):
 
 ```python
 import logging

--- a/.agents/skills/patch-coverage/SKILL.md
+++ b/.agents/skills/patch-coverage/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: patch-coverage
+description: >-
+  Procedure and guidelines for verifying and maintaining 100% patch test
+  coverage on all modified and added lines across Keymaster PRs and branches.
+---
+
+# Patch Coverage & Test Completeness Guide
+
+This skill provides step-by-step instructions for ensuring every change or
+bugfix introduced in Keymaster achieves **100% patch test coverage** (every
+modified/added line is exercised by automated tests) and satisfies repository
+quality gates.
+
+## Core Principles
+
+1. **100% Patch Coverage**:
+   - While overall project coverage threshold is `>= 80%`, every new line or
+     modified execution branch in a pull request should have corresponding unit
+     or integration test coverage.
+   - Codecov evaluates patch coverage on every PR and flags any un-executed
+     new lines.
+
+2. **Branch & Edge Case Completeness**:
+   - Cover both success (`True`, result objects) and failure branches (`False`,
+     `None`, exceptions).
+   - Test fallback and default paths (e.g. `_node_id` fallbacks when `_node` is
+     `None`, disconnected clients, missing entities).
+   - Test warning and error logging paths with pytest's `caplog` fixture to
+     verify diagnostic log statements fire when intended.
+
+---
+
+## Workflow for Verifying Patch Coverage
+
+### 1. Identify Changed Files and Lines
+
+Check your current git diff against the base branch (`upstream/main` or `main`):
+
+```bash
+git diff upstream/main...HEAD --stat
+git diff upstream/main...HEAD custom_components/
+```
+
+### 2. Run Targeted Tests with Missing Line Reporting
+
+Run pytest specifically covering the modified module:
+
+```bash
+# Example for provider modifications:
+pytest tests/providers/test_<provider>.py \
+  --cov=custom_components/keymaster/providers/<provider>.py \
+  --cov-report=term-missing
+
+# Example for coordinator modifications:
+pytest tests/test_coordinator.py \
+  --cov=custom_components/keymaster/coordinator.py \
+  --cov-report=term-missing
+```
+
+Look closely at the `Missing` column in the terminal output to confirm that no
+newly added or edited line numbers are listed.
+
+### 3. Common Uncovered Line Patterns & Solutions
+
+- **`if not self._node: return None/False`**:
+  - *Cause*: No test exercised the method when the provider is uninitialized
+    or disconnected.
+  - *Solution*: Add `test_<method>_no_node` asserting `None` or `False` when
+    `provider._node = None`.
+- **`except Exception as e: _LOGGER.warning(...)`**:
+  - *Cause*: Exception handling block was never triggered.
+  - *Solution*: Add a unit test with `side_effect=RuntimeError("test")` and
+    assert `caplog.text`.
+- **`node.node_id if node else self._node_id`**:
+  - *Cause*: Ternary fallback branch when `node` is `None` not reached.
+  - *Solution*: Add a test asserting `get_node_id()` returns `self._node_id`
+    when `_node` is `None`.
+- **Verification retry branch**:
+  - *Cause*: Logic handling transient write result or non-empty slot readback
+    not tested.
+  - *Solution*: Mock get/readback returning uncleared value and verify warning
+    log + return `False`.
+
+### 4. Assert Diagnostic Logging with `caplog`
+
+When adding warning/error logs, assert that the log messages are generated:
+
+```python
+async def test_operation_warns_when_dead(zwave_provider, mock_zwave_node, caplog):
+    """Test operation logs warning when node is dead."""
+    mock_zwave_node.status = NodeStatus.DEAD
+    zwave_provider._node = mock_zwave_node
+
+    result = await zwave_provider.async_clear_usercode(1)
+
+    assert result is False
+    assert "Node 14 is not alive, skipping clear_usercode for slot 1" in caplog.text
+```
+
+### 5. Final Full-Suite Verification
+
+Run the entire suite to verify overall coverage threshold and cross-module
+compatibility:
+
+```bash
+pytest --cov=custom_components/keymaster --cov-report=term-missing
+```
+
+Ensure total coverage meets repository requirements and patch coverage is 100%.

--- a/.agents/skills/patch-coverage/SKILL.md
+++ b/.agents/skills/patch-coverage/SKILL.md
@@ -8,18 +8,16 @@ description: >-
 # Patch Coverage & Test Completeness Guide
 
 This skill provides step-by-step instructions for ensuring every change or
-bugfix introduced in Keymaster achieves **100% patch test coverage** (every
-modified/added line is exercised by automated tests) and satisfies repository
-quality gates.
+bugfix introduced in Keymaster achieves thorough **patch test coverage** (exercising
+all modified/added lines) and satisfies repository quality gates.
 
 ## Core Principles
 
-1. **100% Patch Coverage**:
-   - While overall project coverage threshold is `>= 80%`, every new line or
-     modified execution branch in a pull request should have corresponding unit
-     or integration test coverage.
-   - Codecov evaluates patch coverage on every PR and flags any un-executed
-     new lines.
+1. **Patch Coverage & Quality Gates**:
+   - The repository configures an overall project test coverage floor of **>= 80%**
+     in `pyproject.toml` (`[tool.coverage.report] fail_under = 80`).
+   - Every new line or modified execution branch in a pull request should be
+     accompanied by automated tests to ensure no regressions or untested branches.
 
 2. **Branch & Edge Case Completeness**:
    - Cover both success (`True`, result objects) and failure branches (`False`,
@@ -44,22 +42,25 @@ git diff upstream/main...HEAD custom_components/
 
 ### 2. Run Targeted Tests with Missing Line Reporting
 
-Run pytest specifically covering the modified module:
+When running targeted tests on a single file or module, include `--cov-fail-under=0`
+so pytest does not fail due to the global 80% total coverage threshold:
 
 ```bash
 # Example for provider modifications:
 pytest tests/providers/test_<provider>.py \
   --cov=custom_components/keymaster/providers/<provider>.py \
-  --cov-report=term-missing
+  --cov-report=term-missing \
+  --cov-fail-under=0
 
 # Example for coordinator modifications:
 pytest tests/test_coordinator.py \
   --cov=custom_components/keymaster/coordinator.py \
-  --cov-report=term-missing
+  --cov-report=term-missing \
+  --cov-fail-under=0
 ```
 
-Look closely at the `Missing` column in the terminal output to confirm that no
-newly added or edited line numbers are listed.
+Inspect the `Missing` column in the terminal output to confirm that no
+newly added or edited line numbers in your diff are left uncovered.
 
 ### 3. Common Uncovered Line Patterns & Solutions
 
@@ -84,18 +85,23 @@ newly added or edited line numbers are listed.
 
 ### 4. Assert Diagnostic Logging with `caplog`
 
-When adding warning/error logs, assert that the log messages are generated:
+When testing diagnostic logging (especially `DEBUG` or `WARNING` messages),
+ensure `caplog.set_level` is set appropriately:
 
 ```python
-async def test_operation_warns_when_dead(zwave_provider, mock_zwave_node, caplog):
-    """Test operation logs warning when node is dead."""
+import logging
+from zwave_js_server.const import NodeStatus
+
+async def test_operation_skips_when_node_dead(zwave_provider, mock_zwave_node, caplog):
+    """Test operation logs debug message and returns False when node is dead."""
+    caplog.set_level(logging.DEBUG)
     mock_zwave_node.status = NodeStatus.DEAD
     zwave_provider._node = mock_zwave_node
 
     result = await zwave_provider.async_clear_usercode(1)
 
     assert result is False
-    assert "Node 14 is not alive, skipping clear_usercode for slot 1" in caplog.text
+    assert "[ZWaveJSProvider] Node 14 is dead, skipping command" in caplog.text
 ```
 
 ### 5. Final Full-Suite Verification
@@ -107,4 +113,8 @@ compatibility:
 pytest --cov=custom_components/keymaster --cov-report=term-missing
 ```
 
-Ensure total coverage meets repository requirements and patch coverage is 100%.
+Or run via tox:
+
+```bash
+tox -e py314
+```

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: submit-pr
+description: >-
+  Procedure for preparing and submitting pull requests in keymaster, enforcing
+  the required PR template (.github/PULL_REQUEST_TEMPLATE.md), checklist
+  validation, and quality gates.
+---
+
+# Pull Request Submission Guide for Keymaster
+
+This skill provides step-by-step instructions for preparing, validating, and
+submitting pull requests to the Keymaster repository.
+
+## Pre-PR Quality Gates Checklist
+
+Before creating a PR, ensure all verification steps pass locally:
+
+1. **Format & Linting**:
+
+   ```bash
+   ruff check --fix .
+   ruff format .
+   mypy custom_components/keymaster
+   ```
+
+2. **Frontend Build & Tests (if frontend modified)**:
+
+   ```bash
+   yarn lint
+   yarn test
+   yarn build
+   ```
+
+3. **Integration Tests & Coverage**:
+
+   ```bash
+   pytest --cov=custom_components/keymaster --cov-report=term-missing
+   ```
+
+   - Ensure all tests pass and coverage remains **>= 80%**.
+
+## Mandatory Pull Request Template
+
+Every pull request description **MUST** follow the repository template located
+at `.github/PULL_REQUEST_TEMPLATE.md`.
+
+### Required Sections & Rules
+
+1. **# Summary**:
+   - Provide a concise summary of the change and which issue is fixed or
+     linked.
+   - Include relevant motivation and context.
+
+2. **## Breaking change** *(Include ONLY if applicable; remove section if not
+   a breaking change)*:
+   - Clearly describe what breaks for existing users, why the change was made,
+     and how users can update their configurations to make it work.
+
+3. **## Proposed change**:
+   - Describe the architectural and functional changes to communicate to
+     maintainers why the PR should be accepted.
+
+4. **## Type of change**:
+   - Check **exactly one (1)** box from:
+     - `- [ ] Dependency upgrade`
+     - `- [ ] Bugfix (non-breaking change which fixes an issue)`
+     - `- [ ] New feature (which adds functionality)`
+     - `- [ ] Breaking change (fix/feature causing existing functionality to break)`
+     - `- [ ] Code quality improvements to existing code or addition of tests`
+   - *Note*: If changes require multiple boxes, split the work into separate
+     PRs.
+
+5. **## Additional information**:
+   - Link related or closed issues:
+     - `This PR fixes or closes issue: fixes #<issue_number>`
+     - `This PR is related to issue: #<issue_number>`
+
+## Template Format Reference
+
+```markdown
+# Summary
+<!-- Summary of changes, motivation, and context -->
+
+## Breaking change
+<!-- Only include if breaking change, otherwise omit -->
+
+## Proposed change
+<!-- Big picture explanation of the changes -->
+
+## Type of change
+- [ ] Dependency upgrade
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (which adds functionality)
+- [ ] Breaking change (fix/feature causing existing functionality to break)
+- [ ] Code quality improvements to existing code or addition of tests
+
+## Additional information
+- This PR fixes or closes issue: fixes #
+- This PR is related to issue:
+```

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -37,7 +37,8 @@ Before creating a PR, ensure all verification steps pass locally:
    pytest --cov=custom_components/keymaster --cov-report=term-missing
    ```
 
-   - Ensure all tests pass and coverage remains **>= 80%**.
+   - Ensure all tests pass, overall project coverage remains **>= 80%**, and
+     patch coverage on new/modified lines is **100%** (see `patch-coverage` skill).
 
 ## Mandatory Pull Request Template
 

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -15,12 +15,17 @@ submitting pull requests to the Keymaster repository.
 
 Before creating a PR, ensure all verification steps pass locally:
 
-1. **Format & Linting**:
+1. **Format, Linting & Type Checking**:
 
    ```bash
+   # Run full CI lint environment via tox:
+   tox -e lint
+
+   # Or run individual tools:
    ruff check --fix .
    ruff format .
-   mypy custom_components/keymaster
+   mypy .
+   codespell custom_components/keymaster tests
    ```
 
 2. **Frontend Build & Tests (if frontend modified)**:
@@ -34,11 +39,16 @@ Before creating a PR, ensure all verification steps pass locally:
 3. **Integration Tests & Coverage**:
 
    ```bash
+   # Run standard test suite
    pytest --cov=custom_components/keymaster --cov-report=term-missing
+
+   # Or run via tox:
+   tox -e py314
    ```
 
-   - Ensure all tests pass, overall project coverage remains **>= 80%**, and
-     patch coverage on new/modified lines is **100%** (see `patch-coverage` skill).
+   - Ensure all tests pass, overall project coverage remains **>= 80%**
+     (`[tool.coverage.report] fail_under = 80`), and all newly modified/added lines
+     have thorough test coverage (see `patch-coverage` skill).
 
 ## Mandatory Pull Request Template
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Keymaster Agent Instructions
+
+## Repository Overview
+
+Keymaster is a Home Assistant custom integration that manages lock user
+codes, access schedules, and notifications across multiple lock providers
+(`zwave_js`, `zigbee2mqtt`, `zha`, `schlage`, `akuvox`) with a bundled
+TypeScript/Lit Lovelace dashboard strategy.
+
+## Core Rules & Quality Standards
+
+- **Python Version**: Target Python 3.14 standards (`pyproject.toml`).
+  Use modern typing (`list[str]`, `X | Y`, `from __future__ import annotations`).
+- **Async Conventions**: Keymaster is an asynchronous Home Assistant integration.
+  Always use async Home Assistant primitives (`async_create_task`, async event
+  listeners) and avoid blocking synchronous I/O on the event loop.
+- **Test Coverage**: Maintain test coverage at or above **80%**
+  (`pytest --cov=custom_components/keymaster --cov-report=term-missing`).
+- **Linting & Formatting**: Ensure `ruff check --fix .` and `ruff format .`
+  pass cleanly on Python code, and `mypy custom_components/keymaster` passes.
+  For changes under `lovelace_strategy/`, run `yarn lint` and `yarn test`.
+- **PR Template**: When drafting or submitting PRs, strictly follow
+  `.github/PULL_REQUEST_TEMPLATE.md` and select exactly one type of change.
+
+## Available Agent Skills
+
+When performing specialized workflows, refer to the corresponding skill in
+`.agents/skills/`:
+
+- **`ha-lock-provider`**: For developing, testing, and debugging lock platform
+  providers inheriting from `BaseLockProvider`.
+- **`ha-integration-testing`**: For writing and running pytest test suites with
+  Home Assistant custom component fixtures.
+- **`lovelace-strategy`**: For TypeScript/Lit frontend strategy development,
+  Vitest tests, and bundling into `custom_components/keymaster/www/`.
+- **`ha-code-quality`**: For Ruff, MyPy, ESLint, and pre-commit checks.
+- **`coordinator-lifecycle`**: For `KeymasterCoordinator` state machine, child
+  entity platforms, autolock, and storage migrations.
+- **`submit-pr`**: For preparing, validating, and submitting pull requests
+  according to repo requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,14 +11,20 @@ TypeScript/Lit Lovelace dashboard strategy.
 
 - **Python Version**: Target Python 3.14 standards (`pyproject.toml`).
   Use modern typing (`list[str]`, `X | Y`, `from __future__ import annotations`).
+- **Code Style & Line Length**: Adhere to the **100-character line length limit**
+  configured in Ruff.
 - **Async Conventions**: Keymaster is an asynchronous Home Assistant integration.
   Always use async Home Assistant primitives (`async_create_task`, async event
   listeners) and avoid blocking synchronous I/O on the event loop.
-- **Test Coverage**: Maintain test coverage at or above **80%**
-  (`pytest --cov=custom_components/keymaster --cov-report=term-missing`).
-- **Linting & Formatting**: Ensure `ruff check --fix .` and `ruff format .`
-  pass cleanly on Python code, and `mypy custom_components/keymaster` passes.
-  For changes under `lovelace_strategy/`, run `yarn lint` and `yarn test`.
+- **Test Coverage**: Maintain overall test coverage at or above **80%**
+  (`[tool.coverage.report] fail_under = 80`). Aim for 100% patch coverage on
+  modified lines.
+- **Linting & Quality Gates**: Ensure `tox -e lint` (or `ruff check --fix .`,
+  `ruff format .`, `mypy .`, and `codespell custom_components/keymaster tests`)
+  passes cleanly. For changes under `lovelace_strategy/`, run `yarn lint` and
+  `yarn test`.
+- **Pre-commit / Prek**: Local checks can be run with `prek run --all-files` or
+  `pre-commit run --all-files`.
 - **PR Template**: When drafting or submitting PRs, strictly follow
   `.github/PULL_REQUEST_TEMPLATE.md` and select exactly one type of change.
 
@@ -28,15 +34,15 @@ When performing specialized workflows, refer to the corresponding skill in
 `.agents/skills/`:
 
 - **`ha-lock-provider`**: For developing, testing, and debugging lock platform
-  providers inheriting from `BaseLockProvider`.
+  providers inheriting from `BaseLockProvider` (see also `PROVIDERS.md`).
 - **`ha-integration-testing`**: For writing and running pytest test suites with
-  Home Assistant custom component fixtures.
+  Home Assistant custom component fixtures and tox.
 - **`lovelace-strategy`**: For TypeScript/Lit frontend strategy development,
   Vitest tests, and bundling into `custom_components/keymaster/www/`.
-- **`ha-code-quality`**: For Ruff, MyPy, ESLint, and pre-commit checks.
-- **`coordinator-lifecycle`**: For `KeymasterCoordinator` state machine, child
-  entity platforms, autolock, and storage migrations.
-- **`patch-coverage`**: For verifying and maintaining 100% patch test coverage
+- **`ha-code-quality`**: For Ruff, MyPy, Codespell, ESLint, Prek, and Tox checks.
+- **`coordinator-lifecycle`**: For `KeymasterCoordinator` and `KeymasterLockCoordinator`
+  fanout architecture, entity platforms, autolock, and storage migrations.
+- **`patch-coverage`**: For verifying and maintaining patch test coverage
   on all modified lines and branches.
 - **`submit-pr`**: For preparing, validating, and submitting pull requests
   according to repo requirements.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,5 +36,7 @@ When performing specialized workflows, refer to the corresponding skill in
 - **`ha-code-quality`**: For Ruff, MyPy, ESLint, and pre-commit checks.
 - **`coordinator-lifecycle`**: For `KeymasterCoordinator` state machine, child
   entity platforms, autolock, and storage migrations.
+- **`patch-coverage`**: For verifying and maintaining 100% patch test coverage
+  on all modified lines and branches.
 - **`submit-pr`**: For preparing, validating, and submitting pull requests
   according to repo requirements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ prek install
 ```
 
 Note: `prek` is a fast local runner that reads `.pre-commit-config.yaml`.
-GitHub CI automatically runs `prek` and `pre-commit.ci`.
+GitHub CI automatically runs `prek`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,8 @@ source .venv/bin/activate
 # Install development, test, and lint dependencies
 pip install -r requirements_dev.txt -r requirements_test.txt -r requirements_lint.txt
 
-# Or using uv:
-uv sync
+# Or using uv pip:
+uv pip install -r requirements_dev.txt -r requirements_test.txt -r requirements_lint.txt
 ```
 
 ### 2. Frontend Environment (Lovelace Strategy)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Keymaster consists of:
 
 ### 1. Python Environment
 
-Ensure Python 3.13 or 3.14 is installed. Set up a virtual environment:
+Ensure Python 3.14 is installed. Set up a virtual environment:
 
 ```bash
 # Create and activate virtual environment
@@ -40,21 +40,46 @@ Ensure Node.js and Yarn are installed:
 yarn install
 ```
 
-### 3. Pre-Commit Hooks
+### 3. Pre-Commit / Prek Hooks
 
-Install pre-commit hooks to automatically check lint and formatting on commit:
+Install pre-commit or prek hooks to automatically check lint and formatting on commit:
 
 ```bash
+# Using pre-commit:
 pre-commit install
+
+# Or using prek (fast Rust-based drop-in runner):
+prek install
 ```
+
+Note: `prek` is a fast local runner that reads `.pre-commit-config.yaml`.
+GitHub CI automatically runs `prek` and `pre-commit.ci`.
 
 ---
 
 ## Coding Standards & Quality Gates
 
-Before submitting any code, all quality gates must pass cleanly.
+Before submitting any code, all quality gates must pass cleanly. Adhere to the
+**100-character line length limit** enforced across Python files.
 
-### Python (Ruff & MyPy)
+### Automated Quality Gates (Tox)
+
+Keymaster uses `tox` in CI to run tests and linter suites:
+
+```bash
+# Run all CI test and lint environments
+tox
+
+# Run only the lint suite
+tox -e lint
+
+# Run only the Python 3.14 pytest suite
+tox -e py314
+```
+
+### Python (Ruff, MyPy & Codespell)
+
+You can also run individual tools directly:
 
 - **Formatting & Linting**:
 
@@ -69,7 +94,13 @@ Before submitting any code, all quality gates must pass cleanly.
 - **Type Checking**:
 
   ```bash
-  mypy custom_components/keymaster
+  mypy .
+  ```
+
+- **Spell Checking**:
+
+  ```bash
+  codespell custom_components/keymaster tests
   ```
 
 - **Async Hygiene**: Use `async_create_task` and Home Assistant async helpers.
@@ -94,19 +125,23 @@ Before submitting any code, all quality gates must pass cleanly.
 
 ## Testing
 
-Keymaster enforces automated testing with a minimum of **80% code coverage**.
+Keymaster enforces automated testing with a minimum of **80% code coverage**
+(configured in `pyproject.toml` under `[tool.coverage.report] fail_under = 80`).
 
 ### Backend Integration Tests (Pytest)
 
 ```bash
-# Run test suite
+# Run standard test suite (excludes slow and perf tests)
 pytest
 
 # Run tests with terminal coverage report
 pytest --cov=custom_components/keymaster --cov-report=term-missing
 
-# Run a specific test file
-pytest tests/test_coordinator.py
+# Run a specific test file (use --cov-fail-under=0 for targeted runs)
+pytest tests/test_coordinator.py --cov-fail-under=0
+
+# Run all tests including slow and perf markers
+pytest -m ""
 ```
 
 ### Frontend Tests (Vitest)
@@ -142,5 +177,5 @@ python3 scripts/compare_lovelace_output.py
    - `Code quality improvements to existing code or addition of tests`
 4. **Link Relevant Issues**: Reference any corresponding issue numbers
    (`fixes #123` or `related to #123`).
-5. **Passing CI**: Ensure all GitHub Actions workflows (Pytest, Vitest, Ruff,
-   MyPy, Yarn) pass.
+5. **Passing CI**: Ensure all GitHub Actions workflows (Tox, Pytest, Prek,
+   Codecov, Yarn) pass.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,10 @@ python3 -m venv .venv
 source .venv/bin/activate
 
 # Install development, test, and lint dependencies
-pip install -r requirements_dev.txt -r requirements_test.txt -r requirements_lint.txt
+pip install -r requirements_dev.txt
 
 # Or using uv pip:
-uv pip install -r requirements_dev.txt -r requirements_test.txt -r requirements_lint.txt
+uv pip install -r requirements_dev.txt
 ```
 
 ### 2. Frontend Environment (Lovelace Strategy)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,146 @@
+# Contributing to Keymaster
+
+Thank you for your interest in contributing to Keymaster! This guide explains how
+to set up your development environment, run tests, adhere to code quality
+standards, and submit pull requests.
+
+---
+
+## Development Environment Setup
+
+Keymaster consists of:
+
+1. **Python / Home Assistant Backend**: Custom integration targeting Python 3.14
+   standards.
+2. **TypeScript / Lit Frontend**: Custom Lovelace dashboard strategy in
+   `lovelace_strategy/`.
+
+### 1. Python Environment
+
+Ensure Python 3.13 or 3.14 is installed. Set up a virtual environment:
+
+```bash
+# Create and activate virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Install development, test, and lint dependencies
+pip install -r requirements_dev.txt -r requirements_test.txt -r requirements_lint.txt
+
+# Or using uv:
+uv sync
+```
+
+### 2. Frontend Environment (Lovelace Strategy)
+
+Ensure Node.js and Yarn are installed:
+
+```bash
+# Install frontend dependencies
+yarn install
+```
+
+### 3. Pre-Commit Hooks
+
+Install pre-commit hooks to automatically check lint and formatting on commit:
+
+```bash
+pre-commit install
+```
+
+---
+
+## Coding Standards & Quality Gates
+
+Before submitting any code, all quality gates must pass cleanly.
+
+### Python (Ruff & MyPy)
+
+- **Formatting & Linting**:
+
+  ```bash
+  # Check and fix lint issues
+  ruff check --fix .
+
+  # Format python files
+  ruff format .
+  ```
+
+- **Type Checking**:
+
+  ```bash
+  mypy custom_components/keymaster
+  ```
+
+- **Async Hygiene**: Use `async_create_task` and Home Assistant async helpers.
+  Never perform blocking synchronous I/O on the event loop.
+
+### Frontend (TypeScript, ESLint & Vitest)
+
+- **Linting & Formatting**:
+
+  ```bash
+  yarn lint
+  yarn lint:fix
+  ```
+
+- **Building Strategy Bundle**:
+
+  ```bash
+  yarn build
+  ```
+
+---
+
+## Testing
+
+Keymaster enforces automated testing with a minimum of **80% code coverage**.
+
+### Backend Integration Tests (Pytest)
+
+```bash
+# Run test suite
+pytest
+
+# Run tests with terminal coverage report
+pytest --cov=custom_components/keymaster --cov-report=term-missing
+
+# Run a specific test file
+pytest tests/test_coordinator.py
+```
+
+### Frontend Tests (Vitest)
+
+```bash
+# Run Vitest test runner
+yarn test
+
+# Run frontend tests with coverage
+yarn test:coverage
+```
+
+### Verify Lovelace Strategy Output
+
+```bash
+python3 scripts/compare_lovelace_output.py
+```
+
+---
+
+## Submitting Pull Requests
+
+1. **Focus on a Single Change**: Keep PRs focused. If your work addresses
+   multiple unrelated topics, please split them into separate pull requests.
+2. **Mandatory PR Template**: All PR descriptions must follow
+   [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+3. **Select One Change Type**: In the PR template checklist, check **exactly
+   one** box:
+   - `Dependency upgrade`
+   - `Bugfix (non-breaking change which fixes an issue)`
+   - `New feature (which adds functionality)`
+   - `Breaking change (fix/feature causing existing functionality to break)`
+   - `Code quality improvements to existing code or addition of tests`
+4. **Link Relevant Issues**: Reference any corresponding issue numbers
+   (`fixes #123` or `related to #123`).
+5. **Passing CI**: Ensure all GitHub Actions workflows (Pytest, Vitest, Ruff,
+   MyPy, Yarn) pass.


### PR DESCRIPTION
# Summary

This PR adds repository-level agent customizations (`AGENTS.md` and tailored skills under `.agents/skills/`) as well as a comprehensive `CONTRIBUTING.md` guide for Keymaster contributors and agent pair-programmers.

## Proposed change

- Adds `.agents/skills/` containing on-demand procedural runbooks:
  - `ha-lock-provider`: Lock platform provider implementation and testing guide.
  - `ha-integration-testing`: Async Home Assistant unit and integration test workflows.
  - `patch-coverage`: Procedure for verifying and maintaining 100% patch test coverage on all modified lines/branches.
  - `lovelace-strategy`: TypeScript/Lit frontend build and Vitest suite instructions.
  - `ha-code-quality`: Ruff, MyPy, and ESLint quality standards.
  - `coordinator-lifecycle`: Coordinator state machine and entity platform conventions.
  - `submit-pr`: Pull request preparation, checklist validation, and PR template enforcement.
- Adds `AGENTS.md` providing baseline instructions and quality standards.
- Adds `CONTRIBUTING.md` providing setup instructions, quality gate requirements, testing workflows, and PR submission guidelines for human and AI contributors.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #712
- This PR is related to issue:
