### PR TITLE
fix(zwave_js): add dynamic node resolution and diagnostic logging for usercode operations (#665)

### DIFF
--- a/custom_components/keymaster/providers/zwave_js.py
+++ b/custom_components/keymaster/providers/zwave_js.py
@@ -329,15 +329,13 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
     def _get_node(self) -> ZwaveJSNode | None:
         """Get the current Z-Wave node instance, refreshing if needed."""
-        if (
-            self._node_id is not None
-            and self._client
-            and self._client.driver
-            and self._client.driver.controller
-        ):
-            live_node = self._client.driver.controller.nodes.get(self._node_id)
-            if live_node is not None:
-                self._node = live_node
+        if self._node_id is None:
+            return self._node
+        if self._client and self._client.driver and self._client.driver.controller:
+            # The controller registry is authoritative when reachable, including
+            # for removals: a node popped by handle_node_removed has client=None
+            # and must not be used for commands.
+            self._node = self._client.driver.controller.nodes.get(self._node_id)
         return self._node
 
     def _is_node_alive(self) -> bool:
@@ -355,7 +353,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
             return False
         try:
             if node.status == NodeStatus.DEAD:
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "[ZWaveJSProvider] Node %s is dead, skipping command",
                     node.node_id,
                 )
@@ -378,7 +376,13 @@ class ZWaveJSLockProvider(BaseLockProvider):
             return False
         try:
             return await node.async_ping()
-        except Exception:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning(
+                "[ZWaveJSProvider] Ping failed for node %s: %s: %s",
+                node.node_id,
+                e.__class__.__qualname__,
+                e,
+            )
             return False
 
     @property

--- a/custom_components/keymaster/providers/zwave_js.py
+++ b/custom_components/keymaster/providers/zwave_js.py
@@ -322,9 +322,23 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
     # Platform-specific state
     _node: ZwaveJSNode | None = field(default=None, init=False, repr=False)
+    _node_id: int | None = field(default=None, init=False, repr=False)
     _device: DeviceEntry | None = field(default=None, init=False, repr=False)
     _client: ZwaveJSClient | None = field(default=None, init=False, repr=False)
     _uses_credential_cc: bool = field(default=False, init=False, repr=False)
+
+    def _get_node(self) -> ZwaveJSNode | None:
+        """Get the current Z-Wave node instance, refreshing if needed."""
+        if (
+            self._node_id is not None
+            and self._client
+            and self._client.driver
+            and self._client.driver.controller
+        ):
+            live_node = self._client.driver.controller.nodes.get(self._node_id)
+            if live_node is not None:
+                self._node = live_node
+        return self._node
 
     def _is_node_alive(self) -> bool:
         """Check if the Z-Wave node is alive (not dead).
@@ -332,26 +346,38 @@ class ZWaveJSLockProvider(BaseLockProvider):
         Returns False only for dead nodes. Asleep nodes (battery devices)
         are considered alive since they wake periodically.
         """
-        if not self._node:
+        node = self._get_node()
+        if not node:
+            _LOGGER.warning(
+                "[ZWaveJSProvider] Node %s is not available",
+                self._node_id if self._node_id is not None else "unknown",
+            )
             return False
         try:
-            if self._node.status == NodeStatus.DEAD:
-                _LOGGER.debug(
+            if node.status == NodeStatus.DEAD:
+                _LOGGER.warning(
                     "[ZWaveJSProvider] Node %s is dead, skipping command",
-                    self._node.node_id,
+                    node.node_id,
                 )
                 return False
-        except Exception:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning(
+                "[ZWaveJSProvider] Error checking status for node %s: %s: %s",
+                node.node_id,
+                e.__class__.__qualname__,
+                e,
+            )
             return False
         else:
             return True
 
     async def async_ping_node(self) -> bool:
         """Ping the Z-Wave node to check if it is responsive."""
-        if not self._node:
+        node = self._get_node()
+        if not node:
             return False
         try:
-            return await self._node.async_ping()
+            return await node.async_ping()
         except Exception:  # noqa: BLE001
             return False
 
@@ -373,7 +399,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
     @property
     def node(self) -> ZwaveJSNode | None:
         """Return the Z-Wave JS node."""
-        return self._node
+        return self._get_node()
 
     @property
     def device(self) -> DeviceEntry | None:
@@ -465,6 +491,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
             )
             return False
 
+        self._node_id = node_id
         self._node = self._client.driver.controller.nodes.get(node_id)
         if not self._node:
             _LOGGER.error(
@@ -509,11 +536,12 @@ class ZWaveJSLockProvider(BaseLockProvider):
         if not self._client:
             return False
 
+        node = self._get_node()
         connected = bool(
             self._client.connected
             and self._client.driver
             and self._client.driver.controller
-            and self._node,
+            and node,
         )
 
         self._connected = connected
@@ -539,12 +567,13 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
     async def _verify_credential_state(self, slot_num: int, expect_present: bool) -> bool:
         """Re-read a credential slot after a transient write result."""
-        if not self._node:
+        node = self._get_node()
+        if not node:
             return False
 
         try:
-            user = await self._node.access_control.get_user(slot_num)
-            credentials = await self._node.access_control.get_credentials(slot_num)
+            user = await node.access_control.get_user(slot_num)
+            credentials = await node.access_control.get_credentials(slot_num)
         except BaseZwaveJSServerError as e:
             _LOGGER.debug(
                 "[ZWaveJSProvider] Verify failed for slot %s: %s",
@@ -560,14 +589,15 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
     async def async_get_usercodes(self) -> list[CodeSlot]:
         """Get all user codes from the Z-Wave JS lock."""
-        if not self._node:
+        node = self._get_node()
+        if not node:
             _LOGGER.error("[ZWaveJSProvider] No node available for get_usercodes")
             return []
 
         if self._uses_credential_cc:
             try:
-                users = await self._node.access_control.get_users_cached()
-                credentials = await self._node.access_control.get_all_credentials_cached()
+                users = await node.access_control.get_users_cached()
+                credentials = await node.access_control.get_all_credentials_cached()
             except BaseZwaveJSServerError as e:
                 _LOGGER.error(
                     "[ZWaveJSProvider] Failed to get credentials: %s: %s",
@@ -590,7 +620,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
             ]
 
         try:
-            zwave_codes = get_usercodes(self._node)
+            zwave_codes = get_usercodes(node)
         except FailedZWaveCommand as e:
             _LOGGER.error(
                 "[ZWaveJSProvider] Failed to get usercodes: %s: %s",
@@ -618,15 +648,17 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
     async def async_get_usercode(self, slot_num: int) -> CodeSlot | None:
         """Get a specific user code from the lock."""
-        if not self._node:
+        node = self._get_node()
+        if not node:
+            _LOGGER.warning("[ZWaveJSProvider] No node available for get_usercode")
             return None
 
         if self._uses_credential_cc:
             try:
-                user = await self._node.access_control.get_user_cached(slot_num)
+                user = await node.access_control.get_user_cached(slot_num)
                 if user is None:
                     return CodeSlot(slot_num=slot_num, code=None, in_use=False)
-                credentials = await self._node.access_control.get_credentials_cached(slot_num)
+                credentials = await node.access_control.get_credentials_cached(slot_num)
             except BaseZwaveJSServerError as e:
                 _LOGGER.error(
                     "[ZWaveJSProvider] Failed to get credential for slot %s: %s: %s",
@@ -638,7 +670,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
             return self._credential_to_code_slot(user, credentials, slot_num)
 
         try:
-            zw_slot: ZwaveJSCodeSlot = get_usercode(self._node, slot_num)
+            zw_slot: ZwaveJSCodeSlot = get_usercode(node, slot_num)
             return CodeSlot(
                 slot_num=slot_num,
                 code=zw_slot[ZWAVEJS_ATTR_USERCODE] or None,
@@ -655,18 +687,25 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
     async def async_refresh_usercode(self, slot_num: int) -> CodeSlot | None:
         """Get a specific user code directly from the node (forces refresh)."""
-        if not self._node:
+        node = self._get_node()
+        if not node:
+            _LOGGER.warning("[ZWaveJSProvider] No node available for refresh_usercode")
             return None
 
         if not self._is_node_alive():
+            _LOGGER.warning(
+                "[ZWaveJSProvider] Node %s is not alive, skipping refresh_usercode for slot %s",
+                node.node_id,
+                slot_num,
+            )
             return None
 
         if self._uses_credential_cc:
             try:
-                user = await self._node.access_control.get_user(slot_num)
+                user = await node.access_control.get_user(slot_num)
                 if user is None:
                     return CodeSlot(slot_num=slot_num, code=None, in_use=False)
-                credentials = await self._node.access_control.get_credentials(slot_num)
+                credentials = await node.access_control.get_credentials(slot_num)
             except BaseZwaveJSServerError as e:
                 _LOGGER.error(
                     "[ZWaveJSProvider] Failed to refresh credential for slot %s: %s: %s",
@@ -678,7 +717,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
             return self._credential_to_code_slot(user, credentials, slot_num)
 
         try:
-            zw_slot: ZwaveJSCodeSlot = await get_usercode_from_node(self._node, slot_num)
+            zw_slot: ZwaveJSCodeSlot = await get_usercode_from_node(node, slot_num)
             return CodeSlot(
                 slot_num=slot_num,
                 code=zw_slot[ZWAVEJS_ATTR_USERCODE] or None,
@@ -695,16 +734,22 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
     async def async_set_usercode(self, slot_num: int, code: str, name: str | None = None) -> bool:
         """Set user code on a slot."""
-        if not self._node:
+        node = self._get_node()
+        if not node:
             _LOGGER.error("[ZWaveJSProvider] No node available for set_usercode")
             return False
 
         if not self._is_node_alive():
+            _LOGGER.warning(
+                "[ZWaveJSProvider] Node %s is not alive, skipping set_usercode for slot %s",
+                node.node_id,
+                slot_num,
+            )
             return False
 
         if self._uses_credential_cc:
             try:
-                credential_result = await self._node.access_control.set_credential(
+                credential_result = await node.access_control.set_credential(
                     slot_num,
                     UserCredentialType.PIN_CODE,
                     slot_num,
@@ -739,7 +784,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
             if name:
                 try:
-                    user_result = await self._node.access_control.set_user(
+                    user_result = await node.access_control.set_user(
                         slot_num,
                         SetUserOptions(user_name=name),
                     )
@@ -764,7 +809,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
             return True
 
         try:
-            await set_usercode(self._node, slot_num, code)
+            await set_usercode(node, slot_num, code)
         except BaseZwaveJSServerError as e:
             _LOGGER.error(
                 "[ZWaveJSProvider] Failed to set usercode on slot %s: %s: %s",
@@ -782,16 +827,22 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
     async def async_clear_usercode(self, slot_num: int) -> bool:
         """Clear user code from a slot."""
-        if not self._node:
+        node = self._get_node()
+        if not node:
             _LOGGER.error("[ZWaveJSProvider] No node available for clear_usercode")
             return False
 
         if not self._is_node_alive():
+            _LOGGER.warning(
+                "[ZWaveJSProvider] Node %s is not alive, skipping clear_usercode for slot %s",
+                node.node_id,
+                slot_num,
+            )
             return False
 
         if self._uses_credential_cc:
             try:
-                credential_result = await self._node.access_control.delete_credential(
+                credential_result = await node.access_control.delete_credential(
                     slot_num,
                     UserCredentialType.PIN_CODE,
                     slot_num,
@@ -811,7 +862,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
                     )
                     return False
 
-                user_result = await self._node.access_control.delete_user(slot_num)
+                user_result = await node.access_control.delete_user(slot_num)
                 # LOCATION_EMPTY means the user was already absent, which is the
                 # desired post-condition for a clear operation.
                 ok_user_results = (
@@ -852,7 +903,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
             return False
 
         try:
-            await clear_usercode(self._node, slot_num)
+            await clear_usercode(node, slot_num)
         except BaseZwaveJSServerError as e:
             _LOGGER.error(
                 "[ZWaveJSProvider] Failed to clear usercode on slot %s: %s: %s",
@@ -869,7 +920,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
         # Verify the code was cleared
         try:
-            usercode = get_usercode(self._node, slot_num)
+            usercode = get_usercode(node, slot_num)
         except BaseZwaveJSServerError as e:
             _LOGGER.error(
                 "[ZWaveJSProvider] Failed to verify clear on slot %s: %s: %s",
@@ -882,8 +933,8 @@ class ZWaveJSLockProvider(BaseLockProvider):
         # Treat both "" and full string of "0" as cleared (Schlage BE469 firmware bug workaround)
         code_value = str(usercode.get(ZWAVEJS_ATTR_USERCODE) or "")
         if code_value not in ("", "0" * len(code_value)):
-            _LOGGER.debug(
-                "[ZWaveJSProvider] Slot %s not yet cleared, will retry",
+            _LOGGER.warning(
+                "[ZWaveJSProvider] Slot %s not yet cleared after command, will retry",
                 slot_num,
             )
             return False
@@ -962,12 +1013,13 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
         async def handle_zwave_notification_event(event: Event) -> None:
             """Handle Z-Wave JS notification event."""
-            if not self._node or not self._device:
+            node = self._get_node()
+            if not node or not self._device:
                 return
 
             # Verify this event is for our lock
             if (
-                event.data.get(ATTR_NODE_ID) != self._node.node_id
+                event.data.get(ATTR_NODE_ID) != node.node_id
                 or event.data.get(ATTR_DEVICE_ID) != self._device.id
             ):
                 return
@@ -1118,14 +1170,16 @@ class ZWaveJSLockProvider(BaseLockProvider):
 
     def get_node_id(self) -> int | None:
         """Get the Z-Wave node ID."""
-        return self._node.node_id if self._node else None
+        node = self._get_node()
+        return node.node_id if node else self._node_id
 
     def get_node_status(self) -> str | None:
         """Get the Z-Wave node status."""
-        if not self._node:
+        node = self._get_node()
+        if not node:
             return None
         try:
-            node_state = dump_node_state(self._node)
+            node_state = dump_node_state(node)
             return node_state.get("status")
         except Exception:  # noqa: BLE001
             return None

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -1646,14 +1646,17 @@ class TestZWaveJSLockProviderPingNode:
 
         assert result is False
 
-    async def test_ping_node_returns_false_on_exception(self, zwave_provider, mock_zwave_node):
-        """Test async_ping_node returns False when an exception occurs."""
+    async def test_ping_node_returns_false_on_exception(
+        self, zwave_provider, mock_zwave_node, caplog
+    ):
+        """Test async_ping_node returns False and logs warning when an exception occurs."""
         mock_zwave_node.async_ping = AsyncMock(side_effect=RuntimeError("network error"))
         zwave_provider._node = mock_zwave_node
 
         result = await zwave_provider.async_ping_node()
 
         assert result is False
+        assert "Ping failed for node 14: RuntimeError: network error" in caplog.text
 
 
 class TestZWaveJSLockProviderNodeResolution:
@@ -1683,6 +1686,40 @@ class TestZWaveJSLockProviderNodeResolution:
         resolved_node = zwave_provider.node
         assert resolved_node is new_node
         assert zwave_provider._node is new_node
+
+    def test_dynamic_node_resolution_clears_removed_node(
+        self,
+        zwave_provider,
+        mock_zwave_client,
+    ):
+        """Test that _get_node fails closed and clears cached reference when node was removed."""
+        stale_node = MagicMock()
+        stale_node.node_id = 14
+        stale_node.client = None
+
+        mock_zwave_client.driver.controller.nodes = {}
+        zwave_provider._client = mock_zwave_client
+        zwave_provider._node_id = 14
+        zwave_provider._node = stale_node
+
+        resolved_node = zwave_provider.node
+        assert resolved_node is None
+        assert zwave_provider._node is None
+
+    def test_dynamic_node_resolution_preserves_node_when_driver_none(
+        self,
+        zwave_provider,
+        mock_zwave_client,
+        mock_zwave_node,
+    ):
+        """Test that _get_node returns cached node when driver is transiently None."""
+        mock_zwave_client.driver = None
+        zwave_provider._client = mock_zwave_client
+        zwave_provider._node_id = 14
+        zwave_provider._node = mock_zwave_node
+
+        resolved_node = zwave_provider.node
+        assert resolved_node is mock_zwave_node
 
     async def test_clear_usercode_warns_on_retry_if_not_cleared(
         self,

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -1642,3 +1642,25 @@ class TestZWaveJSLockProviderNodeResolution:
 
         assert result is False
         assert "Slot 1 not yet cleared after command, will retry" in caplog.text
+
+    def test_get_node_id_falls_back_to_node_id_when_node_none(self, zwave_provider):
+        """Test get_node_id returns _node_id when node cannot be resolved."""
+        zwave_provider._node = None
+        zwave_provider._node_id = 99
+        assert zwave_provider.get_node_id() == 99
+
+    async def test_async_is_connected_uses_dynamic_node(
+        self,
+        zwave_provider,
+        mock_zwave_client,
+        mock_zwave_node,
+    ):
+        """Test async_is_connected verifies dynamic node presence."""
+        mock_zwave_client.driver.controller.nodes = {14: mock_zwave_node}
+        zwave_provider._client = mock_zwave_client
+        zwave_provider._node_id = 14
+        zwave_provider._node = None
+
+        connected = await zwave_provider.async_is_connected()
+        assert connected is True
+        assert zwave_provider._node is mock_zwave_node

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -14,7 +14,7 @@ from zwave_js_server.const import NodeStatus
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import BaseZwaveJSServerError, FailedZWaveCommand
 
-from custom_components.keymaster.const import DOMAIN
+from custom_components.keymaster.const import ATTR_NODE_ID, DOMAIN
 from custom_components.keymaster.providers import (
     create_provider,
     get_provider_class_for_lock,
@@ -22,9 +22,10 @@ from custom_components.keymaster.providers import (
 )
 from custom_components.keymaster.providers.zwave_js import ZWaveJSLockProvider
 from homeassistant.components.lock.const import LockState
+from homeassistant.components.zwave_js.const import ATTR_PARAMETERS
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_DEVICE_ID, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import Event as HAEvent, HomeAssistant
 from tests.common import async_capture_events
 from tests.const import CONFIG_DATA_910
 
@@ -1079,6 +1080,70 @@ class TestZWaveJSLockProviderEventSubscription:
         zwave_provider.hass.bus.async_listen.assert_called_once()
         # Only notification event listener when no alarm sensors configured
         assert len(zwave_provider._listeners) == 1
+
+    async def test_handle_zwave_notification_event_dispatches_correctly(
+        self,
+        zwave_provider,
+        mock_zwave_client,
+        mock_zwave_node,
+    ):
+        """Test handle_zwave_notification_event resolves node dynamically and filters/dispatches."""
+        mock_device = MagicMock()
+        mock_device.id = "device_123"
+        zwave_provider._device = mock_device
+        zwave_provider._client = mock_zwave_client
+        zwave_provider._node_id = 14
+        mock_zwave_client.driver.controller.nodes = {14: mock_zwave_node}
+        zwave_provider._node = None
+
+        mock_kmlock = MagicMock()
+        mock_kmlock.alarm_level_or_user_code_entity_id = None
+        mock_kmlock.alarm_type_or_access_control_entity_id = None
+        mock_callback = AsyncMock()
+
+        handler = None
+
+        def fake_async_listen(event_type, callback):
+            nonlocal handler
+            handler = callback
+            return MagicMock()
+
+        zwave_provider.hass.bus.async_listen.side_effect = fake_async_listen
+        zwave_provider.subscribe_lock_events(mock_kmlock, mock_callback)
+        assert handler is not None
+
+        # Test event with matching node & device
+        matching_event = HAEvent(
+            "zwave_js_notification",
+            data={
+                ATTR_NODE_ID: 14,
+                ATTR_DEVICE_ID: "device_123",
+                "command_class": 113,
+                "type": 6,
+                "event": 6,
+                ATTR_PARAMETERS: {"userId": 2},
+            },
+        )
+        await handler(matching_event)
+        zwave_provider.hass.async_create_task.assert_called_once()
+
+        # Test event with mismatching node_id ignored
+        mismatched_event = HAEvent(
+            "zwave_js_notification",
+            data={
+                ATTR_NODE_ID: 99,
+                ATTR_DEVICE_ID: "device_123",
+            },
+        )
+        zwave_provider.hass.async_create_task.reset_mock()
+        await handler(mismatched_event)
+        zwave_provider.hass.async_create_task.assert_not_called()
+
+        # Test event when node is None
+        zwave_provider._node = None
+        mock_zwave_client.driver.controller.nodes = {}
+        await handler(matching_event)
+        zwave_provider.hass.async_create_task.assert_not_called()
 
     def test_subscribe_lock_events_with_alarm_sensors(self, zwave_provider, mock_zwave_node):
         """Test subscribe_lock_events also subscribes to state changes when alarm sensors are configured."""

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -1457,16 +1457,25 @@ class TestZWaveJSLockProviderDeadNode:
 
         assert zwave_provider._is_node_alive() is False
 
-    def test_is_node_alive_handles_exception(self, zwave_provider, mock_zwave_node):
-        """Test _is_node_alive returns False when status check raises."""
+    def test_is_node_alive_handles_exception(self, zwave_provider, mock_zwave_node, caplog):
+        """Test _is_node_alive returns False and logs warning when status check raises."""
         type(mock_zwave_node).status = property(
             lambda self: (_ for _ in ()).throw(RuntimeError("node gone")),
         )
         zwave_provider._node = mock_zwave_node
 
         assert zwave_provider._is_node_alive() is False
+        assert "Error checking status for node 14" in caplog.text
 
-    async def test_refresh_usercode_skips_when_dead(self, zwave_provider, mock_zwave_node):
+    def test_is_node_alive_logs_warning_when_no_node(self, zwave_provider, caplog):
+        """Test _is_node_alive logs warning when no node is available."""
+        zwave_provider._node = None
+        zwave_provider._node_id = 42
+
+        assert zwave_provider._is_node_alive() is False
+        assert "Node 42 is not available" in caplog.text
+
+    async def test_refresh_usercode_skips_when_dead(self, zwave_provider, mock_zwave_node, caplog):
         """Test async_refresh_usercode returns None without Z-Wave call when dead."""
         mock_zwave_node.status = NodeStatus.DEAD
         zwave_provider._node = mock_zwave_node
@@ -1479,8 +1488,9 @@ class TestZWaveJSLockProviderDeadNode:
 
         assert result is None
         mock_get.assert_not_called()
+        assert "Node 14 is not alive, skipping refresh_usercode for slot 1" in caplog.text
 
-    async def test_set_usercode_skips_when_dead(self, zwave_provider, mock_zwave_node):
+    async def test_set_usercode_skips_when_dead(self, zwave_provider, mock_zwave_node, caplog):
         """Test async_set_usercode returns False without Z-Wave call when dead."""
         mock_zwave_node.status = NodeStatus.DEAD
         zwave_provider._node = mock_zwave_node
@@ -1493,8 +1503,9 @@ class TestZWaveJSLockProviderDeadNode:
 
         assert result is False
         mock_set.assert_not_called()
+        assert "Node 14 is not alive, skipping set_usercode for slot 1" in caplog.text
 
-    async def test_clear_usercode_skips_when_dead(self, zwave_provider, mock_zwave_node):
+    async def test_clear_usercode_skips_when_dead(self, zwave_provider, mock_zwave_node, caplog):
         """Test async_clear_usercode returns False without Z-Wave call when dead."""
         mock_zwave_node.status = NodeStatus.DEAD
         zwave_provider._node = mock_zwave_node
@@ -1507,6 +1518,7 @@ class TestZWaveJSLockProviderDeadNode:
 
         assert result is False
         mock_clear.assert_not_called()
+        assert "Node 14 is not alive, skipping clear_usercode for slot 1" in caplog.text
 
     async def test_connect_warns_when_dead_but_proceeds(
         self,
@@ -1577,3 +1589,56 @@ class TestZWaveJSLockProviderPingNode:
         result = await zwave_provider.async_ping_node()
 
         assert result is False
+
+
+class TestZWaveJSLockProviderNodeResolution:
+    """Test dynamic node resolution and clear retry logging."""
+
+    def test_dynamic_node_resolution_refreshes_stale_node(
+        self,
+        zwave_provider,
+        mock_zwave_client,
+        mock_zwave_node,
+    ):
+        """Test that _get_node dynamically fetches updated node from controller."""
+        stale_node = MagicMock()
+        stale_node.node_id = 14
+        stale_node.status = NodeStatus.DEAD
+
+        new_node = MagicMock()
+        new_node.node_id = 14
+        new_node.status = NodeStatus.ALIVE
+
+        mock_zwave_client.driver.controller.nodes = {14: new_node}
+        zwave_provider._client = mock_zwave_client
+        zwave_provider._node_id = 14
+        zwave_provider._node = stale_node
+
+        # When node property is accessed, it should return new_node from controller
+        resolved_node = zwave_provider.node
+        assert resolved_node is new_node
+        assert zwave_provider._node is new_node
+
+    async def test_clear_usercode_warns_on_retry_if_not_cleared(
+        self,
+        zwave_provider,
+        mock_zwave_node,
+        caplog,
+    ):
+        """Test clear_usercode logs warning when verification shows code remains."""
+        zwave_provider._node = mock_zwave_node
+
+        with (
+            patch(
+                "custom_components.keymaster.providers.zwave_js.clear_usercode",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "custom_components.keymaster.providers.zwave_js.get_usercode",
+                return_value={"usercode": "1234"},
+            ),
+        ):
+            result = await zwave_provider.async_clear_usercode(1)
+
+        assert result is False
+        assert "Slot 1 not yet cleared after command, will retry" in caplog.text


### PR DESCRIPTION
# Summary

Resolves silent failures in `ZWaveJSLockProvider` during usercode operations (`async_clear_usercode`, `async_set_usercode`, `async_refresh_usercode`) caused by stale node references (e.g., after node re-interviews or client reconnects) and unlogged bailouts in `_is_node_alive()`.

## Proposed change

- **Persist `_node_id` & Dynamic Node Re-resolution**:
  - Store `_node_id` on the provider instance during `async_connect()`.
  - Add `_get_node()` helper to retrieve the live node object dynamically from `self._client.driver.controller.nodes` if the underlying Z-Wave JS node reference has been recreated.
- **Diagnostic Logging in `_is_node_alive()`**:
  - Log warning messages when a node is unavailable (`Node <id> is not available`) or marked dead (`Node <id> is dead, skipping command`).
  - Catch status property exceptions and log warning diagnostics rather than returning `False` silently.
- **Informative Usercode Operation Warnings**:
  - Emit warning logs in `async_refresh_usercode()`, `async_set_usercode()`, and `async_clear_usercode()` when skipping operations due to unavailable/dead nodes.
  - Upgrade `async_clear_usercode()` retry log from `DEBUG` to `WARNING` when verification readback shows usercode is still present after clear command.
- **Unit Tests**:
  - Added unit test coverage in `tests/providers/test_zwave_js.py` for dynamic node resolution, failure logging in `_is_node_alive()`, dead node operation warnings, and clear retry warnings.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #665
- This PR is related to issue:
