### PR TITLE
fix(lint): format Python examples in agent skill docs

### DIFF
--- a/.agents/skills/ha-lock-provider/SKILL.md
+++ b/.agents/skills/ha-lock-provider/SKILL.md
@@ -45,6 +45,7 @@ When creating or modifying a provider:
    if TYPE_CHECKING:
        from ..lock import KeymasterLock
 
+
    @dataclass
    class CustomLockProvider(BaseLockProvider):
        """Custom lock provider implementation."""

--- a/.agents/skills/patch-coverage/SKILL.md
+++ b/.agents/skills/patch-coverage/SKILL.md
@@ -97,6 +97,7 @@ their respective test modules (e.g. `tests/providers/test_zwave_js.py`):
 import logging
 from zwave_js_server.const import NodeStatus
 
+
 async def test_operation_skips_when_node_dead(zwave_provider, mock_zwave_node, caplog):
     """Test operation logs debug message and returns False when node is dead."""
     caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
# Summary

Format the Python examples embedded in two agent skill Markdown documents with ruff 0.16.0.

## Proposed change

Ruff's formatter also checks fenced Python code blocks in Markdown when `ruff format --check .` runs in the lint tox environment. This PR applies only the formatter changes needed for:

- `.agents/skills/ha-lock-provider/SKILL.md`
- `.agents/skills/patch-coverage/SKILL.md`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

CI is currently red on main because of this formatting failure, and the same failure is blocking the open Dependabot PRs. This change unblocks those PRs without changing prose or behavior.
