### PR TITLE
fix(deps): drop phcc-controlled pytest pins from requirements_test.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    ignore:
+      # Pinned to exact versions by pytest-homeassistant-custom-component;
+      # bumping them directly produces unsatisfiable requirements.
+      - dependency-name: "pytest"
+      - dependency-name: "pytest-cov"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,8 +7,6 @@ homeassistant
 pydispatcher
 pyserial
 # Test dependencies for pytest
-pytest>=9.0.3
-pytest-cov
 pytest-homeassistant-custom-component
 pyudev
 serialx


### PR DESCRIPTION
# Summary
Remove direct `pytest` and `pytest-cov` entries from `requirements_test.txt` because both are controlled by `pytest-homeassistant-custom-component`.

Closes #715

## Proposed change
Let `pytest-homeassistant-custom-component` supply its exact pytest pins transitively, and add Dependabot ignore rules for `pytest` and `pytest-cov` under the pip ecosystem so unsatisfiable bumps are not re-proposed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #715
- This PR is related to issue: #723 was closed as unmergeable because the direct pytest bump could not resolve against phcc's exact pins.
- Resolution output was verified against Python 3.14.2 and still selects `pytest==9.0.3`, `pytest-cov==7.1.0`, and `pytest-homeassistant-custom-component==0.13.357`.
