### PR TITLE
ci: run Python CI on documentation and tooling changes

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -5,19 +5,27 @@ on:
     branches: [beta, main]
     paths:
       - "**.py"
+      - "**.md"
+      - ".agents/**"
       - "custom_components/**"
       - "tests/**"
       - "pyproject.toml"
       - "requirements*.txt"
+      - "tox.ini"
+      - ".pre-commit-config.yaml"
       - ".github/workflows/pytest.yaml"
   pull_request:
     branches: [beta, main]
     paths:
       - "**.py"
+      - "**.md"
+      - ".agents/**"
       - "custom_components/**"
       - "tests/**"
       - "pyproject.toml"
       - "requirements*.txt"
+      - "tox.ini"
+      - ".pre-commit-config.yaml"
       - ".github/workflows/pytest.yaml"
   schedule:
     - cron: "0 7 1-28/7 * *"


### PR DESCRIPTION
# Summary

Run Python CI when Markdown documentation, agent skill files, tox configuration, or pre-commit configuration changes.

## Proposed change

Add `**.md`, `.agents/**`, `tox.ini`, and `.pre-commit-config.yaml` to the `push` and `pull_request` path filters for the Python CI workflow. These files are covered by `ruff format --check .` and/or define the CI gates run by tox and prek.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

This PR modifies the workflow's own path filters, so it will itself trigger the workflow and demonstrate the fix.
