### PR TITLE
feat(coordinator): include code slot details on lock events (#737)

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1241,6 +1241,44 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             },
         )
 
+    def _fire_lock_state_changed(
+        self,
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+        source: str | None,
+        event_label: str | None,
+        action_code: int | None,
+    ) -> None:
+        """Fire the keymaster_lock_state_changed bus event for a lock."""
+        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
+        self.hass.bus.fire(
+            EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+            event_data={
+                ATTR_NOTIFICATION_SOURCE: source,
+                ATTR_NAME: kmlock.lock_name,
+                ATTR_ENTITY_ID: kmlock.lock_entity_id,
+                ATTR_STATE: LockState.LOCKED,
+                ATTR_ACTION_CODE: action_code,
+                ATTR_ACTION_TEXT: event_label,
+                ATTR_CODE_SLOT: code_slot_num,
+                ATTR_CODE_SLOT_NAME: (slot.name or "") if slot and code_slot_num != 0 else "",
+            },
+        )
+
+    @staticmethod
+    def _format_slot_message(
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+        event_label: str | None,
+    ) -> str | None:
+        """Append code slot details to a notification message."""
+        if code_slot_num <= 0:
+            return event_label
+        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
+        if slot and slot.name:
+            return f"{event_label} by {slot.name} [{code_slot_num}]"
+        return f"{event_label} by Code Slot {code_slot_num}"
+
     async def _send_code_slot_unlock_notification(
         self,
         kmlock: KeymasterLock,
@@ -1252,10 +1290,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if not slot or not slot.notifications:
             return False
 
-        if slot.name:
-            message = f"{event_label} by {slot.name} [{code_slot_num}]"
-        else:
-            message = f"{event_label} by Code Slot {code_slot_num}"
+        message = self._format_slot_message(kmlock, code_slot_num, event_label)
         await send_manual_notification(
             hass=self.hass,
             script_name=kmlock.notify_script_name,
@@ -1271,16 +1306,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         event_label: str | None,
     ) -> None:
         """Send a global unlock notification."""
-        message = event_label
-        if code_slot_num > 0:
-            if (
-                kmlock.code_slots
-                and kmlock.code_slots.get(code_slot_num)
-                and kmlock.code_slots[code_slot_num].name
-            ):
-                message = f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
-            else:
-                message = f"{message} by Code Slot {code_slot_num}"
+        message = self._format_slot_message(kmlock, code_slot_num, event_label)
         await send_manual_notification(
             hass=self.hass,
             script_name=kmlock.notify_script_name,
@@ -1493,7 +1519,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     async def _lock_locked(
         self,
         kmlock: KeymasterLock,
-        code_slot_num: int = 0,
+        code_slot_num: int | None = None,
         source: str | None = None,
         event_label: str | None = None,
         action_code: int | None = None,
@@ -1565,18 +1591,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
         if kmlock.lock_notifications:
-            message = event_label
-            if code_slot_num > 0:
-                if (
-                    kmlock.code_slots
-                    and kmlock.code_slots.get(code_slot_num)
-                    and kmlock.code_slots[code_slot_num].name
-                ):
-                    message = (
-                        f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
-                    )
-                else:
-                    message = f"{message} by Code Slot {code_slot_num}"
+            message = self._format_slot_message(kmlock, code_slot_num, event_label)
             await send_manual_notification(
                 hass=self.hass,
                 script_name=kmlock.notify_script_name,
@@ -1584,20 +1599,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 message=message,
             )
 
-        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
-        self.hass.bus.fire(
-            EVENT_KEYMASTER_LOCK_STATE_CHANGED,
-            event_data={
-                ATTR_NOTIFICATION_SOURCE: source,
-                ATTR_NAME: kmlock.lock_name,
-                ATTR_ENTITY_ID: kmlock.lock_entity_id,
-                ATTR_STATE: LockState.LOCKED,
-                ATTR_ACTION_CODE: action_code,
-                ATTR_ACTION_TEXT: event_label,
-                ATTR_CODE_SLOT: code_slot_num,
-                ATTR_CODE_SLOT_NAME: (slot.name or "") if slot and code_slot_num != 0 else "",
-            },
-        )
+        self._fire_lock_state_changed(kmlock, code_slot_num, source, event_label, action_code)
 
     async def _door_opened(self, kmlock: KeymasterLock) -> None:
         if not self._throttle.is_allowed(

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -993,6 +993,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         elif inferred_action == LockState.LOCKED:
             await self._lock_locked(
                 kmlock=kmlock,
+                code_slot_num=code_slot_num,
                 source="event",
                 event_label=event_label,
                 action_code=action_code,
@@ -1236,7 +1237,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 ATTR_ACTION_CODE: action_code,
                 ATTR_ACTION_TEXT: event_label,
                 ATTR_CODE_SLOT: code_slot_num,
-                ATTR_CODE_SLOT_NAME: slot.name if slot and code_slot_num != 0 else "",
+                ATTR_CODE_SLOT_NAME: (slot.name or "") if slot and code_slot_num != 0 else "",
             },
         )
 
@@ -1492,6 +1493,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     async def _lock_locked(
         self,
         kmlock: KeymasterLock,
+        code_slot_num: int = 0,
         source: str | None = None,
         event_label: str | None = None,
         action_code: int | None = None,
@@ -1528,9 +1530,14 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._last_unlock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
         self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
         self._cancel_pending_keypad_unlock_notification(kmlock)
+        if not isinstance(code_slot_num, int):
+            code_slot_num = 0
+
         _LOGGER.debug(
-            "[lock_locked] %s: Running. source: %s, event_label: %s, action_code: %s",
+            "[lock_locked] %s: Running. code_slot_num: %s, source: %s, "
+            "event_label: %s, action_code: %s",
             kmlock.lock_name,
+            code_slot_num,
             source,
             event_label,
             action_code,
@@ -1558,13 +1565,26 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
         if kmlock.lock_notifications:
+            message = event_label
+            if code_slot_num > 0:
+                if (
+                    kmlock.code_slots
+                    and kmlock.code_slots.get(code_slot_num)
+                    and kmlock.code_slots[code_slot_num].name
+                ):
+                    message = (
+                        f"{message} by {kmlock.code_slots[code_slot_num].name} [{code_slot_num}]"
+                    )
+                else:
+                    message = f"{message} by Code Slot {code_slot_num}"
             await send_manual_notification(
                 hass=self.hass,
                 script_name=kmlock.notify_script_name,
                 title=kmlock.lock_name,
-                message=event_label,
+                message=message,
             )
 
+        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
         self.hass.bus.fire(
             EVENT_KEYMASTER_LOCK_STATE_CHANGED,
             event_data={
@@ -1574,6 +1594,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 ATTR_STATE: LockState.LOCKED,
                 ATTR_ACTION_CODE: action_code,
                 ATTR_ACTION_TEXT: event_label,
+                ATTR_CODE_SLOT: code_slot_num,
+                ATTR_CODE_SLOT_NAME: (slot.name or "") if slot and code_slot_num != 0 else "",
             },
         )
 

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -223,6 +223,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._initial_setup_done_event = asyncio.Event()
         self._throttle = Throttle()
         self._last_unlock_code_slot: dict[str, int | None] = {}
+        self._last_lock_code_slot: dict[str, int | None] = {}
         self._sync_status_counter: int = 0
         self._quick_refresh_entry_ids: set[str] = set()
         self._cancel_quick_refresh: dict[str, Callable] = {}
@@ -1079,6 +1080,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 if uses_provider_lock_events:
                     if kmlock.lock_state != LockState.LOCKED:
                         kmlock.lock_state = LockState.LOCKED
+                        self._last_lock_code_slot.setdefault(kmlock.keymaster_config_entry_id, 0)
                         self._pending_provider_lock_event.add(kmlock.keymaster_config_entry_id)
                     self._pending_provider_unlock_event.discard(kmlock.keymaster_config_entry_id)
 
@@ -1217,6 +1219,31 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
             kmlock.listeners.append(unsub)
 
+    def _fire_lock_state_changed_event(
+        self,
+        kmlock: KeymasterLock,
+        state: str,
+        code_slot_num: int,
+        source: str | None,
+        event_label: str | None,
+        action_code: int | None,
+    ) -> None:
+        """Fire the keymaster_lock_state_changed bus event."""
+        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
+        self.hass.bus.fire(
+            EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+            event_data={
+                ATTR_NOTIFICATION_SOURCE: source,
+                ATTR_NAME: kmlock.lock_name,
+                ATTR_ENTITY_ID: kmlock.lock_entity_id,
+                ATTR_STATE: state,
+                ATTR_ACTION_CODE: action_code,
+                ATTR_ACTION_TEXT: event_label,
+                ATTR_CODE_SLOT: code_slot_num,
+                ATTR_CODE_SLOT_NAME: (slot.name or "") if slot and code_slot_num != 0 else "",
+            },
+        )
+
     def _fire_unlock_state_changed(
         self,
         kmlock: KeymasterLock,
@@ -1226,19 +1253,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         action_code: int | None,
     ) -> None:
         """Fire the keymaster_lock_state_changed bus event for an unlock."""
-        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
-        self.hass.bus.fire(
-            EVENT_KEYMASTER_LOCK_STATE_CHANGED,
-            event_data={
-                ATTR_NOTIFICATION_SOURCE: source,
-                ATTR_NAME: kmlock.lock_name,
-                ATTR_ENTITY_ID: kmlock.lock_entity_id,
-                ATTR_STATE: LockState.UNLOCKED,
-                ATTR_ACTION_CODE: action_code,
-                ATTR_ACTION_TEXT: event_label,
-                ATTR_CODE_SLOT: code_slot_num,
-                ATTR_CODE_SLOT_NAME: (slot.name or "") if slot and code_slot_num != 0 else "",
-            },
+        self._fire_lock_state_changed_event(
+            kmlock, LockState.UNLOCKED, code_slot_num, source, event_label, action_code
         )
 
     def _fire_lock_state_changed(
@@ -1250,19 +1266,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         action_code: int | None,
     ) -> None:
         """Fire the keymaster_lock_state_changed bus event for a lock."""
-        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
-        self.hass.bus.fire(
-            EVENT_KEYMASTER_LOCK_STATE_CHANGED,
-            event_data={
-                ATTR_NOTIFICATION_SOURCE: source,
-                ATTR_NAME: kmlock.lock_name,
-                ATTR_ENTITY_ID: kmlock.lock_entity_id,
-                ATTR_STATE: LockState.LOCKED,
-                ATTR_ACTION_CODE: action_code,
-                ATTR_ACTION_TEXT: event_label,
-                ATTR_CODE_SLOT: code_slot_num,
-                ATTR_CODE_SLOT_NAME: (slot.name or "") if slot and code_slot_num != 0 else "",
-            },
+        self._fire_lock_state_changed_event(
+            kmlock, LockState.LOCKED, code_slot_num, source, event_label, action_code
         )
 
     @staticmethod
@@ -1443,6 +1448,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         kmlock.lock_state = LockState.UNLOCKED
         self._throttle.reset("lock_locked", kmlock.keymaster_config_entry_id)
+        self._last_lock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
         _LOGGER.debug(
             "[lock_unlocked] %s: Running. code_slot_num: %s, source: %s, "
             "event_label: %s, action_code: %s",
@@ -1524,6 +1530,42 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         event_label: str | None = None,
         action_code: int | None = None,
     ) -> None:
+        pending_provider_event = (
+            kmlock.keymaster_config_entry_id in self._pending_provider_lock_event
+        )
+        # Check for supersede condition before throttle: when the lock is already
+        # locked and a more informative slot>0 event arrives, re-fire the bus event
+        # with the corrected slot info so downstream consumers receive it.
+        if kmlock.lock_state == LockState.LOCKED and not pending_provider_event:
+            prior_slot = self._last_lock_code_slot.get(kmlock.keymaster_config_entry_id)
+            if isinstance(code_slot_num, int) and code_slot_num > 0 and prior_slot == 0:
+                _LOGGER.debug(
+                    "[lock_locked] %s: Superseding prior slot=0 lock with slot=%s. source: %s",
+                    kmlock.lock_name,
+                    code_slot_num,
+                    source,
+                )
+                self._last_lock_code_slot[kmlock.keymaster_config_entry_id] = code_slot_num
+                self._fire_lock_state_changed(
+                    kmlock, code_slot_num, source, event_label, action_code
+                )
+                if kmlock.lock_notifications:
+                    message = self._format_slot_message(kmlock, code_slot_num, event_label)
+                    await send_manual_notification(
+                        hass=self.hass,
+                        script_name=kmlock.notify_script_name,
+                        title=kmlock.lock_name,
+                        message=message,
+                    )
+            if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
+                if kmlock.autolock_timer:
+                    await kmlock.autolock_timer.cancel()
+                    self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
+                self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
+            self._cancel_pending_keypad_unlock_notification(kmlock)
+            if not kmlock.pending_retry_lock:
+                return
+
         if not self._throttle.is_allowed(
             "lock_locked",
             kmlock.keymaster_config_entry_id,
@@ -1532,28 +1574,15 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("[lock_locked] %s: Throttled. source: %s", kmlock.lock_name, source)
             return
 
-        pending_provider_event = (
-            kmlock.keymaster_config_entry_id in self._pending_provider_lock_event
-        )
-        if (
-            kmlock.lock_state == LockState.LOCKED
-            and not kmlock.pending_retry_lock
-            and not pending_provider_event
-        ):
-            if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
-                if kmlock.autolock_timer:
-                    await kmlock.autolock_timer.cancel()
-                    self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
-                self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
-            self._cancel_pending_keypad_unlock_notification(kmlock)
-            return
-
         self._pending_provider_lock_event.discard(kmlock.keymaster_config_entry_id)
 
         kmlock.lock_state = LockState.LOCKED
         kmlock.pending_retry_lock = False
         self._throttle.reset("lock_unlocked", kmlock.keymaster_config_entry_id)
         self._last_unlock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
+        if not isinstance(code_slot_num, int):
+            code_slot_num = 0
+        self._last_lock_code_slot[kmlock.keymaster_config_entry_id] = code_slot_num
         self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
         self._cancel_pending_keypad_unlock_notification(kmlock)
         if not isinstance(code_slot_num, int):
@@ -1970,6 +1999,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         self.kmlocks.pop(kmlock.keymaster_config_entry_id, None)
         self._last_unlock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
+        self._last_lock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
         self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
         self._pending_provider_unlock_event.discard(kmlock.keymaster_config_entry_id)
         self._pending_provider_lock_event.discard(kmlock.keymaster_config_entry_id)

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1223,6 +1223,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self,
         kmlock: KeymasterLock,
         state: str,
+        *,
         code_slot_num: int,
         source: str | None,
         event_label: str | None,
@@ -1254,7 +1255,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Fire the keymaster_lock_state_changed bus event for an unlock."""
         self._fire_lock_state_changed_event(
-            kmlock, LockState.UNLOCKED, code_slot_num, source, event_label, action_code
+            kmlock,
+            LockState.UNLOCKED,
+            code_slot_num=code_slot_num,
+            source=source,
+            event_label=event_label,
+            action_code=action_code,
         )
 
     def _fire_lock_state_changed(
@@ -1267,7 +1273,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Fire the keymaster_lock_state_changed bus event for a lock."""
         self._fire_lock_state_changed_event(
-            kmlock, LockState.LOCKED, code_slot_num, source, event_label, action_code
+            kmlock,
+            LockState.LOCKED,
+            code_slot_num=code_slot_num,
+            source=source,
+            event_label=event_label,
+            action_code=action_code,
         )
 
     @staticmethod

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1544,10 +1544,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         pending_provider_event = (
             kmlock.keymaster_config_entry_id in self._pending_provider_lock_event
         )
-        # Check for supersede condition before throttle: when the lock is already
-        # locked and a more informative slot>0 event arrives, re-fire the bus event
-        # with the corrected slot info so downstream consumers receive it.
-        if kmlock.lock_state == LockState.LOCKED and not pending_provider_event:
+        if (
+            kmlock.lock_state == LockState.LOCKED
+            and not kmlock.pending_retry_lock
+            and not pending_provider_event
+        ):
             prior_slot = self._last_lock_code_slot.get(kmlock.keymaster_config_entry_id)
             if isinstance(code_slot_num, int) and code_slot_num > 0 and prior_slot == 0:
                 _LOGGER.debug(
@@ -1560,22 +1561,13 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 self._fire_lock_state_changed(
                     kmlock, code_slot_num, source, event_label, action_code
                 )
-                if kmlock.lock_notifications:
-                    message = self._format_slot_message(kmlock, code_slot_num, event_label)
-                    await send_manual_notification(
-                        hass=self.hass,
-                        script_name=kmlock.notify_script_name,
-                        title=kmlock.lock_name,
-                        message=message,
-                    )
             if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
                 if kmlock.autolock_timer:
                     await kmlock.autolock_timer.cancel()
                     self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                 self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
             self._cancel_pending_keypad_unlock_notification(kmlock)
-            if not kmlock.pending_retry_lock:
-                return
+            return
 
         if not self._throttle.is_allowed(
             "lock_locked",
@@ -1596,8 +1588,6 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._last_lock_code_slot[kmlock.keymaster_config_entry_id] = code_slot_num
         self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
         self._cancel_pending_keypad_unlock_notification(kmlock)
-        if not isinstance(code_slot_num, int):
-            code_slot_num = 0
 
         _LOGGER.debug(
             "[lock_locked] %s: Running. code_slot_num: %s, source: %s, "

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1216,6 +1216,36 @@ class TestLockStateEventHandlers:
                 },
             )
 
+    async def test_lock_locked_with_invalid_code_slot_num_coerced_to_zero(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test _lock_locked coerces non-int code_slot_num to 0."""
+        mock_kmlock.lock_notifications = False
+        mock_coordinator._throttle = Mock()
+        mock_coordinator._throttle.is_allowed = Mock(return_value=True)
+
+        await mock_coordinator._lock_locked(
+            mock_kmlock,
+            code_slot_num=None,
+            source="event",
+            event_label="Keypad Lock",
+            action_code=5,
+        )
+
+        mock_coordinator.hass.bus.fire.assert_called_once_with(
+            "keymaster_lock_state_changed",
+            event_data={
+                "notification_source": "event",
+                "lockname": "Front Door",
+                "entity_id": "lock.front_door",
+                "state": LockState.LOCKED,
+                "action_code": 5,
+                "action_text": "Keypad Lock",
+                "code_slot_num": 0,
+                "code_slot_name": "",
+            },
+        )
+
     async def test_lock_unlocked_starts_autolock_timer(self, mock_coordinator, mock_kmlock):
         """Test _lock_unlocked starts autolock timer and schedules data update."""
         mock_kmlock.lock_state = LockState.LOCKED

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1285,6 +1285,47 @@ class TestLockStateEventHandlers:
         mock_coordinator._fire_unlock_state_changed(mock_kmlock, 2, "event", "Keypad Unlock", 6)
         assert mock_coordinator.hass.bus.fire.call_args.kwargs["event_data"]["code_slot_name"] == ""
 
+    async def test_lock_locked_supersede_sequence_no_duplicate_side_effects(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test slot=0 then slot>0 lock re-fires with slot info without duplicating side effects."""
+        mock_coordinator._throttle = Throttle()
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_kmlock.pending_retry_lock = False
+        mock_kmlock.lock_notifications = True
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.autolock_timer = None
+        mock_kmlock.code_slots = {2: Mock(name="slot2")}
+        mock_kmlock.code_slots[2].name = "Alice"
+
+        with (
+            patch(
+                "custom_components.keymaster.coordinator.send_manual_notification",
+                new=AsyncMock(),
+            ) as mock_notify,
+            patch(
+                "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+                new=AsyncMock(),
+            ),
+        ):
+            for slot in (0, 2):
+                await mock_coordinator._lock_locked(
+                    mock_kmlock,
+                    code_slot_num=slot,
+                    source="event",
+                    event_label="Keypad Lock",
+                    action_code=5,
+                )
+
+        # Both events reach the bus, the second with the corrected slot.
+        fired = [
+            call.kwargs["event_data"]["code_slot_num"]
+            for call in mock_coordinator.hass.bus.fire.call_args_list
+        ]
+        assert fired == [0, 2]
+        # Exactly one notification for one physical lock.
+        assert mock_notify.call_count == 1
+
     async def test_lock_locked_supersedes_slot_zero(self, mock_coordinator, mock_kmlock):
         """Test a slot>0 lock event supersedes a prior slot=0 lock event when already locked."""
         mock_kmlock.lock_state = LockState.LOCKED
@@ -1297,34 +1338,88 @@ class TestLockStateEventHandlers:
         mock_kmlock.code_slots[2].name = "Alice"
         mock_coordinator._last_lock_code_slot[mock_kmlock.keymaster_config_entry_id] = 0
 
-        with patch(
-            "custom_components.keymaster.coordinator.send_manual_notification",
-            new=AsyncMock(),
-        ) as mock_notify:
+        await mock_coordinator._lock_locked(
+            mock_kmlock,
+            code_slot_num=2,
+            source="event",
+            event_label="Keypad Lock",
+            action_code=5,
+        )
+
+        assert mock_coordinator._last_lock_code_slot[mock_kmlock.keymaster_config_entry_id] == 2
+        mock_coordinator.hass.bus.fire.assert_called_once_with(
+            "keymaster_lock_state_changed",
+            event_data={
+                "notification_source": "event",
+                "lockname": "Front Door",
+                "entity_id": "lock.front_door",
+                "state": LockState.LOCKED,
+                "action_code": 5,
+                "action_text": "Keypad Lock",
+                "code_slot_num": 2,
+                "code_slot_name": "Alice",
+            },
+        )
+
+    async def test_lock_locked_supersede_repeated_slot_no_refire(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test repeated slot>0 lock events do not repeatedly re-fire supersede."""
+        mock_coordinator._throttle = Throttle()
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_kmlock.pending_retry_lock = False
+        mock_kmlock.lock_notifications = False
+        mock_kmlock.autolock_timer = None
+        mock_kmlock.code_slots = {2: Mock(name="slot2")}
+        mock_kmlock.code_slots[2].name = "Alice"
+
+        for slot in (0, 2, 2):
             await mock_coordinator._lock_locked(
                 mock_kmlock,
-                code_slot_num=2,
+                code_slot_num=slot,
                 source="event",
                 event_label="Keypad Lock",
                 action_code=5,
             )
 
-            assert mock_coordinator._last_lock_code_slot[mock_kmlock.keymaster_config_entry_id] == 2
-            mock_notify.assert_called_once()
-            assert mock_notify.call_args.kwargs["message"] == "Keypad Lock by Alice [2]"
-            mock_coordinator.hass.bus.fire.assert_called_once_with(
-                "keymaster_lock_state_changed",
-                event_data={
-                    "notification_source": "event",
-                    "lockname": "Front Door",
-                    "entity_id": "lock.front_door",
-                    "state": LockState.LOCKED,
-                    "action_code": 5,
-                    "action_text": "Keypad Lock",
-                    "code_slot_num": 2,
-                    "code_slot_name": "Alice",
-                },
-            )
+        fired = [
+            call.kwargs["event_data"]["code_slot_num"]
+            for call in mock_coordinator.hass.bus.fire.call_args_list
+        ]
+        assert fired == [0, 2]
+
+    async def test_lock_locked_initial_slot_gt_zero_no_supersede(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test initial slot>0 lock event does not trigger a supersede on repeated call."""
+        mock_coordinator._throttle = Throttle()
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_kmlock.pending_retry_lock = False
+        mock_kmlock.lock_notifications = False
+        mock_kmlock.autolock_timer = None
+        mock_kmlock.code_slots = {2: Mock(name="slot2")}
+        mock_kmlock.code_slots[2].name = "Alice"
+
+        await mock_coordinator._lock_locked(
+            mock_kmlock,
+            code_slot_num=2,
+            source="event",
+            event_label="Keypad Lock",
+            action_code=5,
+        )
+
+        assert mock_coordinator.hass.bus.fire.call_count == 1
+        assert mock_coordinator._last_lock_code_slot[mock_kmlock.keymaster_config_entry_id] == 2
+
+        # A second slot=2 call while locked is ignored
+        await mock_coordinator._lock_locked(
+            mock_kmlock,
+            code_slot_num=2,
+            source="event",
+            event_label="Keypad Lock",
+            action_code=5,
+        )
+        assert mock_coordinator.hass.bus.fire.call_count == 1
 
     async def test_lock_unlocked_starts_autolock_timer(self, mock_coordinator, mock_kmlock):
         """Test _lock_unlocked starts autolock timer and schedules data update."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1323,8 +1323,10 @@ class TestLockStateEventHandlers:
             for call in mock_coordinator.hass.bus.fire.call_args_list
         ]
         assert fired == [0, 2]
-        # Exactly one notification for one physical lock.
+        # Exactly one notification for one physical lock, and it is the generic
+        # message from the slot=0 event -- the supersede must not re-notify.
         assert mock_notify.call_count == 1
+        assert mock_notify.call_args.kwargs["message"] == "Keypad Lock"
 
     async def test_lock_locked_supersedes_slot_zero(self, mock_coordinator, mock_kmlock):
         """Test a slot>0 lock event supersedes a prior slot=0 lock event when already locked."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1124,13 +1124,97 @@ class TestLockStateEventHandlers:
             await mock_coordinator._lock_locked(
                 mock_kmlock,
                 source="keypad",
-                event_label="Locked by User 1",
+                event_label="Keypad Lock",
             )
 
             mock_notify.assert_called_once()
             call_kwargs = mock_notify.call_args.kwargs
             assert call_kwargs["title"] == "Front Door"
-            assert call_kwargs["message"] == "Locked by User 1"
+            assert call_kwargs["message"] == "Keypad Lock"
+
+    async def test_lock_locked_with_code_slot_and_slot_name(self, mock_coordinator, mock_kmlock):
+        """Test _lock_locked with code_slot_num formats notification and fires event with slot details."""
+        mock_kmlock.lock_notifications = True
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.code_slots = {
+            2: Mock(name="Alice", code="1234"),
+        }
+        mock_kmlock.code_slots[2].name = "Alice"
+        mock_coordinator._throttle = Mock()
+        mock_coordinator._throttle.is_allowed = Mock(return_value=True)
+
+        with patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify:
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=2,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+
+            mock_notify.assert_called_once()
+            call_kwargs = mock_notify.call_args.kwargs
+            assert call_kwargs["title"] == "Front Door"
+            assert call_kwargs["message"] == "Keypad Lock by Alice [2]"
+
+            mock_coordinator.hass.bus.fire.assert_called_once_with(
+                "keymaster_lock_state_changed",
+                event_data={
+                    "notification_source": "event",
+                    "lockname": "Front Door",
+                    "entity_id": "lock.front_door",
+                    "state": LockState.LOCKED,
+                    "action_code": 5,
+                    "action_text": "Keypad Lock",
+                    "code_slot_num": 2,
+                    "code_slot_name": "Alice",
+                },
+            )
+
+    async def test_lock_locked_with_code_slot_without_name(self, mock_coordinator, mock_kmlock):
+        """Test _lock_locked with unnamed code slot formats fallback message."""
+        mock_kmlock.lock_notifications = True
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.code_slots = {
+            3: Mock(name=None, code="5678"),
+        }
+        mock_kmlock.code_slots[3].name = None
+        mock_coordinator._throttle = Mock()
+        mock_coordinator._throttle.is_allowed = Mock(return_value=True)
+
+        with patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify:
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=3,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+
+            mock_notify.assert_called_once()
+            call_kwargs = mock_notify.call_args.kwargs
+            assert call_kwargs["title"] == "Front Door"
+            assert call_kwargs["message"] == "Keypad Lock by Code Slot 3"
+
+            mock_coordinator.hass.bus.fire.assert_called_once_with(
+                "keymaster_lock_state_changed",
+                event_data={
+                    "notification_source": "event",
+                    "lockname": "Front Door",
+                    "entity_id": "lock.front_door",
+                    "state": LockState.LOCKED,
+                    "action_code": 5,
+                    "action_text": "Keypad Lock",
+                    "code_slot_num": 3,
+                    "code_slot_name": "",
+                },
+            )
 
     async def test_lock_unlocked_starts_autolock_timer(self, mock_coordinator, mock_kmlock):
         """Test _lock_unlocked starts autolock timer and schedules data update."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -115,6 +115,7 @@ def mock_coordinator(mock_hass) -> Any:
         coordinator.hass = mock_hass
         coordinator.kmlocks = {}
         coordinator._last_unlock_code_slot = {}
+        coordinator._last_lock_code_slot = {}
         coordinator._pending_keypad_unlock_notifications = {}
         coordinator._state_change_autolock_started = set()
         coordinator._pending_provider_unlock_event = set()
@@ -1273,6 +1274,56 @@ class TestLockStateEventHandlers:
             )
             assert (
                 mock_coordinator.hass.bus.fire.call_args.kwargs["event_data"]["code_slot_num"] == 7
+            )
+
+    async def test_lock_unlocked_unnamed_slot_emits_empty_code_slot_name(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test unnamed slots emit '' (not None) as code_slot_name on unlock."""
+        mock_kmlock.code_slots = {2: Mock()}
+        mock_kmlock.code_slots[2].name = None
+        mock_coordinator._fire_unlock_state_changed(mock_kmlock, 2, "event", "Keypad Unlock", 6)
+        assert mock_coordinator.hass.bus.fire.call_args.kwargs["event_data"]["code_slot_name"] == ""
+
+    async def test_lock_locked_supersedes_slot_zero(self, mock_coordinator, mock_kmlock):
+        """Test a slot>0 lock event supersedes a prior slot=0 lock event when already locked."""
+        mock_kmlock.lock_state = LockState.LOCKED
+        mock_kmlock.pending_retry_lock = False
+        mock_kmlock.lock_notifications = True
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.code_slots = {
+            2: Mock(name="Alice", code="1234"),
+        }
+        mock_kmlock.code_slots[2].name = "Alice"
+        mock_coordinator._last_lock_code_slot[mock_kmlock.keymaster_config_entry_id] = 0
+
+        with patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify:
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=2,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+
+            assert mock_coordinator._last_lock_code_slot[mock_kmlock.keymaster_config_entry_id] == 2
+            mock_notify.assert_called_once()
+            assert mock_notify.call_args.kwargs["message"] == "Keypad Lock by Alice [2]"
+            mock_coordinator.hass.bus.fire.assert_called_once_with(
+                "keymaster_lock_state_changed",
+                event_data={
+                    "notification_source": "event",
+                    "lockname": "Front Door",
+                    "entity_id": "lock.front_door",
+                    "state": LockState.LOCKED,
+                    "action_code": 5,
+                    "action_text": "Keypad Lock",
+                    "code_slot_num": 2,
+                    "code_slot_name": "Alice",
+                },
             )
 
     async def test_lock_unlocked_starts_autolock_timer(self, mock_coordinator, mock_kmlock):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1246,6 +1246,35 @@ class TestLockStateEventHandlers:
             },
         )
 
+    async def test_lock_locked_with_unknown_code_slot(self, mock_coordinator, mock_kmlock):
+        """Test _lock_locked with a slot number missing from code_slots."""
+        mock_kmlock.lock_notifications = True
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.code_slots = {}
+        mock_coordinator._throttle = Mock()
+        mock_coordinator._throttle.is_allowed = Mock(return_value=True)
+
+        with patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify:
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=7,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+
+            assert mock_notify.call_args.kwargs["message"] == "Keypad Lock by Code Slot 7"
+            assert (
+                mock_coordinator.hass.bus.fire.call_args.kwargs["event_data"]["code_slot_name"]
+                == ""
+            )
+            assert (
+                mock_coordinator.hass.bus.fire.call_args.kwargs["event_data"]["code_slot_num"] == 7
+            )
+
     async def test_lock_unlocked_starts_autolock_timer(self, mock_coordinator, mock_kmlock):
         """Test _lock_unlocked starts autolock timer and schedules data update."""
         mock_kmlock.lock_state = LockState.LOCKED

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -74,6 +74,7 @@ async def test_handle_provider_lock_event_keypad_lock(hass, mock_coordinator, mo
 
     mock_coordinator._lock_locked.assert_called_once()
     args, kwargs = mock_coordinator._lock_locked.call_args
+    assert kwargs["code_slot_num"] == 1
     assert kwargs["source"] == "event"
     assert kwargs["event_label"] == "Keypad Lock"
     assert kwargs["action_code"] == 5


### PR DESCRIPTION
# Summary

Forward `code_slot_num` through to `_lock_locked` and include `code_slot` (`code_slot_num`) and `code_slot_name` on `keymaster_lock_state_changed` bus events for lock operations, matching unlock events. Also normalizes `code_slot_name` to `""` for unnamed slots across both unlock and lock events.

## Proposed change

When a lock event occurs with user slot information (e.g. keypad locking with PIN), the provider extracts `code_slot_num` from the payload, but `_handle_provider_lock_event` previously dropped `code_slot_num` when invoking `_lock_locked`. Furthermore, `_lock_locked` omitted `code_slot` / `code_slot_name` from the fired `keymaster_lock_state_changed` event and did not format user slot details into the lock notification message.

This change:
1. Updates `_handle_provider_lock_event` to pass `code_slot_num` to `_lock_locked`.
2. Updates `_lock_locked` to accept `code_slot_num: int | None = None` and coerce non-int values to `0`.
3. Adds slot-0 supersede handling on the lock side so a following `code_slot_num > 0` lock event updates and re-fires the state changed event with slot info, mirroring `_lock_unlocked`.
4. Extracted shared `_format_slot_message` static helper for formatting `by <name> [<slot>]` or `by Code Slot <slot>`.
5. Unified `_fire_lock_state_changed_event` helper to construct and fire `EVENT_KEYMASTER_LOCK_STATE_CHANGED` for both lock and unlock events, normalizing `code_slot_name` to `""` if the slot is unnamed (`name=None`).
6. Adds unit tests for named slot, unnamed slot, non-int coercion, missing slot in `code_slots`, unlock unnamed slot empty string normalization, and slot-0 lock supersede behavior without duplicate side effects.

*Note: Per-code-slot notification switches (`slot.notifications`) and lock-side notification deferral for superseded events remain scoped for a separate follow-up issue.*

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #737
- This PR is related to issue:
