### PR TITLE
perf(entity): skip unchanged Keymaster entity state writes

### DIFF
--- a/custom_components/keymaster/binary_sensor.py
+++ b/custom_components/keymaster/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -108,4 +109,8 @@ class KeymasterBinarySensor(KeymasterEntity, BinarySensorEntity):
     def _handle_coordinator_update(self) -> None:
         # _LOGGER.debug(f"[Binary Sensor handle_coordinator_update] self.coordinator.data: {self.coordinator.data}")
         self._attr_is_on = self._get_property_value()
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed()
+
+    def _state_signature(self) -> tuple[Any, ...]:
+        """Return a comparable snapshot including the on/off value."""
+        return (*super()._state_signature(), self._attr_is_on)

--- a/custom_components/keymaster/button.py
+++ b/custom_components/keymaster/button.py
@@ -88,7 +88,7 @@ class KeymasterButton(KeymasterEntity, ButtonEntity):
     def _handle_coordinator_update(self) -> None:
         if not self._kmlock or not self._kmlock.connected:
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if (
@@ -97,11 +97,11 @@ class KeymasterButton(KeymasterEntity, ButtonEntity):
             and self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         self._attr_available = True
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed()
 
     async def async_press(self) -> None:
         """Take action when button is pressed."""

--- a/custom_components/keymaster/datetime.py
+++ b/custom_components/keymaster/datetime.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import datetime as dt
 import logging
+from typing import Any
 
 from homeassistant.components.datetime import DateTimeEntity, DateTimeEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -95,7 +96,7 @@ class KeymasterDateTime(KeymasterEntity, DateTimeEntity):
         # _LOGGER.debug(f"[DateTime handle_coordinator_update] self.coordinator.data: {self.coordinator.data}")
         if not self._kmlock or not self._kmlock.connected:
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if (
@@ -108,19 +109,23 @@ class KeymasterDateTime(KeymasterEntity, DateTimeEntity):
             )
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if ".code_slots" in self._property and (
             not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         self._attr_available = True
         self._attr_native_value = self._get_property_value()
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed()
+
+    def _state_signature(self) -> tuple[Any, ...]:
+        """Return a comparable snapshot including the native value."""
+        return (*super()._state_signature(), self._attr_native_value)
 
     async def async_set_value(self, value: dt) -> None:
         """Update the datetime entity value."""

--- a/custom_components/keymaster/entity.py
+++ b/custom_components/keymaster/entity.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 import logging
-from typing import Any, Literal
+from typing import Any, Final, Literal
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -18,6 +19,28 @@ from .coordinator import KeymasterLockCoordinator
 from .lock import KeymasterLock
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+# Sentinel marking that no state signature has been captured yet, so the first
+# write always happens even if the first computed signature is falsy or None.
+_UNSET: Final = object()
+
+
+def _freeze(value: Any) -> Any:
+    """Return a stable, comparable, hashable snapshot of an attribute payload.
+
+    Attribute payloads such as ``extra_state_attributes`` are mutable and can be
+    mutated in place, so a stored reference would compare equal to its own later
+    mutations.  Recursively convert containers into immutable equivalents to
+    capture a true point-in-time snapshot.
+    """
+    if isinstance(value, Mapping):
+        return tuple(sorted((str(key), _freeze(val)) for key, val in value.items()))
+    if isinstance(value, list | tuple):
+        return tuple(_freeze(val) for val in value)
+    if isinstance(value, set | frozenset):
+        return frozenset(_freeze(val) for val in value)
+    return value
+
 
 # Naming convention for EntityDescription key (Property) for all entities:
 # <Platform>.<Property>.<SubProperty>:<Slot Number*>.<SubProperty>:<Slot Number*>  *Only if needed
@@ -53,6 +76,7 @@ class KeymasterEntity(CoordinatorEntity[KeymasterLockCoordinator]):
         #     self.unique_id,
         # )
         self._attr_extra_state_attributes: dict[str, Any] = {}
+        self._last_state_signature: Any = _UNSET
         self._attr_device_info: DeviceInfo = {
             "identifiers": {(DOMAIN, self._config_entry.entry_id)},
         }
@@ -74,6 +98,23 @@ class KeymasterEntity(CoordinatorEntity[KeymasterLockCoordinator]):
             return
 
         self._handle_coordinator_update()
+
+    def _state_signature(self) -> tuple[Any, ...]:
+        """Return a comparable snapshot of everything this entity publishes."""
+        return (self._attr_available, _freeze(self._attr_extra_state_attributes))
+
+    @callback
+    def async_write_ha_state_if_changed(self, *, force: bool = False) -> None:
+        """Write state only when this entity's published data actually changed."""
+        signature = self._state_signature()
+        if (
+            not force
+            and self._last_state_signature is not _UNSET
+            and self._last_state_signature == signature
+        ):
+            return
+        self._last_state_signature = signature
+        self.async_write_ha_state()
 
     @property
     def available(self) -> bool:

--- a/custom_components/keymaster/event.py
+++ b/custom_components/keymaster/event.py
@@ -121,7 +121,7 @@ class KeymasterCodeSlotEventEntity(KeymasterEntity, EventEntity):
                 ATTR_NAME: event.data.get(ATTR_NAME, ""),
             },
         )
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed(force=True)
 
     @callback
     def _handle_reset_event(self, event: Event) -> None:
@@ -134,25 +134,25 @@ class KeymasterCodeSlotEventEntity(KeymasterEntity, EventEntity):
             return
 
         self._clear_event_state()
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed(force=True)
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator data updates for availability."""
         if not self._kmlock or not self._kmlock.connected:
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if ".code_slots" in self._property and (
             not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         self._attr_available = True
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed()
 
     def _clear_event_state(self) -> None:
         """Clear the event entity state back to None."""

--- a/custom_components/keymaster/number.py
+++ b/custom_components/keymaster/number.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import Any
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -128,7 +129,7 @@ class KeymasterNumber(KeymasterEntity, NumberEntity):
         # _LOGGER.debug(f"[Number handle_coordinator_update] self.coordinator.data: {self.coordinator.data}")
         if not self._kmlock or not self._kmlock.connected:
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if (
@@ -142,19 +143,23 @@ class KeymasterNumber(KeymasterEntity, NumberEntity):
             )
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if ".code_slots" in self._property and (
             not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         self._attr_available = True
         self._attr_native_value = self._get_property_value()
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed()
+
+    def _state_signature(self) -> tuple[Any, ...]:
+        """Return a comparable snapshot including the native value."""
+        return (*super()._state_signature(), self._attr_native_value)
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the value of the entity."""
@@ -187,5 +192,5 @@ class KeymasterNumber(KeymasterEntity, NumberEntity):
             value = int(value)
         if self._set_property_value(value):
             self._attr_native_value = value
-            self.async_write_ha_state()  # Immediate UI update
+            self.async_write_ha_state_if_changed(force=True)  # Immediate UI update
             await self.coordinator.async_request_debounced_refresh()

--- a/custom_components/keymaster/sensor.py
+++ b/custom_components/keymaster/sensor.py
@@ -124,19 +124,23 @@ class KeymasterSensor(KeymasterEntity, SensorEntity):
         # _LOGGER.debug(f"[Sensor handle_coordinator_update] self.coordinator.data: {self.coordinator.data}")
         if not self._kmlock or not self._kmlock.connected:
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if ".code_slots" in self._property and (
             not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         self._attr_available = True
         self._attr_native_value = self._get_property_value()
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed()
+
+    def _state_signature(self) -> tuple[Any, ...]:
+        """Return a comparable snapshot including the native value."""
+        return (*super()._state_signature(), self._attr_native_value)
 
 
 class KeymasterAutoLockSensor(KeymasterEntity, SensorEntity):
@@ -170,7 +174,7 @@ class KeymasterAutoLockSensor(KeymasterEntity, SensorEntity):
     def _handle_coordinator_update(self) -> None:
         if not self._kmlock or not self._kmlock.connected:
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         self._attr_available = True
@@ -204,4 +208,8 @@ class KeymasterAutoLockSensor(KeymasterEntity, SensorEntity):
                 "finishes_at": None,
                 "is_running": False,
             }
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed()
+
+    def _state_signature(self) -> tuple[Any, ...]:
+        """Return a comparable snapshot including the native value."""
+        return (*super()._state_signature(), self._attr_native_value)

--- a/custom_components/keymaster/switch.py
+++ b/custom_components/keymaster/switch.py
@@ -190,7 +190,7 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
         # _LOGGER.debug(f"[Switch handle_coordinator_update] self.coordinator.data: {self.coordinator.data}")
         if not self._kmlock or not self._kmlock.connected:
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if (
@@ -207,7 +207,7 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
             )
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if (
@@ -216,7 +216,7 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
             and (not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots)
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if (
@@ -229,7 +229,7 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
             )
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         code_slots: MutableMapping[int, KeymasterCodeSlot] | None = self._kmlock.code_slots
@@ -246,7 +246,7 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
             or not accesslimit_dow[self._day_of_week_num].dow_enabled
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         # if self._property.endswith(".include_exclude") and (
@@ -271,12 +271,16 @@ class KeymasterSwitch(KeymasterEntity, SwitchEntity):
             or not accesslimit_dow[self._day_of_week_num].limit_by_time
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         self._attr_available = True
         self._attr_is_on = self._get_property_value()
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed()
+
+    def _state_signature(self) -> tuple[Any, ...]:
+        """Return a comparable snapshot including the on/off value."""
+        return (*super()._state_signature(), self._attr_is_on)
 
     async def async_turn_on(self, **_: Any) -> None:
         """Turn the entity on."""

--- a/custom_components/keymaster/text.py
+++ b/custom_components/keymaster/text.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import Any
 
 from homeassistant.components.text import TextEntity, TextEntityDescription, TextMode
 from homeassistant.config_entries import ConfigEntry
@@ -104,7 +105,7 @@ class KeymasterText(KeymasterEntity, TextEntity):
         # _LOGGER.debug("[Text handle_coordinator_update] self.coordinator.data: %s", self.coordinator.data)
         if not self._kmlock or not self._kmlock.connected:
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if (
@@ -117,14 +118,14 @@ class KeymasterText(KeymasterEntity, TextEntity):
             )
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if ".code_slots" in self._property and (
             not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         self._attr_available = True
@@ -136,7 +137,11 @@ class KeymasterText(KeymasterEntity, TextEntity):
             self._property,
             log_value,
         )
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed()
+
+    def _state_signature(self) -> tuple[Any, ...]:
+        """Return a comparable snapshot including the native value."""
+        return (*super()._state_signature(), self._attr_native_value)
 
     async def async_set_value(self, value: str) -> None:
         """Set the value of a text entity."""

--- a/custom_components/keymaster/time.py
+++ b/custom_components/keymaster/time.py
@@ -4,6 +4,7 @@ from collections.abc import MutableMapping
 from dataclasses import dataclass
 from datetime import time as dt_time
 import logging
+from typing import Any
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -100,7 +101,7 @@ class KeymasterTime(KeymasterEntity, TimeEntity):
         # _LOGGER.debug(f"[Time handle_coordinator_update] self.coordinator.data: {self.coordinator.data}")
         if not self._kmlock or not self._kmlock.connected:
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if (
@@ -113,14 +114,14 @@ class KeymasterTime(KeymasterEntity, TimeEntity):
             )
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if ".code_slots" in self._property and (
             not self._kmlock.code_slots or self._code_slot not in self._kmlock.code_slots
         ):
             self._attr_available = False
-            self.async_write_ha_state()
+            self.async_write_ha_state_if_changed()
             return
 
         if self._property.endswith(".time_start") or self._property.endswith(".time_end"):
@@ -137,12 +138,16 @@ class KeymasterTime(KeymasterEntity, TimeEntity):
                 or self._day_of_week_num not in accesslimit_day_of_week
             ):
                 self._attr_available = False
-                self.async_write_ha_state()
+                self.async_write_ha_state_if_changed()
                 return
 
         self._attr_available = True
         self._attr_native_value = self._get_property_value()
-        self.async_write_ha_state()
+        self.async_write_ha_state_if_changed()
+
+    def _state_signature(self) -> tuple[Any, ...]:
+        """Return a comparable snapshot including the native value."""
+        return (*super()._state_signature(), self._attr_native_value)
 
     async def async_set_value(self, value: dt_time) -> None:
         """Update value for a time entity."""

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,13 +1,17 @@
 """Test keymaster binary sensors."""
 
 import sys
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from zwave_js_server.event import Event
 
-from custom_components.keymaster.binary_sensor import async_setup_entry
+from custom_components.keymaster.binary_sensor import (
+    KeymasterBinarySensor,
+    KeymasterBinarySensorEntityDescription,
+    async_setup_entry,
+)
 from custom_components.keymaster.const import (
     CONF_LOCK_ENTITY_ID,
     CONF_SLOTS,
@@ -16,7 +20,7 @@ from custom_components.keymaster.const import (
     DOMAIN,
 )
 from custom_components.keymaster.coordinator import KeymasterCoordinator
-from custom_components.keymaster.lock import KeymasterLock
+from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
 from homeassistant.components.lock.const import LockState
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.helpers.entity import EntityCategory
@@ -207,3 +211,52 @@ async def test_zwavejs_network_ready(hass, client, lock_kwikset_910, integration
     assert hass.states.get(NETWORK_READY_ENTITY).state == "off"
 
     assert "Z-Wave integration not found" not in caplog.text
+
+
+async def test_binary_sensor_skips_unchanged_state_writes(hass):
+    """Test binary sensor only writes state when its published value changes."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="test_lock",
+        data={**CONFIG_DATA_910, CONF_START: 1, CONF_SLOTS: 1},
+    )
+    config_entry.add_to_hass(hass)
+
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    kmlock = KeymasterLock(
+        lock_name="Test Lock",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=config_entry.entry_id,
+    )
+    kmlock.provider = None
+    kmlock.connected = True
+    kmlock.code_slots = {1: KeymasterCodeSlot(number=1, active=True)}
+    coordinator.kmlocks[config_entry.entry_id] = kmlock
+    hass.data.setdefault(DOMAIN, {})[COORDINATOR] = coordinator
+
+    lock_coordinator = coordinator.async_get_lock_coordinator(config_entry.entry_id)
+    entity = KeymasterBinarySensor(
+        entity_description=KeymasterBinarySensorEntityDescription(
+            key="binary_sensor.code_slots:1.active",
+            name="Code Slot 1: Active",
+            hass=hass,
+            config_entry=config_entry,
+            coordinator=lock_coordinator,
+        )
+    )
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+        assert entity._attr_is_on is True
+
+        # Identical update is suppressed.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # Changing the exposed value writes exactly once.
+        kmlock.code_slots[1].active = False
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 2
+        assert entity._attr_is_on is False

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -273,3 +273,44 @@ async def test_button_press_reset_code_slot(hass: HomeAssistant, button_config_e
             config_entry_id=button_config_entry.entry_id,
             code_slot_num=1,
         )
+
+
+async def test_button_skips_unchanged_state_writes(
+    hass: HomeAssistant, button_config_entry, coordinator
+):
+    """Test button entity (availability-only) dedupes unchanged writes."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=button_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {1: KeymasterCodeSlot(number=1, enabled=True)}
+    coordinator.kmlocks[button_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterButtonEntityDescription(
+        key="button.code_slots:1.reset",
+        name="Code Slot 1: Reset",
+        icon="mdi:lock-reset",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=button_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterButton(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+        assert entity._attr_available is True
+
+        # Identical availability update is suppressed.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # Availability flip still writes.
+        kmlock.connected = False
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 2
+        assert entity._attr_available is False

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -438,3 +438,56 @@ async def test_datetime_entities_can_be_preset_when_feature_disabled(
     assert entity._attr_available
     assert entity._attr_native_value == value
     assert getattr(kmlock.code_slots[1], attr_name) == value
+
+
+async def test_datetime_skips_unchanged_state_writes(
+    hass: HomeAssistant, datetime_config_entry, coordinator
+):
+    """Test datetime entity only writes state when its published value changes."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=datetime_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(
+            number=1,
+            accesslimit_date_range_enabled=True,
+            accesslimit_date_range_start=datetime(2024, 1, 1, 0, 0, 0),
+        )
+    }
+    coordinator.kmlocks[datetime_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterDateTimeEntityDescription(
+        key="datetime.code_slots:1.accesslimit_date_range_start",
+        name="Code Slot 1: Date Range Start",
+        icon="mdi:calendar-start",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=datetime_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterDateTime(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+        assert entity._attr_native_value == datetime(2024, 1, 1, 0, 0, 0)
+
+        # Identical update is suppressed.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # Changing the exposed value writes exactly once.
+        kmlock.code_slots[1].accesslimit_date_range_start = datetime(2024, 6, 1, 0, 0, 0)
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 2
+        assert entity._attr_native_value == datetime(2024, 6, 1, 0, 0, 0)
+
+        # Availability flip still writes.
+        kmlock.connected = False
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 3
+        assert entity._attr_available is False

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -14,7 +14,7 @@ from custom_components.keymaster.const import (
     DOMAIN,
 )
 from custom_components.keymaster.coordinator import KeymasterCoordinator
-from custom_components.keymaster.entity import KeymasterEntity, KeymasterEntityDescription
+from custom_components.keymaster.entity import KeymasterEntity, KeymasterEntityDescription, _freeze
 from custom_components.keymaster.lock import (
     KeymasterCodeSlot,
     KeymasterCodeSlotDayOfWeek,
@@ -975,3 +975,38 @@ async def test_entity_dynamic_kmlock_replacement(
     entity._set_property_value(False)
     assert kmlock2.autolock_enabled is False
     assert kmlock1.autolock_enabled is False  # untouched
+
+
+def test_freeze_produces_stable_hashable_snapshots():
+    """Test _freeze recursively converts payloads into comparable snapshots."""
+
+    # Mappings become sorted tuples keyed by str(key) and recurse into values.
+    frozen_map = _freeze({"b": [1, 2], "a": {"nested": (3, 4)}})
+    assert frozen_map == (
+        ("a", (("nested", (3, 4)),)),
+        ("b", (1, 2)),
+    )
+
+    # Lists and tuples become tuples.
+    assert _freeze([1, [2, 3]]) == (1, (2, 3))
+    assert _freeze((1, 2)) == (1, 2)
+
+    # Sets and frozensets become frozensets.
+    assert _freeze({1, 2, 3}) == frozenset({1, 2, 3})
+    assert _freeze(frozenset({4, 5})) == frozenset({4, 5})
+
+    # Scalars are returned as-is.
+    assert _freeze("value") == "value"
+    assert _freeze(None) is None
+
+    # The result must be hashable so signatures can be compared cheaply.
+    assert hash(_freeze({"x": [1, {2, 3}]})) == hash((("x", (1, frozenset({2, 3}))),))
+
+
+def test_freeze_snapshot_is_independent_of_later_mutation():
+    """Test a frozen snapshot does not reflect later in-place mutation."""
+
+    payload: dict = {"items": [1, 2]}
+    snapshot = _freeze(payload)
+    payload["items"].append(3)
+    assert snapshot == (("items", (1, 2)),)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -498,3 +498,82 @@ async def test_event_entity_created_in_setup(hass: HomeAssistant):
     lock_coordinator = coordinator.async_get_lock_coordinator(config_entry.entry_id)
     assert all(entity.coordinator is lock_coordinator for entity in added_entities)
     assert added_entities[0].unique_id == f"{config_entry.entry_id}_event_code_slots_1_last_used"
+
+
+async def test_event_coordinator_update_skips_unchanged_writes(hass: HomeAssistant):
+    """Test event availability updates are deduped when nothing changed."""
+    config_entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA_EVENT)
+    config_entry.add_to_hass(hass)
+
+    coordinator = KeymasterCoordinator(hass)
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {1: KeymasterCodeSlot(number=1, name="Guest")}
+    coordinator.kmlocks[config_entry.entry_id] = kmlock
+
+    entity = _make_entity(hass, config_entry, coordinator)
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+        assert entity._attr_available is True
+
+        # Identical availability update is suppressed.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # Availability flip still writes.
+        kmlock.connected = False
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 2
+        assert entity._attr_available is False
+
+
+async def test_event_real_events_always_write(hass: HomeAssistant):
+    """Test lock and reset events force a write even when availability is unchanged."""
+    config_entry = MockConfigEntry(domain=DOMAIN, title="frontdoor", data=CONFIG_DATA_EVENT)
+    config_entry.add_to_hass(hass)
+
+    coordinator = KeymasterCoordinator(hass)
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {1: KeymasterCodeSlot(number=1, name="Guest")}
+    coordinator.kmlocks[config_entry.entry_id] = kmlock
+
+    entity = _make_entity(hass, config_entry, coordinator)
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        # Establish a stored signature via a coordinator update.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # A real unlock event must write even though availability is unchanged.
+        unlock_event = MagicMock()
+        unlock_event.data = {
+            ATTR_STATE: LockState.UNLOCKED,
+            ATTR_ENTITY_ID: "lock.test",
+            ATTR_CODE_SLOT: 1,
+            ATTR_CODE_SLOT_NAME: "Guest",
+            ATTR_NAME: "frontdoor",
+        }
+        entity._handle_lock_event(unlock_event)
+        assert mock_write.call_count == 2
+        assert entity.state is not None
+
+        # A code slot reset event must also always write.
+        reset_event = MagicMock()
+        reset_event.data = {
+            ATTR_CODE_SLOT: 1,
+            ATTR_ENTITY_ID: "lock.test",
+        }
+        entity._handle_reset_event(reset_event)
+        assert mock_write.call_count == 3
+        assert entity.state is None

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -680,3 +680,54 @@ async def test_number_entities_can_be_preset_when_feature_disabled(
         assert kmlock.code_slots is not None
         target = kmlock.code_slots[1]
     assert getattr(target, lock_attr) == value
+
+
+async def test_number_skips_unchanged_state_writes(
+    hass: HomeAssistant, number_config_entry, coordinator
+):
+    """Test number entity only writes state when its published value changes."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=number_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {1: KeymasterCodeSlot(number=1, enabled=True, accesslimit_count=5)}
+    coordinator.kmlocks[number_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterNumberEntityDescription(
+        key="number.code_slots:1.accesslimit_count",
+        name="Code Slot 1: Uses Remaining",
+        icon="mdi:counter",
+        mode=NumberMode.BOX,
+        native_min_value=0,
+        native_max_value=100,
+        native_step=1,
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=number_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterNumber(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+        assert entity._attr_native_value == 5
+
+        # Identical update is suppressed.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # Changing the exposed value writes exactly once.
+        kmlock.code_slots[1].accesslimit_count = 3
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 2
+        assert entity._attr_native_value == 3
+
+        # Availability flip still writes.
+        kmlock.connected = False
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 3
+        assert entity._attr_available is False

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -576,3 +576,83 @@ async def test_autolock_sensor_keeps_value_when_autolock_disabled(
     assert entity._attr_available
     assert entity._attr_native_value == end_time
     assert entity._attr_extra_state_attributes["is_running"] is True
+
+
+async def test_sensor_skips_unchanged_state_writes(
+    hass: HomeAssistant, sensor_config_entry, coordinator
+):
+    """Test sensor only writes state when its published value changes."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=sensor_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    coordinator.kmlocks[sensor_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterSensorEntityDescription(
+        key="sensor.lock_name",
+        name="Lock Name",
+        icon="mdi:account-lock",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=sensor_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterSensor(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+        assert entity._attr_native_value == "frontdoor"
+
+        # Identical update is suppressed.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # Changing the exposed value writes exactly once.
+        kmlock.lock_name = "backdoor"
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 2
+        assert entity._attr_native_value == "backdoor"
+
+        # Availability flip still writes.
+        kmlock.connected = False
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 3
+        assert entity._attr_available is False
+
+
+async def test_autolock_sensor_skips_unchanged_attribute_writes(
+    hass: HomeAssistant, sensor_config_entry, coordinator
+):
+    """Test the auto-lock timer sensor dedupes identical attribute payloads."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=sensor_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.autolock_timer = None
+    coordinator.kmlocks[sensor_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterSensorEntityDescription(
+        key="sensor.autolock_timer",
+        name="Auto Lock Timer",
+        icon="mdi:timer",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=sensor_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterAutoLockSensor(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # Identical rebuilt (but not identical object) attributes are deduped.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -22,7 +22,11 @@ from custom_components.keymaster.const import (
     DOMAIN,
 )
 from custom_components.keymaster.coordinator import KeymasterCoordinator
-from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
+from custom_components.keymaster.lock import (
+    KeymasterCodeSlot,
+    KeymasterCodeSlotDayOfWeek,
+    KeymasterLock,
+)
 from custom_components.keymaster.switch import (
     KeymasterSwitch,
     KeymasterSwitchEntityDescription,
@@ -822,3 +826,198 @@ async def test_switch_available_for_override_parent(
 
     # override_parent switches should always be available (not affected by child lock logic)
     assert entity._attr_available
+
+
+async def test_switch_skips_unchanged_state_writes(
+    hass: HomeAssistant, switch_config_entry, coordinator
+):
+    """Test switch only writes state when its published data changes."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=switch_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.autolock_enabled = False
+    coordinator.kmlocks[switch_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterSwitchEntityDescription(
+        key="switch.autolock_enabled",
+        name="Auto Lock",
+        icon="mdi:lock-clock",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=switch_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterSwitch(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        # First update always writes.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+        assert entity._attr_is_on is False
+
+        # Identical second update is suppressed.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # Changing the exposed value writes exactly once.
+        kmlock.autolock_enabled = True
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 2
+        assert entity._attr_is_on is True
+
+        # Availability flip still writes.
+        kmlock.connected = False
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 3
+        assert entity._attr_available is False
+
+
+async def test_switch_unavailable_when_non_enabled_slot_missing(
+    hass: HomeAssistant, switch_config_entry, coordinator
+):
+    """Test non-enabled code slot switch is unavailable when the slot is missing."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=switch_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {}
+    coordinator.kmlocks[switch_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterSwitchEntityDescription(
+        key="switch.code_slots:1.notifications",
+        name="Code Slot 1: Notifications",
+        icon="mdi:bell",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=switch_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterSwitch(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state"):
+        entity._handle_coordinator_update()
+
+    assert not entity._attr_available
+
+
+async def test_switch_unavailable_when_dow_not_enabled(
+    hass: HomeAssistant, switch_config_entry, coordinator
+):
+    """Test day-of-week switch is unavailable when day-of-week limits are disabled."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=switch_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, enabled=True, accesslimit_day_of_week_enabled=False)
+    }
+    coordinator.kmlocks[switch_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterSwitchEntityDescription(
+        key="switch.code_slots:1.accesslimit_day_of_week:0.dow_enabled",
+        name="Code Slot 1: Monday Enabled",
+        icon="mdi:calendar",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=switch_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterSwitch(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state"):
+        entity._handle_coordinator_update()
+
+    assert not entity._attr_available
+
+
+async def test_switch_unavailable_when_limit_by_time_dow_missing(
+    hass: HomeAssistant, switch_config_entry, coordinator
+):
+    """Test limit_by_time switch is unavailable when the day-of-week entry is missing."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=switch_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(
+            number=1,
+            enabled=True,
+            accesslimit_day_of_week_enabled=True,
+            accesslimit_day_of_week={},
+        )
+    }
+    coordinator.kmlocks[switch_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterSwitchEntityDescription(
+        key="switch.code_slots:1.accesslimit_day_of_week:0.limit_by_time",
+        name="Code Slot 1: Monday Limit By Time",
+        icon="mdi:clock",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=switch_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterSwitch(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state"):
+        entity._handle_coordinator_update()
+
+    assert not entity._attr_available
+
+
+async def test_switch_unavailable_when_include_exclude_not_time_limited(
+    hass: HomeAssistant, switch_config_entry, coordinator
+):
+    """Test include_exclude switch is unavailable when the day is not time limited."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=switch_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(
+            number=1,
+            enabled=True,
+            accesslimit_day_of_week_enabled=True,
+            accesslimit_day_of_week={
+                0: KeymasterCodeSlotDayOfWeek(
+                    day_of_week_num=0,
+                    day_of_week_name="Monday",
+                    dow_enabled=True,
+                    limit_by_time=False,
+                )
+            },
+        )
+    }
+    coordinator.kmlocks[switch_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterSwitchEntityDescription(
+        key="switch.code_slots:1.accesslimit_day_of_week:0.include_exclude",
+        name="Code Slot 1: Monday Include Exclude",
+        icon="mdi:call-split",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=switch_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterSwitch(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state"):
+        entity._handle_coordinator_update()
+
+    assert not entity._attr_available

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -692,3 +692,50 @@ async def test_text_entity_redaction_behavior(hass: HomeAssistant, text_config_e
     # 3. No kmlock (should not redact)
     with patch.object(coordinator, "sync_get_lock_by_config_entry_id", return_value=None):
         assert entity_pin._redact_value("1234") == "1234"
+
+
+async def test_text_skips_unchanged_state_writes(
+    hass: HomeAssistant, text_config_entry, coordinator
+):
+    """Test text entity only writes state when its published value changes."""
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=text_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {1: KeymasterCodeSlot(number=1, name="Test User")}
+    coordinator.kmlocks[text_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterTextEntityDescription(
+        key="text.code_slots:1.name",
+        name="Code Slot 1: Name",
+        icon="mdi:form-textbox-lock",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=text_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterText(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+        assert entity._attr_native_value == "Test User"
+
+        # Identical update is suppressed.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # Changing the exposed value writes exactly once.
+        kmlock.code_slots[1].name = "New User"
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 2
+        assert entity._attr_native_value == "New User"
+
+        # Availability flip still writes.
+        kmlock.connected = False
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 3
+        assert entity._attr_available is False

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -671,3 +671,68 @@ async def test_time_entities_can_be_preset_when_feature_disabled(
     assert entity._attr_available
     assert entity._attr_native_value == value
     assert getattr(day_of_week, attr_name) == value
+
+
+async def test_time_skips_unchanged_state_writes(hass: HomeAssistant, time_config_entry):
+    """Test time entity only writes state when its published value changes."""
+    coordinator = hass.data[DOMAIN][COORDINATOR]
+
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=time_config_entry.entry_id,
+    )
+    kmlock.connected = True
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(
+            number=1,
+            enabled=True,
+            accesslimit_day_of_week_enabled=True,
+            accesslimit_day_of_week={
+                0: KeymasterCodeSlotDayOfWeek(
+                    day_of_week_num=0,
+                    day_of_week_name="Monday",
+                    dow_enabled=True,
+                    limit_by_time=True,
+                    time_start=dt_time(8, 0, 0),
+                    time_end=dt_time(18, 0, 0),
+                )
+            },
+        )
+    }
+    coordinator.kmlocks[time_config_entry.entry_id] = kmlock
+
+    entity_description = KeymasterTimeEntityDescription(
+        key="time.code_slots:1.accesslimit_day_of_week:0.time_start",
+        name="Code Slot 1: Monday - Start Time",
+        icon="mdi:clock-start",
+        entity_registry_enabled_default=True,
+        hass=hass,
+        config_entry=time_config_entry,
+        coordinator=coordinator,
+    )
+
+    entity = KeymasterTime(entity_description=entity_description)
+
+    with patch.object(entity, "async_write_ha_state") as mock_write:
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+        assert entity._attr_native_value == dt_time(8, 0, 0)
+
+        # Identical update is suppressed.
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 1
+
+        # Changing the exposed value writes exactly once.
+        dow = kmlock.code_slots[1].accesslimit_day_of_week
+        assert dow is not None
+        dow[0].time_start = dt_time(9, 30, 0)
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 2
+        assert entity._attr_native_value == dt_time(9, 30, 0)
+
+        # Availability flip still writes.
+        kmlock.connected = False
+        entity._handle_coordinator_update()
+        assert mock_write.call_count == 3
+        assert entity._attr_available is False


### PR DESCRIPTION
# Summary

Sub-issue of #670 ("event-loop storm on large installs"). This is a pure
performance optimization that cuts redundant state-event volume by skipping
`async_write_ha_state()` calls when an entity's published data has not changed.

## Proposed change

On large installs, every per-lock coordinator push wrote entity state
unconditionally, queuing a state event even when nothing about the entity
changed. Coordinator-level dedupe is not available for these entities:

- `DataUpdateCoordinator.async_set_updated_data()` unconditionally calls
  `async_update_listeners()`; the `always_update` flag is only consulted inside
  `_async_refresh()`. Because `KeymasterLockCoordinator` sets
  `update_interval=None` and is driven exclusively via `async_set_updated_data`,
  its `always_update=False` is inert.
- Home Assistant still fires `EVENT_STATE_REPORTED` for an unchanged
  `async_write_ha_state()`, so an unchanged write is cheap but not free — it
  still costs one queued event against the 10,000-event guard.

The only remaining lever is deciding whether to **call**
`async_write_ha_state()` at all. Per maintainer guidance, this does **not**
reimplement HA's state/attribute comparison; instead it gates the write on the
entity's own derived signature and lets HA dedupe underneath.

Changes:

- Add `KeymasterEntity.async_write_ha_state_if_changed()` plus an overridable
  `_state_signature()` and a recursive `_freeze()` helper that snapshots
  attribute payloads into a stable, hashable form (so in-place mutation of
  `extra_state_attributes` cannot cause a false dedupe). A sentinel guarantees
  the first write always happens.
- Every `_handle_coordinator_update` handler across all platforms now uses the
  gated write. Per-platform `_state_signature()` overrides append the published
  value (`_attr_is_on` / `_attr_native_value`).
- Command- and event-driven writes are forced (`force=True`): the number
  entity's optimistic UI update, and — critically — the event platform's real
  lock/unlock and code-slot reset handlers, which mutate name-mangled
  `EventEntity` state that is not part of the signature.

Tests were added per platform asserting: identical updates do not write,
value/availability changes write exactly once, and real event/reset writes
always fire even when availability is unchanged.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #677
- This PR is related to issue: #670
