### PR TITLE
fix(schlage): support HA 2026.9 plain-dict coordinator data

### DIFF
--- a/custom_components/keymaster/providers/schlage.py
+++ b/custom_components/keymaster/providers/schlage.py
@@ -13,6 +13,7 @@ services (``schlage.get_codes``, ``schlage.add_code``,
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 import logging
 import re
@@ -57,6 +58,23 @@ def _is_masked_pin(pin: str) -> bool:
         return True
     # Only treat '*' repeated as masked; allow real all-zero PINs like '0000'.
     return len(set(pin)) == 1 and pin[0] == "*"
+
+
+def _get_schlage_locks(coordinator: Any) -> Mapping[str, Any] | None:
+    """Return the Schlage coordinator's lock mapping across HA data-shape changes.
+
+    HA < 2026.9 stored a ``SchlageData`` dataclass exposing ``locks``.
+    HA >= 2026.9 stores ``dict[str, LockData]`` directly (core commit fc49ae5).
+    """
+    data = getattr(coordinator, "data", None)
+    if data is None:
+        return None
+    locks = getattr(data, "locks", None)
+    if isinstance(locks, Mapping):
+        return locks
+    if isinstance(data, Mapping):
+        return data
+    return None
 
 
 @dataclass
@@ -147,18 +165,16 @@ class SchlageLockProvider(BaseLockProvider):
             )
             return False
 
-        try:
-            if schlage_device_id not in coordinator.data.locks:
-                _LOGGER.error(
-                    "[SchlageProvider] Lock %s not found in Schlage coordinator data",
-                    schlage_device_id,
-                )
-                return False
-        except (AttributeError, TypeError) as e:
+        locks = _get_schlage_locks(coordinator)
+        if locks is None:
             _LOGGER.error(
-                "[SchlageProvider] Can't access Schlage coordinator data: %s: %s",
-                e.__class__.__qualname__,
-                e,
+                "[SchlageProvider] Can't access Schlage coordinator data",
+            )
+            return False
+        if schlage_device_id not in locks:
+            _LOGGER.error(
+                "[SchlageProvider] Lock %s not found in Schlage coordinator data",
+                schlage_device_id,
             )
             return False
 
@@ -192,7 +208,7 @@ class SchlageLockProvider(BaseLockProvider):
             self._connected = False
             return False
 
-        locks = getattr(coordinator.data, "locks", None)
+        locks = _get_schlage_locks(coordinator)
         self._connected = bool(locks and self._schlage_device_id in locks)
         return self._connected
 

--- a/tests/providers/test_schlage.py
+++ b/tests/providers/test_schlage.py
@@ -9,6 +9,7 @@ import pytest
 from custom_components.keymaster.const import CONF_REDACT_SLOT_NAMES
 from custom_components.keymaster.providers.schlage import (
     SchlageLockProvider,
+    _get_schlage_locks,
     _make_tagged_name,
     _parse_tag,
 )
@@ -141,6 +142,54 @@ class TestProperties:
 # ---------------------------------------------------------------------------
 
 
+class TestGetSchlageLocks:
+    """Tests for the shape-tolerant _get_schlage_locks helper."""
+
+    def test_data_none(self):
+        """Return None when coordinator.data is None."""
+        coordinator = MagicMock()
+        coordinator.data = None
+        assert _get_schlage_locks(coordinator) is None
+
+    def test_no_coordinator_data_attr(self):
+        """Return None when coordinator has no data attribute at all."""
+        coordinator = type("Coordinator", (), {})()
+        assert _get_schlage_locks(coordinator) is None
+
+    def test_old_shape_locks_attribute(self):
+        """HA < 2026.9: data exposes a .locks mapping."""
+        locks = {"dev123": object()}
+        data = MagicMock()
+        data.locks = locks
+        coordinator = MagicMock()
+        coordinator.data = data
+        assert _get_schlage_locks(coordinator) is locks
+
+    def test_new_shape_plain_dict(self):
+        """HA >= 2026.9: data IS the mapping, with no .locks attribute."""
+        data = {"dev123": object()}
+        coordinator = MagicMock()
+        coordinator.data = data
+        assert _get_schlage_locks(coordinator) is data
+
+    def test_locks_present_but_none(self):
+        """A .locks attribute that is None falls back to data-as-mapping."""
+
+        class DictWithNoneLocks(dict):
+            locks = None
+
+        data = DictWithNoneLocks({"dev123": object()})
+        assert _get_schlage_locks(MagicMock(data=data)) is data
+
+    def test_non_mapping_data(self):
+        """Return None when data is neither a .locks holder nor a mapping."""
+        coordinator = MagicMock()
+        # A plain object() is truthy, has no ``locks`` attribute, and is not a
+        # Mapping, so the helper must fall through to ``return None``.
+        coordinator.data = object()
+        assert _get_schlage_locks(coordinator) is None
+
+
 class TestConnect:
     """Tests for async_connect."""
 
@@ -167,6 +216,49 @@ class TestConnect:
         assert schlage_provider._connected is True
         assert schlage_provider._schlage_device_id == "schlage_device_123"
         assert schlage_provider.lock_config_entry_id == "schlage_config_entry"
+
+    async def test_connect_success_new_dict_shape(self, schlage_provider):
+        """Test successful connection with HA >= 2026.9 plain-dict data."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_config_entry"
+        lock_entry.device_id = "ha_device_id"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
+        coordinator = MagicMock()
+        # New shape: coordinator.data IS the mapping, no .locks attribute.
+        coordinator.data = {"schlage_device_123": MagicMock()}
+        schlage_entry.runtime_data = coordinator
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {("schlage", "schlage_device_123")}
+        schlage_provider.device_registry.async_get.return_value = device_entry
+
+        result = await schlage_provider.async_connect()
+        assert result is True
+        assert schlage_provider._connected is True
+        assert schlage_provider._schlage_device_id == "schlage_device_123"
+
+    async def test_connect_lock_not_in_dict_shape(self, schlage_provider):
+        """Test connection fails when lock absent from plain-dict data."""
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        lock_entry.device_id = "ha_device"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
+        coordinator = MagicMock()
+        coordinator.data = {}  # New shape, empty
+        schlage_entry.runtime_data = coordinator
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {("schlage", "schlage_device_123")}
+        schlage_provider.device_registry.async_get.return_value = device_entry
+        assert await schlage_provider.async_connect() is False
 
     async def test_connect_entity_not_found(self, schlage_provider):
         """Test connection fails when entity not in registry."""
@@ -331,6 +423,40 @@ class TestIsConnected:
         schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
 
         assert await schlage_provider.async_is_connected() is True
+
+    async def test_connected_lock_in_dict_shape(self, schlage_provider):
+        """Test returns True with HA >= 2026.9 plain-dict data."""
+        schlage_provider._schlage_device_id = "dev123"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
+        coordinator = MagicMock()
+        coordinator.data = {"dev123": MagicMock()}  # New shape
+        schlage_entry.runtime_data = coordinator
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        assert await schlage_provider.async_is_connected() is True
+
+    async def test_not_connected_dict_shape_lock_absent(self, schlage_provider):
+        """Test returns False with plain-dict data missing the device id."""
+        schlage_provider._schlage_device_id = "dev123"
+
+        lock_entry = MagicMock()
+        lock_entry.config_entry_id = "schlage_entry"
+        schlage_provider.entity_registry.async_get.return_value = lock_entry
+
+        schlage_entry = MagicMock()
+        schlage_entry.state = ConfigEntryState.LOADED
+        coordinator = MagicMock()
+        coordinator.data = {"other": MagicMock()}  # New shape, wrong id
+        schlage_entry.runtime_data = coordinator
+        schlage_provider.hass.config_entries.async_get_entry.return_value = schlage_entry
+
+        assert await schlage_provider.async_is_connected() is False
 
     async def test_not_connected_lock_removed(self, schlage_provider):
         """Test returns False when lock removed from coordinator."""


### PR DESCRIPTION
# Summary

Home Assistant 2026.9 changes the Schlage integration's coordinator data
shape. The `SchlageData` dataclass wrapper (which exposed `.locks`) has been
removed, and `SchlageDataUpdateCoordinator.data` is now a plain
`dict[str, LockData]` (core commit `fc49ae5`, first tag **2026.9.0b0**).

Keymaster's Schlage provider read `.locks` off the coordinator data in two
places, so on HA >= 2026.9 the lock failed to set up ("Can't access Schlage
coordinator data") and `async_is_connected()` permanently reported `False`.
Fixes #740.

## Proposed change

Adds a shape-tolerant `_get_schlage_locks` helper used by both call sites in
`custom_components/keymaster/providers/schlage.py`:

- prefer a `.locks` mapping attribute (HA < 2026.9),
- otherwise treat `coordinator.data` itself as a mapping (HA >= 2026.9),
- otherwise return `None` and keep the existing "can't access coordinator
  data" error path (setup returns `False`).

A plain `dict` has no `.locks` attribute and `SchlageData` is not a `Mapping`,
so the two shapes cannot be confused. This keeps compatibility with the
current HA floor (2026.7.0) with **no manifest bump**, so a single release
works on both sides of the change.

Adds tests exercising both data shapes (old dataclass-with-`.locks` and new
plain dict) for `async_connect`, `async_is_connected`, and a direct unit test
of the helper. Patch coverage is 100% on the changed module.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #740
- This PR is related to issue:
