### PR TITLE
feat(coordinator): support per-code-slot notifications and keypad lock deferral

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -325,6 +325,8 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
         kmlock = coordinator.sync_get_lock_by_config_entry_id(config_entry.entry_id)
         if kmlock:
+            coordinator._cancel_pending_keypad_lock_notification(kmlock)  # noqa: SLF001
+            coordinator._cancel_pending_keypad_unlock_notification(kmlock)  # noqa: SLF001
             await KeymasterCoordinator._unsubscribe_listeners(kmlock)  # noqa: SLF001
             if kmlock.provider:
                 await kmlock.provider.async_unload()

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -86,8 +86,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 # dismiss-on-success loop in _lock_locked. Single source of truth so
 # new ids can't be added in one place and silently missed in the other.
 AUTOLOCK_NOTIFICATION_SUFFIXES: tuple[str, ...] = ("door_open", "door_closed", "failed")
-KEYPAD_UNLOCK_NOTIFICATION_DELAY_SECONDS = 1
-KEYPAD_LOCK_NOTIFICATION_DELAY_SECONDS = 1
+KEYPAD_NOTIFICATION_DELAY_SECONDS = 1
 
 STORAGE_VERSION = 1
 STORAGE_KEY = f"{DOMAIN}.locks"
@@ -304,6 +303,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         finally:
             self._deferred_notifications_shutting_down = True
             self.async_cancel_pending_notifications()
+            self._cancel_all_pending_keypad_notifications()
             self._lock_coordinators.clear()
             if self._refresh_keepalive_unsub is not None:
                 self._refresh_keepalive_unsub()
@@ -318,6 +318,17 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 self._cancel_debounced_refresh.clear()
             await super().async_shutdown()
             self._shutdown_complete = True
+
+    @callback
+    def _cancel_all_pending_keypad_notifications(self) -> None:
+        """Cancel every pending deferred keypad lock/unlock notification."""
+        for pending in (
+            self._pending_keypad_unlock_notifications,
+            self._pending_keypad_lock_notifications,
+        ):
+            for cancel in pending.values():
+                cancel()
+            pending.clear()
 
     @callback
     def async_schedule_all_lock_notifications(self) -> None:
@@ -1337,28 +1348,13 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         return True
 
-    async def _send_global_unlock_notification(
+    async def _send_global_slot_notification(
         self,
         kmlock: KeymasterLock,
         code_slot_num: int,
         event_label: str | None,
     ) -> None:
-        """Send a global unlock notification."""
-        message = self._format_slot_message(kmlock, code_slot_num, event_label)
-        await send_manual_notification(
-            hass=self.hass,
-            script_name=kmlock.notify_script_name,
-            title=kmlock.lock_name,
-            message=message,
-        )
-
-    async def _send_global_lock_notification(
-        self,
-        kmlock: KeymasterLock,
-        code_slot_num: int,
-        event_label: str | None,
-    ) -> None:
-        """Send a global lock notification."""
+        """Send a global lock/unlock notification."""
         message = self._format_slot_message(kmlock, code_slot_num, event_label)
         await send_manual_notification(
             hass=self.hass,
@@ -1376,7 +1372,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         """Send a deferred global keypad unlock notification."""
         self._pending_keypad_unlock_notifications.pop(kmlock.keymaster_config_entry_id, None)
         if kmlock.lock_notifications:
-            await self._send_global_unlock_notification(kmlock, 0, event_label)
+            await self._send_global_slot_notification(kmlock, 0, event_label)
         if self._last_unlock_code_slot.get(kmlock.keymaster_config_entry_id) == 0:
             self._last_unlock_code_slot[kmlock.keymaster_config_entry_id] = None
 
@@ -1389,7 +1385,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         """Send a deferred global keypad lock notification."""
         self._pending_keypad_lock_notifications.pop(kmlock.keymaster_config_entry_id, None)
         if kmlock.lock_notifications:
-            await self._send_global_lock_notification(kmlock, 0, event_label)
+            await self._send_global_slot_notification(kmlock, 0, event_label)
         if self._last_lock_code_slot.get(kmlock.keymaster_config_entry_id) == 0:
             self._last_lock_code_slot[kmlock.keymaster_config_entry_id] = None
 
@@ -1425,7 +1421,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._pending_keypad_unlock_notifications[kmlock.keymaster_config_entry_id] = (
             async_call_later(
                 hass=self.hass,
-                delay=KEYPAD_UNLOCK_NOTIFICATION_DELAY_SECONDS,
+                delay=KEYPAD_NOTIFICATION_DELAY_SECONDS,
                 action=functools.partial(
                     self._send_deferred_keypad_unlock_notification,
                     kmlock,
@@ -1444,7 +1440,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._pending_keypad_lock_notifications[kmlock.keymaster_config_entry_id] = (
             async_call_later(
                 hass=self.hass,
-                delay=KEYPAD_LOCK_NOTIFICATION_DELAY_SECONDS,
+                delay=KEYPAD_NOTIFICATION_DELAY_SECONDS,
                 action=functools.partial(
                     self._send_deferred_keypad_lock_notification,
                     kmlock,
@@ -1454,26 +1450,11 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
 
     @staticmethod
-    def _global_unlock_notification_superseded(
+    def _global_notification_superseded(
         kmlock: KeymasterLock,
         code_slot_num: int,
     ) -> bool:
-        """Return whether per-slot notification should replace global unlock text."""
-        if not kmlock.code_slots:
-            return False
-
-        if code_slot_num > 0:
-            slot = kmlock.code_slots.get(code_slot_num)
-            return bool(slot and slot.notifications)
-
-        return False
-
-    @staticmethod
-    def _global_lock_notification_superseded(
-        kmlock: KeymasterLock,
-        code_slot_num: int,
-    ) -> bool:
-        """Return whether per-slot notification should replace global lock text."""
+        """Return whether per-slot notification should replace global lock/unlock text."""
         if not kmlock.code_slots:
             return False
 
@@ -1551,7 +1532,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     and not sent_slot_notification
                     and kmlock.lock_notifications
                 ):
-                    await self._send_global_unlock_notification(kmlock, 0, event_label)
+                    await self._send_global_slot_notification(kmlock, 0, event_label)
             return
 
         if not self._throttle.is_allowed(
@@ -1567,6 +1548,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         kmlock.lock_state = LockState.UNLOCKED
         self._throttle.reset("lock_locked", kmlock.keymaster_config_entry_id)
         self._last_lock_code_slot.pop(kmlock.keymaster_config_entry_id, None)
+        self._cancel_pending_keypad_lock_notification(kmlock)
         _LOGGER.debug(
             "[lock_unlocked] %s: Running. code_slot_num: %s, source: %s, "
             "event_label: %s, action_code: %s",
@@ -1591,8 +1573,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if kmlock.lock_notifications:
             if self._should_defer_keypad_unlock_notification(kmlock, code_slot_num, event_label):
                 self._defer_keypad_unlock_notification(kmlock, event_label)
-            elif not self._global_unlock_notification_superseded(kmlock, code_slot_num):
-                await self._send_global_unlock_notification(kmlock, code_slot_num, event_label)
+            elif not self._global_notification_superseded(kmlock, code_slot_num):
+                await self._send_global_slot_notification(kmlock, code_slot_num, event_label)
 
         if code_slot_num > 0 and kmlock.code_slots and code_slot_num in kmlock.code_slots:
             if (
@@ -1679,7 +1661,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     and not sent_slot_notification
                     and kmlock.lock_notifications
                 ):
-                    await self._send_global_lock_notification(kmlock, 0, event_label)
+                    await self._send_global_slot_notification(kmlock, 0, event_label)
             if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
                 if kmlock.autolock_timer:
                     await kmlock.autolock_timer.cancel()
@@ -1744,8 +1726,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if kmlock.lock_notifications:
             if self._should_defer_keypad_lock_notification(kmlock, code_slot_num, event_label):
                 self._defer_keypad_lock_notification(kmlock, event_label)
-            elif not self._global_lock_notification_superseded(kmlock, code_slot_num):
-                await self._send_global_lock_notification(kmlock, code_slot_num, event_label)
+            elif not self._global_notification_superseded(kmlock, code_slot_num):
+                await self._send_global_slot_notification(kmlock, code_slot_num, event_label)
 
         if code_slot_num > 0 and kmlock.code_slots and code_slot_num in kmlock.code_slots:
             await self._send_code_slot_lock_notification(kmlock, code_slot_num, event_label)

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -87,6 +87,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 # new ids can't be added in one place and silently missed in the other.
 AUTOLOCK_NOTIFICATION_SUFFIXES: tuple[str, ...] = ("door_open", "door_closed", "failed")
 KEYPAD_UNLOCK_NOTIFICATION_DELAY_SECONDS = 1
+KEYPAD_LOCK_NOTIFICATION_DELAY_SECONDS = 1
 
 STORAGE_VERSION = 1
 STORAGE_KEY = f"{DOMAIN}.locks"
@@ -229,6 +230,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._cancel_quick_refresh: dict[str, Callable] = {}
         self._cancel_debounced_refresh: dict[str, Callable] = {}
         self._pending_keypad_unlock_notifications: dict[str, Callable[[], None]] = {}
+        self._pending_keypad_lock_notifications: dict[str, Callable[[], None]] = {}
         self._state_change_autolock_started: set[str] = set()
         self._pending_provider_unlock_event: set[str] = set()
         self._pending_provider_lock_event: set[str] = set()
@@ -1315,6 +1317,26 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         return True
 
+    async def _send_code_slot_lock_notification(
+        self,
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+        event_label: str | None,
+    ) -> bool:
+        """Send a per-code-slot lock notification when enabled."""
+        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
+        if not slot or not slot.notifications:
+            return False
+
+        message = self._format_slot_message(kmlock, code_slot_num, event_label)
+        await send_manual_notification(
+            hass=self.hass,
+            script_name=kmlock.notify_script_name,
+            title=kmlock.lock_name,
+            message=message,
+        )
+        return True
+
     async def _send_global_unlock_notification(
         self,
         kmlock: KeymasterLock,
@@ -1322,6 +1344,21 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         event_label: str | None,
     ) -> None:
         """Send a global unlock notification."""
+        message = self._format_slot_message(kmlock, code_slot_num, event_label)
+        await send_manual_notification(
+            hass=self.hass,
+            script_name=kmlock.notify_script_name,
+            title=kmlock.lock_name,
+            message=message,
+        )
+
+    async def _send_global_lock_notification(
+        self,
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+        event_label: str | None,
+    ) -> None:
+        """Send a global lock notification."""
         message = self._format_slot_message(kmlock, code_slot_num, event_label)
         await send_manual_notification(
             hass=self.hass,
@@ -1343,9 +1380,33 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if self._last_unlock_code_slot.get(kmlock.keymaster_config_entry_id) == 0:
             self._last_unlock_code_slot[kmlock.keymaster_config_entry_id] = None
 
+    async def _send_deferred_keypad_lock_notification(
+        self,
+        kmlock: KeymasterLock,
+        event_label: str | None,
+        _: dt,
+    ) -> None:
+        """Send a deferred global keypad lock notification."""
+        self._pending_keypad_lock_notifications.pop(kmlock.keymaster_config_entry_id, None)
+        if kmlock.lock_notifications:
+            await self._send_global_lock_notification(kmlock, 0, event_label)
+        if self._last_lock_code_slot.get(kmlock.keymaster_config_entry_id) == 0:
+            self._last_lock_code_slot[kmlock.keymaster_config_entry_id] = None
+
     def _cancel_pending_keypad_unlock_notification(self, kmlock: KeymasterLock) -> bool:
         """Cancel pending keypad unlock notification if one exists."""
         cancel = self._pending_keypad_unlock_notifications.pop(
+            kmlock.keymaster_config_entry_id,
+            None,
+        )
+        if not cancel:
+            return False
+        cancel()
+        return True
+
+    def _cancel_pending_keypad_lock_notification(self, kmlock: KeymasterLock) -> bool:
+        """Cancel pending keypad lock notification if one exists."""
+        cancel = self._pending_keypad_lock_notifications.pop(
             kmlock.keymaster_config_entry_id,
             None,
         )
@@ -1373,12 +1434,46 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
         )
 
+    def _defer_keypad_lock_notification(
+        self,
+        kmlock: KeymasterLock,
+        event_label: str | None,
+    ) -> None:
+        """Defer a provisional global keypad lock notification."""
+        self._cancel_pending_keypad_lock_notification(kmlock)
+        self._pending_keypad_lock_notifications[kmlock.keymaster_config_entry_id] = (
+            async_call_later(
+                hass=self.hass,
+                delay=KEYPAD_LOCK_NOTIFICATION_DELAY_SECONDS,
+                action=functools.partial(
+                    self._send_deferred_keypad_lock_notification,
+                    kmlock,
+                    event_label,
+                ),
+            )
+        )
+
     @staticmethod
     def _global_unlock_notification_superseded(
         kmlock: KeymasterLock,
         code_slot_num: int,
     ) -> bool:
         """Return whether per-slot notification should replace global unlock text."""
+        if not kmlock.code_slots:
+            return False
+
+        if code_slot_num > 0:
+            slot = kmlock.code_slots.get(code_slot_num)
+            return bool(slot and slot.notifications)
+
+        return False
+
+    @staticmethod
+    def _global_lock_notification_superseded(
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+    ) -> bool:
+        """Return whether per-slot notification should replace global lock text."""
         if not kmlock.code_slots:
             return False
 
@@ -1396,6 +1491,18 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     ) -> bool:
         """Return whether a slot=0 keypad unlock may be superseded by slot details."""
         if code_slot_num != 0 or event_label != "Keypad Unlock" or not kmlock.code_slots:
+            return False
+
+        return any(slot.notifications for slot in kmlock.code_slots.values())
+
+    @staticmethod
+    def _should_defer_keypad_lock_notification(
+        kmlock: KeymasterLock,
+        code_slot_num: int,
+        event_label: str | None,
+    ) -> bool:
+        """Return whether a slot=0 keypad lock may be superseded by slot details."""
+        if code_slot_num != 0 or event_label != "Keypad Lock" or not kmlock.code_slots:
             return False
 
         return any(slot.notifications for slot in kmlock.code_slots.values())
@@ -1561,12 +1668,25 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 self._fire_lock_state_changed(
                     kmlock, code_slot_num, source, event_label, action_code
                 )
+                had_pending_notification = self._cancel_pending_keypad_lock_notification(kmlock)
+                sent_slot_notification = await self._send_code_slot_lock_notification(
+                    kmlock,
+                    code_slot_num,
+                    event_label,
+                )
+                if (
+                    had_pending_notification
+                    and not sent_slot_notification
+                    and kmlock.lock_notifications
+                ):
+                    await self._send_global_lock_notification(kmlock, 0, event_label)
             if kmlock.keymaster_config_entry_id in self._state_change_autolock_started:
                 if kmlock.autolock_timer:
                     await kmlock.autolock_timer.cancel()
                     self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                 self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
             self._cancel_pending_keypad_unlock_notification(kmlock)
+            self._cancel_pending_keypad_lock_notification(kmlock)
             return
 
         if not self._throttle.is_allowed(
@@ -1588,6 +1708,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._last_lock_code_slot[kmlock.keymaster_config_entry_id] = code_slot_num
         self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
         self._cancel_pending_keypad_unlock_notification(kmlock)
+        self._cancel_pending_keypad_lock_notification(kmlock)
 
         _LOGGER.debug(
             "[lock_locked] %s: Running. code_slot_num: %s, source: %s, "
@@ -1621,13 +1742,13 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
         if kmlock.lock_notifications:
-            message = self._format_slot_message(kmlock, code_slot_num, event_label)
-            await send_manual_notification(
-                hass=self.hass,
-                script_name=kmlock.notify_script_name,
-                title=kmlock.lock_name,
-                message=message,
-            )
+            if self._should_defer_keypad_lock_notification(kmlock, code_slot_num, event_label):
+                self._defer_keypad_lock_notification(kmlock, event_label)
+            elif not self._global_lock_notification_superseded(kmlock, code_slot_num):
+                await self._send_global_lock_notification(kmlock, code_slot_num, event_label)
+
+        if code_slot_num > 0 and kmlock.code_slots and code_slot_num in kmlock.code_slots:
+            await self._send_code_slot_lock_notification(kmlock, code_slot_num, event_label)
 
         self._fire_lock_state_changed(kmlock, code_slot_num, source, event_label, action_code)
 
@@ -2005,6 +2126,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         self._pending_provider_unlock_event.discard(kmlock.keymaster_config_entry_id)
         self._pending_provider_lock_event.discard(kmlock.keymaster_config_entry_id)
         self._cancel_pending_keypad_unlock_notification(kmlock)
+        self._cancel_pending_keypad_lock_notification(kmlock)
         self._cancel_entry_refresh_timers(kmlock.keymaster_config_entry_id)
         await self._rebuild_lock_relationships()
         await self._async_save_data()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -29,6 +29,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.core import CoreState, Event, HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.dt import utcnow
 
 
 def validate_lock_relationship_invariants(
@@ -102,6 +103,9 @@ def mock_hass():
     hass.bus.async_fire = Mock()
     hass.states = Mock()
     hass.states.get = Mock(return_value=None)
+    hass.loop = Mock()
+    hass.loop.time = Mock(return_value=0.0)
+    hass.loop.call_at = Mock(return_value=Mock(cancel=Mock()))
     return hass
 
 
@@ -117,6 +121,7 @@ def mock_coordinator(mock_hass) -> Any:
         coordinator._last_unlock_code_slot = {}
         coordinator._last_lock_code_slot = {}
         coordinator._pending_keypad_unlock_notifications = {}
+        coordinator._pending_keypad_lock_notifications = {}
         coordinator._state_change_autolock_started = set()
         coordinator._pending_provider_unlock_event = set()
         coordinator._pending_provider_lock_event = set()
@@ -1115,6 +1120,7 @@ class TestLockStateEventHandlers:
         """Test _lock_locked sends notification when enabled."""
         mock_kmlock.lock_notifications = True
         mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.code_slots = {}
         mock_coordinator._throttle = Mock()
         mock_coordinator._throttle.is_allowed = Mock(return_value=True)
 
@@ -1297,6 +1303,8 @@ class TestLockStateEventHandlers:
         mock_kmlock.autolock_timer = None
         mock_kmlock.code_slots = {2: Mock(name="slot2")}
         mock_kmlock.code_slots[2].name = "Alice"
+        # notifications disabled for this slot so supersede falls back to generic / does not re-notify
+        mock_kmlock.code_slots[2].notifications = False
 
         with (
             patch(
@@ -1338,15 +1346,26 @@ class TestLockStateEventHandlers:
             2: Mock(name="Alice", code="1234"),
         }
         mock_kmlock.code_slots[2].name = "Alice"
+        mock_kmlock.code_slots[2].notifications = False
         mock_coordinator._last_lock_code_slot[mock_kmlock.keymaster_config_entry_id] = 0
 
-        await mock_coordinator._lock_locked(
-            mock_kmlock,
-            code_slot_num=2,
-            source="event",
-            event_label="Keypad Lock",
-            action_code=5,
-        )
+        with (
+            patch(
+                "custom_components.keymaster.coordinator.send_manual_notification",
+                new=AsyncMock(),
+            ),
+            patch(
+                "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+                new=AsyncMock(),
+            ),
+        ):
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=2,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
 
         assert mock_coordinator._last_lock_code_slot[mock_kmlock.keymaster_config_entry_id] == 2
         mock_coordinator.hass.bus.fire.assert_called_once_with(
@@ -1374,6 +1393,7 @@ class TestLockStateEventHandlers:
         mock_kmlock.autolock_timer = None
         mock_kmlock.code_slots = {2: Mock(name="slot2")}
         mock_kmlock.code_slots[2].name = "Alice"
+        mock_kmlock.code_slots[2].notifications = False
 
         for slot in (0, 2, 2):
             await mock_coordinator._lock_locked(
@@ -1401,6 +1421,7 @@ class TestLockStateEventHandlers:
         mock_kmlock.autolock_timer = None
         mock_kmlock.code_slots = {2: Mock(name="slot2")}
         mock_kmlock.code_slots[2].name = "Alice"
+        mock_kmlock.code_slots[2].notifications = False
 
         await mock_coordinator._lock_locked(
             mock_kmlock,
@@ -1422,6 +1443,257 @@ class TestLockStateEventHandlers:
             action_code=5,
         )
         assert mock_coordinator.hass.bus.fire.call_count == 1
+
+    async def test_lock_locked_per_slot_notification_enabled(self, mock_coordinator, mock_kmlock):
+        """Test lock notification sent when slot notifications enabled and lock_notifications disabled."""
+        mock_coordinator._throttle = Throttle()
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_kmlock.pending_retry_lock = False
+        mock_kmlock.lock_notifications = False
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.autolock_timer = None
+        mock_kmlock.code_slots = {
+            3: Mock(name="Alice", notifications=True),
+        }
+        mock_kmlock.code_slots[3].name = "Alice"
+        mock_kmlock.code_slots[3].notifications = True
+
+        with (
+            patch(
+                "custom_components.keymaster.coordinator.send_manual_notification",
+                new=AsyncMock(),
+            ) as mock_notify,
+            patch(
+                "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+                new=AsyncMock(),
+            ),
+        ):
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=3,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+
+            mock_notify.assert_called_once()
+            assert mock_notify.call_args.kwargs["message"] == "Keypad Lock by Alice [3]"
+
+    async def test_lock_locked_supersedes_global_when_slot_notifications_enabled(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test per-slot lock notification supersedes global notification to prevent duplicates."""
+        mock_coordinator._throttle = Throttle()
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_kmlock.pending_retry_lock = False
+        mock_kmlock.lock_notifications = True
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.autolock_timer = None
+        mock_kmlock.code_slots = {
+            3: Mock(name="Alice", notifications=True),
+        }
+        mock_kmlock.code_slots[3].name = "Alice"
+        mock_kmlock.code_slots[3].notifications = True
+
+        with (
+            patch(
+                "custom_components.keymaster.coordinator.send_manual_notification",
+                new=AsyncMock(),
+            ) as mock_notify,
+            patch(
+                "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+                new=AsyncMock(),
+            ),
+        ):
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=3,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+
+            # Only 1 notification should be dispatched, formatted for the slot
+            assert mock_notify.call_count == 1
+            assert mock_notify.call_args.kwargs["message"] == "Keypad Lock by Alice [3]"
+
+    async def test_lock_locked_defers_keypad_lock_when_slot_notifications_exist(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test slot=0 Keypad Lock notification is deferred when slots have notifications enabled."""
+        mock_coordinator._throttle = Throttle()
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_kmlock.pending_retry_lock = False
+        mock_kmlock.lock_notifications = True
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.autolock_timer = None
+        mock_kmlock.code_slots = {
+            1: Mock(notifications=True),
+        }
+        mock_kmlock.code_slots[1].notifications = True
+
+        with (
+            patch(
+                "custom_components.keymaster.coordinator.send_manual_notification",
+                new=AsyncMock(),
+            ) as mock_notify,
+            patch(
+                "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+                new=AsyncMock(),
+            ),
+        ):
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=0,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+
+            # Deferred, so no notification sent immediately
+            mock_notify.assert_not_called()
+            assert (
+                mock_kmlock.keymaster_config_entry_id
+                in mock_coordinator._pending_keypad_lock_notifications
+            )
+
+    async def test_send_deferred_keypad_lock_notification(self, mock_coordinator, mock_kmlock):
+        """Test deferred keypad lock callback fires global notification when uncancelled."""
+        mock_kmlock.lock_notifications = True
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.code_slots = {}
+        mock_coordinator._last_lock_code_slot[mock_kmlock.keymaster_config_entry_id] = 0
+        mock_coordinator._pending_keypad_lock_notifications[
+            mock_kmlock.keymaster_config_entry_id
+        ] = Mock()
+
+        with patch(
+            "custom_components.keymaster.coordinator.send_manual_notification",
+            new=AsyncMock(),
+        ) as mock_notify:
+            await mock_coordinator._send_deferred_keypad_lock_notification(
+                mock_kmlock,
+                "Keypad Lock",
+                utcnow(),
+            )
+
+            mock_notify.assert_called_once()
+            assert mock_notify.call_args.kwargs["message"] == "Keypad Lock"
+            assert (
+                mock_kmlock.keymaster_config_entry_id
+                not in mock_coordinator._pending_keypad_lock_notifications
+            )
+            assert (
+                mock_coordinator._last_lock_code_slot.get(mock_kmlock.keymaster_config_entry_id)
+                is None
+            )
+
+    async def test_lock_locked_supersede_with_slot_notification(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test slot=0 deferred lock superseded by slot>0 with slot notifications dispatches slot notification."""
+        mock_coordinator._throttle = Throttle()
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_kmlock.pending_retry_lock = False
+        mock_kmlock.lock_notifications = True
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.autolock_timer = None
+        mock_kmlock.code_slots = {
+            2: Mock(name="Alice", notifications=True),
+        }
+        mock_kmlock.code_slots[2].name = "Alice"
+        mock_kmlock.code_slots[2].notifications = True
+
+        with (
+            patch(
+                "custom_components.keymaster.coordinator.send_manual_notification",
+                new=AsyncMock(),
+            ) as mock_notify,
+            patch(
+                "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+                new=AsyncMock(),
+            ),
+        ):
+            # 1. First event: slot=0 (provisional) -> defers notification
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=0,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+            assert mock_notify.call_count == 0
+            assert (
+                mock_kmlock.keymaster_config_entry_id
+                in mock_coordinator._pending_keypad_lock_notifications
+            )
+
+            # 2. Second event: slot=2 (supersede) -> cancels deferral, sends slot notification
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=2,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+
+            assert mock_notify.call_count == 1
+            assert mock_notify.call_args.kwargs["message"] == "Keypad Lock by Alice [2]"
+            assert (
+                mock_kmlock.keymaster_config_entry_id
+                not in mock_coordinator._pending_keypad_lock_notifications
+            )
+
+    async def test_lock_locked_supersede_without_slot_notification_falls_back_to_global(
+        self, mock_coordinator, mock_kmlock
+    ):
+        """Test slot=0 deferred lock superseded by slot>0 without slot notifications dispatches global notification."""
+        mock_coordinator._throttle = Throttle()
+        mock_kmlock.lock_state = LockState.UNLOCKED
+        mock_kmlock.pending_retry_lock = False
+        mock_kmlock.lock_notifications = True
+        mock_kmlock.notify_script_name = "notify_script"
+        mock_kmlock.autolock_timer = None
+        mock_kmlock.code_slots = {
+            1: Mock(name="Bob", notifications=True),
+            2: Mock(name="Alice", notifications=False),
+        }
+        mock_kmlock.code_slots[1].name = "Bob"
+        mock_kmlock.code_slots[1].notifications = True
+        mock_kmlock.code_slots[2].name = "Alice"
+        mock_kmlock.code_slots[2].notifications = False
+
+        with (
+            patch(
+                "custom_components.keymaster.coordinator.send_manual_notification",
+                new=AsyncMock(),
+            ) as mock_notify,
+            patch(
+                "custom_components.keymaster.coordinator.dismiss_persistent_notification",
+                new=AsyncMock(),
+            ),
+        ):
+            # 1. slot=0 deferred because slot 1 has notifications=True
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=0,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+            assert mock_notify.call_count == 0
+
+            # 2. slot=2 arrives (notifications=False). Cancels deferral, fallback sends global notification
+            await mock_coordinator._lock_locked(
+                mock_kmlock,
+                code_slot_num=2,
+                source="event",
+                event_label="Keypad Lock",
+                action_code=5,
+            )
+
+            assert mock_notify.call_count == 1
+            assert mock_notify.call_args.kwargs["message"] == "Keypad Lock"
 
     async def test_lock_unlocked_starts_autolock_timer(self, mock_coordinator, mock_kmlock):
         """Test _lock_unlocked starts autolock timer and schedules data update."""

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -706,6 +706,61 @@ async def test_keypad_lock_deferred_notification_cancelled_on_shutdown(
     mock_notify.assert_not_called()
 
 
+async def test_keypad_lock_deferred_notification_cancelled_on_unlock(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test pending keypad lock notification is cancelled when lock is unlocked within deferral window."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_unlock_cancels_lock_notif",
+    )
+    kmlock.lock_state = LockState.UNLOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Rich", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new=AsyncMock(),
+    ) as mock_notify:
+        await coordinator._lock_locked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Lock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+        assert kmlock.keymaster_config_entry_id in coordinator._pending_keypad_lock_notifications
+
+        # Unlock within the 1-second deferral window
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=1,
+            source="valid_code_entered",
+            event_label="Keypad Unlock",
+            action_code=6,
+        )
+        await hass.async_block_till_done()
+        assert (
+            kmlock.keymaster_config_entry_id not in coordinator._pending_keypad_lock_notifications
+        )
+
+        # Advance timer past 1 second
+        async_fire_time_changed(hass, fire_all=True)
+        await hass.async_block_till_done()
+
+    # Only unlock notification should have fired, no deferred lock notification
+    assert mock_notify.call_count == 1
+    assert mock_notify.call_args.kwargs["message"] == "Keypad Unlock by Rich [1]"
+
+
 async def test_late_slot_event_after_deferred_global_does_not_duplicate_notification(
     hass,
     coordinator_for_unlock_test,

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -618,6 +618,94 @@ async def test_keypad_unlock_deferred_global_notification_fires_without_slot_eve
     )
 
 
+async def test_keypad_lock_deferred_global_notification_fires_without_slot_event(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test deferred global keypad lock text fires after delay if no slot detail arrives."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_deferred_keypad_lock",
+    )
+    kmlock.lock_state = LockState.UNLOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Rich", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new=AsyncMock(),
+    ) as mock_notify:
+        await coordinator._lock_locked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Lock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+        mock_notify.assert_not_called()
+        assert kmlock.keymaster_config_entry_id in coordinator._pending_keypad_lock_notifications
+
+        async_fire_time_changed(hass, fire_all=True)
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Keypad Lock",
+    )
+    assert kmlock.keymaster_config_entry_id not in coordinator._pending_keypad_lock_notifications
+
+
+async def test_keypad_lock_deferred_notification_cancelled_on_shutdown(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test pending keypad lock notifications are cancelled when coordinator is shut down."""
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_shutdown_keypad_lock",
+    )
+    kmlock.lock_state = LockState.UNLOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Rich", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new=AsyncMock(),
+    ) as mock_notify:
+        await coordinator._lock_locked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Lock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+        assert kmlock.keymaster_config_entry_id in coordinator._pending_keypad_lock_notifications
+
+        await coordinator.async_shutdown()
+        assert len(coordinator._pending_keypad_lock_notifications) == 0
+
+        async_fire_time_changed(hass, fire_all=True)
+        await hass.async_block_till_done()
+
+    mock_notify.assert_not_called()
+
+
 async def test_late_slot_event_after_deferred_global_does_not_duplicate_notification(
     hass,
     coordinator_for_unlock_test,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -184,6 +184,11 @@ async def test_unload_entry_preserves_pending_all_lock_notification(hass) -> Non
     async def unload_platform(*_: object) -> bool:
         return True
 
+    cancel_unlock_timer = Mock()
+    cancel_lock_timer = Mock()
+    coordinator._pending_keypad_unlock_notifications[entry.entry_id] = cancel_unlock_timer
+    coordinator._pending_keypad_lock_notifications[entry.entry_id] = cancel_lock_timer
+
     with (
         patch.object(
             hass.config_entries,
@@ -198,6 +203,10 @@ async def test_unload_entry_preserves_pending_all_lock_notification(hass) -> Non
         assert await async_unload_entry(hass, entry)
 
     assert not pending_handle.cancelled()
+    cancel_unlock_timer.assert_called_once()
+    cancel_lock_timer.assert_called_once()
+    assert entry.entry_id not in coordinator._pending_keypad_unlock_notifications
+    assert entry.entry_id not in coordinator._pending_keypad_lock_notifications
 
     await hass.async_block_till_done()
 


### PR DESCRIPTION
# Summary
This PR implements per-code-slot notification routing (`slot.notifications`) and notification deferral on keypad lock events in `KeymasterCoordinator`, completing feature parity between unlock and lock notification pathways following up on #737, #738, and #743.

## Proposed change
1. **Per-Code-Slot Lock Notifications**:
   - Added `_send_code_slot_lock_notification(kmlock, code_slot_num, event_label)` to evaluate `slot.notifications` and send slot-specific notifications when enabled.
   - Added `_send_global_lock_notification(kmlock, code_slot_num, event_label)` and `_global_lock_notification_superseded` helper to suppress generic global notifications when slot-specific notifications are active.
2. **Lock Notification Deferral on Provisional Keypad Locks**:
   - Added `_defer_keypad_lock_notification`, `_cancel_pending_keypad_lock_notification`, and `_should_defer_keypad_lock_notification`.
   - When a provisional `slot=0` "Keypad Lock" event arrives, the global notification is deferred for 1 second if any code slot has notifications enabled.
3. **Supersede Resolution in `_lock_locked`**:
   - If a provisional `slot=0` lock is superseded by a subsequent `slot>0` lock event, the deferred provisional notification is cancelled.
   - If the new slot has notifications enabled, the slot notification is sent. If disabled, the generic global notification is dispatched.
4. **Lifecycle Cleanup**:
   - Updated `_cancel_all_pending_keypad_notifications` and `_delete_lock` to cancel pending lock notifications during shutdown, reload, and delete.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #743
- This PR is related to issue: #737, #738
