### PR TITLE
chore(ci): update release drafter to v7 schema and collapse categories after 3 items

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,39 +5,51 @@ change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 sort-direction: ascending
 categories:
   - title: "💥 Breaking Change 💥"
-    labels:
-      - "breaking-change"
+    semver-increment: major
+    when:
+      label: "breaking-change"
   - title: "✨ New Features ✨"
-    labels:
-      - "enhancement"
-      - "feature"
+    semver-increment: minor
+    when:
+      labels:
+        - "enhancement"
+        - "feature"
   - title: "🐛 Bug Fixes 🐛"
-    labels:
-      - "fix"
-      - "bugfix"
-      - "bug"
+    semver-increment: patch
+    when:
+      labels:
+        - "fix"
+        - "bugfix"
+        - "bug"
   - title: "⚡ Performance ⚡"
-    labels:
-      - "performance"
+    semver-increment: patch
+    when:
+      label: "performance"
   - title: "🔧 Maintenance 🔧"
     collapse-after: 3
-    labels:
-      - "chore"
-      - "documentation"
-      - "maintenance"
-      - "repo"
-      - "dependencies"
-      - "github_actions"
-      - "refactor"
-      - "style"
-      - "build"
-      - "revert"
+    semver-increment: patch
+    when:
+      labels:
+        - "chore"
+        - "documentation"
+        - "maintenance"
+        - "repo"
+        - "dependencies"
+        - "github_actions"
+        - "refactor"
+        - "style"
+        - "build"
+        - "revert"
   - title: "🎓 Code Quality 🎓"
     collapse-after: 3
-    labels:
-      - "code-quality"
-      - "CI"
-      - "test"
+    semver-increment: patch
+    when:
+      labels:
+        - "code-quality"
+        - "CI"
+        - "test"
+  - type: version-resolver
+    semver-increment: patch
 autolabeler:
   - label: "breaking-change"
     title:
@@ -75,30 +87,6 @@ autolabeler:
   - label: "build"
     title:
       - '/^build(\([^)]+\))?:/i'
-version-resolver:
-  major:
-    labels:
-      - "breaking-change"
-  minor:
-    labels:
-      - "feature"
-      - "enhancement"
-  patch:
-    labels:
-      - "bug"
-      - "fix"
-      - "bugfix"
-      - "performance"
-      - "refactor"
-      - "style"
-      - "build"
-      - "chore"
-      - "documentation"
-      - "CI"
-      - "test"
-      - "code-quality"
-      - "revert"
-  default: patch
 # yamllint disable rule:line-length
 template: |
   [![Downloads for this release](https://img.shields.io/github/downloads/FutureTense/keymaster/v$RESOLVED_VERSION/total.svg)](https://github.com/FutureTense/keymaster/releases/v$RESOLVED_VERSION)

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,6 +20,7 @@ categories:
     labels:
       - "performance"
   - title: "🔧 Maintenance 🔧"
+    collapse-after: 3
     labels:
       - "chore"
       - "documentation"
@@ -32,6 +33,7 @@ categories:
       - "build"
       - "revert"
   - title: "🎓 Code Quality 🎓"
+    collapse-after: 3
     labels:
       - "code-quality"
       - "CI"


### PR DESCRIPTION
# Summary
This PR updates the Release Drafter configuration to the Release Drafter v7 schema and configures automatic category collapsing for the "🔧 Maintenance 🔧" and "🎓 Code Quality 🎓" sections when they exceed 3 items.

## Proposed change
- Migrated `.github/release-drafter.yml` to the v7 schema:
  - Updated category matchers from root-level `labels` to `when: label(s): [...]`.
  - Replaced the deprecated root-level `version-resolver` block with category-level `semver-increment` declarations (`major`, `minor`, `patch`) and a fallback `type: version-resolver` entry.
- Added `collapse-after: 3` to the "🔧 Maintenance 🔧" and "🎓 Code Quality 🎓" categories.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to issue: N/A
