### PR TITLE
fix(ci): pass issue parser output via env to avoid script injection

### DIFF
--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -24,18 +24,42 @@ jobs:
 
       - name: 🏷️ Apply Provider Label
         uses: actions/github-script@v9
+        env:
+          # Pass the parser output through the environment rather than
+          # interpolating it into the script body. Untrusted issue content
+          # (e.g. backticks or ${...} in an issue body) must never be parsed
+          # as JavaScript source. See CWE-94 (script injection).
+          ISSUE_JSON: ${{ steps.issue-parser.outputs.jsonString }}
         with:
           script: |
-            const issueData = JSON.parse(`${{ steps.issue-parser.outputs.jsonString }}`);
+            // Providers offered by .github/ISSUE_TEMPLATE/bug_report.yml's
+            // lock-provider dropdown. Only these produce a label so that
+            // untrusted input cannot create arbitrary labels.
+            const validProviders = [
+              'local_akuvox',
+              'schlage',
+              'zha',
+              'zigbee2mqtt',
+              'zwave_js',
+            ];
+
+            let issueData;
+            try {
+              issueData = JSON.parse(process.env.ISSUE_JSON || '{}');
+            } catch (error) {
+              core.info(`Could not parse issue payload: ${error.message}`);
+              return;
+            }
+
             const provider = issueData['lock-provider'];
 
-            if (provider) {
-              const labelName = `provider: ${provider}`;
-
+            if (provider && validProviders.includes(provider)) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                labels: [labelName]
+                labels: [`provider: ${provider}`],
               });
+            } else if (provider) {
+              core.info(`Ignoring unrecognized lock provider: ${provider}`);
             }


### PR DESCRIPTION
# Summary

The `Issue Autolabeler` workflow (`.github/workflows/issue_labeler.yml`)
fails on **every** opened issue and, more importantly, is a GitHub Actions
**script-injection vulnerability (CWE-94)**. This PR fixes both by passing
the untrusted issue-parser output through the environment instead of
interpolating it into the `actions/github-script` body.

## Proposed change

The `🏷️ Apply Provider Label` step built its script by interpolating the
parser output directly into a JavaScript template literal:

```js
const issueData = JSON.parse(`${{ steps.issue-parser.outputs.jsonString }}`);
```

The parser output embeds the raw issue body. Because the job runs with
`permissions: issues: write` and anyone can open an issue, this is an
**untrusted, attacker-controlled value injected into JS source**:

- Any backtick or `${...}` in an issue body breaks out of the template
  literal, producing invalid JavaScript. `actions/github-script` fails at
  **load time** with `SyntaxError: missing ) after argument list` (thrown
  while *loading* the generated script, not running it). This is exactly
  what recent issues with fenced code blocks (#746–#749) triggered.
- A crafted issue body could execute **arbitrary JavaScript** in the
  workflow with the job's token (CWE-94).

Fix, following the standard `actions/github-script` remediation:

- Pass the value via `env: ISSUE_JSON` and read it with
  `process.env.ISSUE_JSON`. Environment values are **never parsed as JS
  source**, so no issue content — backticks included — can alter the
  script or crash the parser.
- Guard `JSON.parse` with `|| '{}'` and a `try/catch`. The workflow fires
  on every opened issue, including free-form ones that are not bug-report
  forms; `stefanbuck/github-issue-parser` can emit an empty/`{}` payload
  there. A malformed or absent payload now no-ops instead of failing.
- Restrict labelling to the providers actually offered by
  `.github/ISSUE_TEMPLATE/bug_report.yml`'s `lock-provider` dropdown
  (`local_akuvox`, `schlage`, `zha`, `zigbee2mqtt`, `zwave_js`), since
  `addLabels` would otherwise create arbitrary labels from untrusted input.

Scope notes:

- The PR autolabeler (`.github/workflows/autolabeler.yaml`) does **not**
  share this flaw: it uses `release-drafter/autolabeler`, which reads the
  PR title/body via the GitHub API and never interpolates untrusted input
  into a script. `yarn.yaml`'s `github-script` steps only use static
  strings. No other workflow needed changes.
- `permissions:` is left minimal (`issues: write`); the `actions/checkout`
  step is retained because the parser needs to read the template path.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Confirmed failing across four recent `event=issues` runs, all
`conclusion=failure`:
[33180065132](https://github.com/FutureTense/keymaster/actions/runs/33180065132),
[33180064242](https://github.com/FutureTense/keymaster/actions/runs/33180064242),
[33180062999](https://github.com/FutureTense/keymaster/actions/runs/33180062999),
[33178663720](https://github.com/FutureTense/keymaster/actions/runs/33178663720).
Log evidence: `##[error]Unhandled error: SyntaxError: missing ) after
argument list`, thrown from `github-script/v9/dist/index.js` at module
load.

**Validation.** An `issues` event cannot be triggered from a PR branch, so
this was validated as far as practical: `python -c 'import yaml'` parses
the workflow, `actionlint` passes, and the repo's `prek` hooks (including
`actionlint` and `yamllint`) all pass. The new form cannot break on
backtick-bearing input because `process.env` values are passed as process
environment strings and are never evaluated as JavaScript source. Live
end-to-end validation on an issue event was not performed to avoid opening
test issues on the upstream repo.

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
