### PR TITLE
fix(ci): anchor version regex replacement in release asset workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,8 +26,8 @@ jobs:
       # Updates the files with the unified VERSION variable
       - name: Set version number
         run: |
-          sed -i '/VERSION = /c\VERSION = "${{ env.VERSION }}"' ${{ github.workspace }}/custom_components/keymaster/const.py
-          sed -i '/version/c\  \"version\": \"${{ env.VERSION }}\"' ${{ github.workspace }}/custom_components/keymaster/manifest.json
+          sed -i 's/^VERSION = .*/VERSION = "${{ env.VERSION }}"/' ${{ github.workspace }}/custom_components/keymaster/const.py
+          sed -i 's/"version": .*/"version": "${{ env.VERSION }}"/' ${{ github.workspace }}/custom_components/keymaster/manifest.json
 
       # Pack the keymaster dir as a zip
       - name: ZIP Keymaster Dir


### PR DESCRIPTION
# Summary

Fix an issue where the release packaging workflow inadvertently replaced unrelated constants containing the substring `VERSION = ` (such as `LARGE_LOCK_ACK_STORE_VERSION = 1`) in `custom_components/keymaster/const.py`, causing `keymaster.zip` release assets to fail importing on HA startup.

## Proposed change

Anchor the `sed` regular expressions used in `.github/workflows/release.yaml` to only replace `^VERSION = ` in `const.py` and `"version": ` in `manifest.json`.

### Verification Performed
- **End-to-End Release Packaging Simulation**: Replicated the release action on `custom_components/keymaster` using the updated `sed` commands, built and compressed into `keymaster.zip`, and unzipped into a clean test directory.
- **Module and Constant Integrity**: Dynamically loaded the resulting `const.py` to confirm that `VERSION` is updated as expected while `LARGE_LOCK_ACK_STORE_VERSION = 1` (and all other constants) remain intact, and verified `manifest.json` JSON parsing.
- **Test Suite**: Executed the full integration test suite (`1161 passed`).

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #751
- This PR is related to issue:
