### PR TITLE
fix(lovelace): key strategy resource cleanup off collection presence

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -92,7 +92,7 @@ async def _flush_pending_save_after_setup(
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up integration."""
-    hass.data.setdefault(DOMAIN, {"resources": False})
+    hass.data.setdefault(DOMAIN, {})
 
     # Expose strategy javascript
     await hass.http.async_register_static_paths(
@@ -350,8 +350,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         _LOGGER.debug(
             "[async_unload_entry] Last keymaster entry unloaded, cleaning up strategy resource"
         )
-        hass_data = hass.data.get(DOMAIN, {})
-        await async_cleanup_strategy_resource(hass, hass_data)
+        await async_cleanup_strategy_resource(hass)
 
     return unload_ok
 

--- a/custom_components/keymaster/resources.py
+++ b/custom_components/keymaster/resources.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.lovelace.const import CONF_RESOURCE_TYPE_WS, DOMAIN as LL_DOMAIN
 from homeassistant.components.lovelace.resources import (
@@ -69,26 +68,20 @@ async def async_register_strategy_resource(hass: HomeAssistant) -> None:
         {CONF_RESOURCE_TYPE_WS: "module", CONF_URL: STRATEGY_PATH}
     )
     _LOGGER.debug("Registered strategy module (resource ID %s)", data[CONF_ID])
-    hass.data[DOMAIN]["resources"] = True
 
 
-async def async_cleanup_strategy_resource(hass: HomeAssistant, hass_data: dict[str, Any]) -> None:
-    """Remove the Lovelace strategy resource if we registered it."""
+async def async_cleanup_strategy_resource(hass: HomeAssistant) -> None:
+    """Remove the Lovelace strategy resource if it is present in the collection."""
     resources = get_lovelace_resources(hass)
     if not resources:
         return
 
     if isinstance(resources, ResourceYAMLCollection):
-        if hass_data.get("resources"):
+        if any(data[CONF_URL] == STRATEGY_PATH for data in resources.async_items()):
             _LOGGER.debug(
-                "Resources switched to YAML mode after registration, "
-                "skipping automatic removal for %s",
+                "Resources are in YAML mode, skipping automatic removal for %s",
                 STRATEGY_PATH,
             )
-        return
-
-    if not hass_data.get("resources"):
-        _LOGGER.debug("Strategy module not automatically registered, skipping removal")
         return
 
     try:
@@ -100,5 +93,4 @@ async def async_cleanup_strategy_resource(hass: HomeAssistant, hass_data: dict[s
         return
 
     await resources.async_delete_item(resource_id)
-    hass_data["resources"] = False
     _LOGGER.debug("Removed strategy module (resource ID %s)", resource_id)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -72,7 +72,6 @@ async def test_register_strategy_resource_creates_new(hass: HomeAssistant, mock_
     call_args = mock_storage_resources.async_create_item.call_args[0][0]
     assert call_args["res_type"] == "module"
     assert call_args["url"] == STRATEGY_PATH
-    assert hass.data[DOMAIN]["resources"] is True
 
 
 async def test_register_strategy_resource_already_exists(
@@ -185,36 +184,50 @@ async def test_register_strategy_resource_yaml_mode_subsequent_debug(
 
 
 async def test_cleanup_strategy_resource_removes(hass: HomeAssistant, mock_storage_resources):
-    """Test cleaning up strategy resource."""
+    """Test cleaning up strategy resource removes it from the collection."""
     mock_storage_resources.async_items.return_value = [{"id": "resource_id", "url": STRATEGY_PATH}]
     hass.data[LOVELACE_DOMAIN] = MagicMock()
     hass.data[LOVELACE_DOMAIN].resources = mock_storage_resources
 
-    await async_cleanup_strategy_resource(hass, {"resources": True})
+    await async_cleanup_strategy_resource(hass)
 
-    mock_storage_resources.async_delete_item.assert_called_once_with("resource_id")
+    mock_storage_resources.async_delete_item.assert_awaited_once_with("resource_id")
 
 
-async def test_cleanup_strategy_resource_not_auto_registered(
+async def test_cleanup_strategy_resource_removes_after_restart(
     hass: HomeAssistant, mock_storage_resources
 ):
-    """Test cleanup skipped when not auto-registered."""
+    """Test cleanup removes the resource after a restart short-circuited registration.
+
+    Regression test for issue #706: with STRATEGY_PATH already present in the
+    collection (as it is after a Home Assistant restart), registration
+    short-circuits on the ``already_registered`` early return. Cleanup must
+    still remove the resource by keying off the collection contents rather than
+    an in-memory flag that is never set on that path.
+    """
+    mock_storage_resources.async_items.return_value = [{"id": "resource_id", "url": STRATEGY_PATH}]
     hass.data[LOVELACE_DOMAIN] = MagicMock()
     hass.data[LOVELACE_DOMAIN].resources = mock_storage_resources
+    hass.data[DOMAIN] = {}
 
-    await async_cleanup_strategy_resource(hass, {"resources": False})
+    # Simulate the post-restart registration call: it short-circuits because the
+    # resource is already present and never creates a new item.
+    await async_register_strategy_resource(hass)
+    mock_storage_resources.async_create_item.assert_not_called()
 
-    mock_storage_resources.async_delete_item.assert_not_called()
+    await async_cleanup_strategy_resource(hass)
+
+    mock_storage_resources.async_delete_item.assert_awaited_once_with("resource_id")
 
 
 async def test_cleanup_strategy_resource_not_found(hass: HomeAssistant, mock_storage_resources):
-    """Test cleanup when resource not found."""
+    """Test cleanup is a no-op when STRATEGY_PATH is absent from the collection."""
     mock_storage_resources.async_items.return_value = []  # No resources
     hass.data[LOVELACE_DOMAIN] = MagicMock()
     hass.data[LOVELACE_DOMAIN].resources = mock_storage_resources
 
     # Should not raise
-    await async_cleanup_strategy_resource(hass, {"resources": True})
+    await async_cleanup_strategy_resource(hass)
 
     mock_storage_resources.async_delete_item.assert_not_called()
 
@@ -222,14 +235,29 @@ async def test_cleanup_strategy_resource_not_found(hass: HomeAssistant, mock_sto
 async def test_cleanup_strategy_resource_yaml_mode_skipped(
     hass: HomeAssistant, mock_yaml_resources, caplog
 ):
-    """Test cleanup skipped in YAML mode after registration."""
+    """Test cleanup refuses to remove a present resource in YAML mode."""
+    mock_yaml_resources.async_items.return_value = [{"url": STRATEGY_PATH, "type": "module"}]
     hass.data[LOVELACE_DOMAIN] = MagicMock()
     hass.data[LOVELACE_DOMAIN].resources = mock_yaml_resources
 
     with caplog.at_level(logging.DEBUG):
-        await async_cleanup_strategy_resource(hass, {"resources": True})
+        await async_cleanup_strategy_resource(hass)
 
     assert "YAML mode" in caplog.text
+
+
+async def test_cleanup_strategy_resource_yaml_mode_absent(
+    hass: HomeAssistant, mock_yaml_resources, caplog
+):
+    """Test cleanup in YAML mode is silent when STRATEGY_PATH is absent."""
+    mock_yaml_resources.async_items.return_value = [{"url": "/local/other.js", "type": "module"}]
+    hass.data[LOVELACE_DOMAIN] = MagicMock()
+    hass.data[LOVELACE_DOMAIN].resources = mock_yaml_resources
+
+    with caplog.at_level(logging.DEBUG):
+        await async_cleanup_strategy_resource(hass)
+
+    assert "YAML mode" not in caplog.text
 
 
 async def test_cleanup_strategy_resource_no_resources(hass: HomeAssistant):
@@ -237,4 +265,4 @@ async def test_cleanup_strategy_resource_no_resources(hass: HomeAssistant):
     # No lovelace domain
 
     # Should not raise
-    await async_cleanup_strategy_resource(hass, {"resources": True})
+    await async_cleanup_strategy_resource(hass)


### PR DESCRIPTION
# Summary

Strategy resource cleanup was effectively dead after the first Home Assistant
restart. `async_register_strategy_resource` only set the in-memory
`hass.data[DOMAIN]["resources"]` flag on the `async_create_item` branch; the
`already_registered` early return left it falsy. After a restart the resource
is already present in `.storage/lovelace_resources`, so registration
short-circuits and the flag never flips for the entire run. The cleanup guard
then bailed and `async_delete_item` was never awaited, so the strategy
resource lingered forever once the last keymaster entry unloaded.

This drops the unreliable in-memory flag entirely and makes cleanup idempotent
by keying off the actual presence of `STRATEGY_PATH` in the resource
collection.

## Proposed change

**Why remove the flag rather than patch it:** setting the flag on the
`already_registered` path too would fix one symptom, but the flag is
in-memory state that cannot survive a restart — it is unreliable by design.
Keying cleanup off the actual collection contents is correct by construction
and cannot be defeated by a restart.

- Remove all reads and writes of the `"resources"` flag:
  - the write in `async_register_strategy_resource` (`resources.py`),
  - the two guards and the reset write in `async_cleanup_strategy_resource`
    (`resources.py`),
  - the `{"resources": False}` seed in `async_setup` (`__init__.py`).
  - The unrelated `"resources_warned"` / `"yaml_warned"` log-once throttles
    are left untouched.
- **`hass_data` parameter decision:** removing the flag makes the
  `hass_data: dict[str, Any]` argument of `async_cleanup_strategy_resource`
  unused. It is dropped rather than kept as a dead argument. This is an
  internal helper with a single caller — `async_unload_entry` in
  `__init__.py` — which is updated accordingly. There is no external/public
  API to preserve, and leaving the unused parameter would be flagged by Ruff.
- **YAML-mode guard preserved:** cleanup still refuses to auto-remove in
  `ResourceYAMLCollection` mode. The "resources are in YAML mode, skipping
  automatic removal" debug log now fires when `STRATEGY_PATH` is actually
  present in the collection, preserving the equivalent signal without relying
  on the removed flag.

**Call sites of the two functions** (`async_register_strategy_resource`,
`async_cleanup_strategy_resource`): both live in `__init__.py`. Registration
is called in `async_setup` and `async_setup_entry` (unchanged signature).
Cleanup is called once, in `async_unload_entry`, updated to drop `hass_data`.

### Behavior change (please note)

In **storage** mode, cleanup now also removes a `STRATEGY_PATH` resource that
a user added manually through the Lovelace UI, because once the flag is gone
it is no longer distinguishable from one keymaster registered. This is
accepted: the strategy module is inert without keymaster installed, so
removing it on the last-entry unload is harmless. **YAML-mode** resources
remain user-managed and are never auto-removed.

### Tests

The throwaway probe from issue #706 is reinstated as permanent coverage in
`tests/test_resources.py`:

1. **Post-restart regression** (`..._removes_after_restart`): with
   `STRATEGY_PATH` already present, registration short-circuits
   (`async_create_item` not called) and cleanup **does** await
   `async_delete_item`. This test **fails on the pre-fix code** and passes
   after the fix.
2. Fresh registration → cleanup removes it (same-run path still works).
3. YAML mode with the resource present → cleanup does **not** remove, logs the
   YAML-mode skip.
4. YAML mode with the resource absent → silent, no crash.
5. No Lovelace / no resource collection → no crash.
6. `STRATEGY_PATH` absent from the collection → cleanup is a no-op.

Fails-before / passes-after was verified explicitly by running the regression
against the pre-fix source (resource **not** removed) and after (resource
removed). `resources.py` retains 100% line coverage; `tox -e lint`
(ruff, ruff format, mypy, codespell) is clean.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #706
- This PR is related to issue: #699
