### PR TITLE
fix(coordinator): snapshot lock ids before awaiting in iteration loops

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -542,7 +542,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             await self._rebuild_lock_relationships()
             await self._update_door_and_lock_state()
             await self._setup_timers()
-            for lock in self.kmlocks.values():
+            for entry_id in list(self.kmlocks):
+                lock = self.kmlocks.get(entry_id)
+                if lock is None:
+                    continue
                 await self._update_listeners(lock)
         finally:
             # Set the event unconditionally to prevent deadlocks on failed setup
@@ -751,10 +754,13 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
     async def _verify_lock_configuration(self) -> None:
         """Verify lock configuration and update as needed."""
-        for lock in self.kmlocks:
+        for lock in list(self.kmlocks):
+            kmlock = self.kmlocks.get(lock)
+            if kmlock is None:
+                continue
             _LOGGER.debug("================================")
             _LOGGER.debug("[verify_lock_configuration] Verifying %s", lock)
-            config_entry_id: str = self.kmlocks[lock].keymaster_config_entry_id
+            config_entry_id: str = kmlock.keymaster_config_entry_id
             config_entry: ConfigEntry | None = self.hass.config_entries.async_get_entry(
                 config_entry_id,
             )
@@ -1823,7 +1829,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         return int(minutes) * 60
 
     async def _setup_timers(self) -> None:
-        for kmlock in self.kmlocks.values():
+        for entry_id in list(self.kmlocks):
+            kmlock = self.kmlocks.get(entry_id)
+            if kmlock is None:
+                continue
             if not isinstance(kmlock, KeymasterLock):
                 continue
             await self._setup_timer(kmlock)
@@ -1901,12 +1910,15 @@ class KeymasterCoordinator(DataUpdateCoordinator):
     ) -> None:
         # _LOGGER.debug("[update_door_and_lock_state] Running")
         entry_id_filter = set(entry_ids) if entry_ids is not None else None
-        locks = (
-            (self.kmlocks[entry_id] for entry_id in entry_id_filter if entry_id in self.kmlocks)
+        entry_ids_to_process = (
+            [entry_id for entry_id in entry_id_filter if entry_id in self.kmlocks]
             if entry_id_filter is not None
-            else self.kmlocks.values()
+            else list(self.kmlocks)
         )
-        for kmlock in locks:
+        for entry_id in entry_ids_to_process:
+            kmlock = self.kmlocks.get(entry_id)
+            if kmlock is None:
+                continue
             if isinstance(kmlock.lock_entity_id, str) and kmlock.lock_entity_id:
                 lock_state = None
                 if temp_lock_state := self.hass.states.get(kmlock.lock_entity_id):
@@ -2725,7 +2737,8 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             dirty.update(await self._sync_child_locks(parent_entry_id))
         if self._sync_status_counter > SYNC_STATUS_THRESHOLD:
             before_sync_status = {
-                lock_entry_id: self._lock_snapshot(lock_entry_id) for lock_entry_id in self.kmlocks
+                lock_entry_id: self._lock_snapshot(lock_entry_id)
+                for lock_entry_id in list(self.kmlocks)
             }
             self._sync_status_counter = 0
             await self._update_door_and_lock_state(trigger_actions_if_changed=True)
@@ -2759,14 +2772,18 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             cancel()
         self._cancel_debounced_refresh.clear()
 
-        for keymaster_config_entry_id in self.kmlocks:
+        for keymaster_config_entry_id in list(self.kmlocks):
+            if keymaster_config_entry_id not in self.kmlocks:
+                continue
             before = self._lock_snapshot(keymaster_config_entry_id)
             await self._update_lock_data(keymaster_config_entry_id=keymaster_config_entry_id)
             if before != self._lock_snapshot(keymaster_config_entry_id):
                 dirty_entry_ids.add(keymaster_config_entry_id)
 
         # Propagate parent kmlock settings to child kmlocks
-        for keymaster_config_entry_id in self.kmlocks:
+        for keymaster_config_entry_id in list(self.kmlocks):
+            if keymaster_config_entry_id not in self.kmlocks:
+                continue
             dirty_entry_ids.update(
                 await self._sync_child_locks(keymaster_config_entry_id=keymaster_config_entry_id)
             )
@@ -2774,7 +2791,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         # Handle sync status update if necessary
         if self._sync_status_counter > SYNC_STATUS_THRESHOLD:
             before_sync_status = {
-                entry_id: self._lock_snapshot(entry_id) for entry_id in self.kmlocks
+                entry_id: self._lock_snapshot(entry_id) for entry_id in list(self.kmlocks)
             }
             self._sync_status_counter = 0
             await self._update_door_and_lock_state(trigger_actions_if_changed=True)

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -2303,3 +2303,178 @@ async def test_setup_timer_keeps_recovered_timer_over_startup_arm(hass):
     assert kmlock.autolock_timer.is_running
     assert kmlock.autolock_timer.duration == 900
     await kmlock.autolock_timer.cancel()
+
+
+async def test_async_refresh_all_locks_survives_entry_removal_mid_update(hass) -> None:
+    """Refresh survives a kmlock removed while an update await is suspended.
+
+    Reproduces issue #705: a deferred ``_delete_lock`` timer can pop an
+    entry from ``self.kmlocks`` while ``async_refresh_all_locks`` is
+    suspended mid-iteration. Iterating the live mapping raised
+    ``RuntimeError: dictionary changed size during iteration``.
+    """
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    coordinator._sync_child_locks = AsyncMock(return_value=set())
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    processed: list[str] = []
+
+    async def update_lock_data(keymaster_config_entry_id: str) -> None:
+        processed.append(keymaster_config_entry_id)
+        # Suspend, then simulate a deferred _delete_lock timer firing.
+        await asyncio.sleep(0)
+        coordinator.kmlocks.pop("entry_2", None)
+
+    coordinator._update_lock_data = update_lock_data
+
+    await coordinator.async_refresh_all_locks()
+
+    assert processed == ["entry_1"]
+    assert "entry_2" not in coordinator.kmlocks
+    await coordinator.async_shutdown()
+
+
+async def test_async_refresh_all_locks_survives_entry_removal_mid_child_sync(hass) -> None:
+    """Refresh survives a kmlock removed while a child-sync await is suspended.
+
+    Covers the second awaited iteration over ``self.kmlocks`` in
+    ``async_refresh_all_locks`` (the ``_sync_child_locks`` loop).
+    """
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+    coordinator._update_lock_data = AsyncMock()
+    coordinator._async_save_data = AsyncMock()
+    coordinator._schedule_quick_refresh_if_needed = AsyncMock()
+
+    synced: list[str] = []
+
+    async def sync_child_locks(keymaster_config_entry_id: str) -> set[str]:
+        synced.append(keymaster_config_entry_id)
+        await asyncio.sleep(0)
+        coordinator.kmlocks.pop("entry_2", None)
+        return set()
+
+    coordinator._sync_child_locks = sync_child_locks
+
+    await coordinator.async_refresh_all_locks()
+
+    assert synced == ["entry_1"]
+    assert "entry_2" not in coordinator.kmlocks
+    await coordinator.async_shutdown()
+
+
+async def test_setup_timers_survives_entry_removal_mid_setup(hass) -> None:
+    """_setup_timers survives a kmlock removed while a timer setup awaits."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+
+    handled: list[str] = []
+
+    async def setup_timer(kmlock: KeymasterLock) -> None:
+        handled.append(kmlock.keymaster_config_entry_id)
+        await asyncio.sleep(0)
+        coordinator.kmlocks.pop("entry_2", None)
+
+    coordinator._setup_timer = setup_timer
+
+    await coordinator._setup_timers()
+
+    assert handled == ["entry_1"]
+    assert "entry_2" not in coordinator.kmlocks
+    await coordinator.async_shutdown()
+
+
+async def test_update_door_and_lock_state_survives_entry_removal(hass) -> None:
+    """_update_door_and_lock_state survives a kmlock removed mid-iteration."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    lock_1 = _make_lock("entry_1", "lock_1")
+    lock_1.lock_state = LockState.LOCKED
+    lock_2 = _make_lock("entry_2", "lock_2")
+    coordinator.kmlocks["entry_1"] = lock_1
+    coordinator.kmlocks["entry_2"] = lock_2
+    hass.states.async_set("lock.lock_1", LockState.UNLOCKED)
+
+    triggered: list[str] = []
+
+    async def lock_unlocked(
+        kmlock: KeymasterLock,
+        code_slot_num: int | None = None,
+        source: str | None = None,
+        event_label: str | None = None,
+        action_code: int | None = None,
+    ) -> None:
+        triggered.append(kmlock.keymaster_config_entry_id)
+        await asyncio.sleep(0)
+        coordinator.kmlocks.pop("entry_2", None)
+
+    coordinator._lock_unlocked = lock_unlocked
+
+    await coordinator._update_door_and_lock_state(trigger_actions_if_changed=True)
+
+    assert triggered == ["entry_1"]
+    assert "entry_2" not in coordinator.kmlocks
+    await coordinator.async_shutdown()
+
+
+async def test_verify_lock_configuration_survives_entry_removal(hass) -> None:
+    """_verify_lock_configuration survives a kmlock removed during delete await."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._initial_setup_done_event.set()
+    coordinator.kmlocks["entry_1"] = _make_lock("entry_1", "lock_1")
+    coordinator.kmlocks["entry_2"] = _make_lock("entry_2", "lock_2")
+
+    deleted: list[str] = []
+
+    async def delete_lock(config_entry_id: str, immediate: bool = False) -> None:
+        deleted.append(config_entry_id)
+        await asyncio.sleep(0)
+        coordinator.kmlocks.pop("entry_2", None)
+
+    coordinator.delete_lock_by_config_entry_id = delete_lock
+
+    await coordinator._verify_lock_configuration()
+
+    assert deleted == ["entry_1"]
+    assert "entry_2" not in coordinator.kmlocks
+    await coordinator.async_shutdown()
+
+
+async def test_async_setup_update_listeners_survives_entry_removal(hass) -> None:
+    """_async_setup's listener loop survives a kmlock removed mid-iteration."""
+    coordinator = KeymasterCoordinator(hass)
+    coordinator._rebuild_lock_relationships = AsyncMock()
+    coordinator._update_door_and_lock_state = AsyncMock()
+    coordinator._setup_timers = AsyncMock()
+    coordinator._verify_lock_configuration = AsyncMock()
+
+    lock_1 = _make_lock("entry_1", "lock_1")
+    lock_2 = _make_lock("entry_2", "lock_2")
+
+    async def load_data() -> dict[str, KeymasterLock]:
+        return {"entry_1": lock_1, "entry_2": lock_2}
+
+    coordinator._async_load_data = load_data
+
+    listened: list[str] = []
+
+    async def update_listeners(kmlock: KeymasterLock) -> None:
+        listened.append(kmlock.keymaster_config_entry_id)
+        await asyncio.sleep(0)
+        coordinator.kmlocks.pop("entry_2", None)
+
+    coordinator._update_listeners = update_listeners
+
+    await coordinator._async_setup()
+
+    assert listened == ["entry_1"]
+    assert "entry_2" not in coordinator.kmlocks
+    await coordinator.async_shutdown()


### PR DESCRIPTION
# Summary

`KeymasterCoordinator` iterated `self.kmlocks` directly in several loops that
`await` inside the body. If a config entry was added or removed while one of
those awaits was suspended, Python raised
`RuntimeError: dictionary changed size during iteration`. This snapshots the
keys before each awaited loop and re-checks existence per iteration. Fixes #705.

## Proposed change

`self.kmlocks` is a `MutableMapping[str, KeymasterLock]`. Iterating it directly
(`for ... in self.kmlocks`, `.values()`, or a comprehension) while an `await`
inside the loop body is suspended is unsafe: if the mapping's size changes
during that suspension the next iterator step crashes.

### The internal trigger (not just user-initiated config-entry churn)

The realistic trigger lives inside the integration's own scheduling.
`delete_lock_by_config_entry_id()` defaults to `immediate=False`: it sets
`kmlock.pending_delete = True` and schedules `_delete_lock` via
`async_call_later(..., QUICK_REFRESH_SECONDS, ...)` rather than popping
synchronously. When that timer fires, `_delete_lock()` calls
`self.kmlocks.pop(...)`. If that pop lands while another coroutine is suspended
mid-iteration over `self.kmlocks` (e.g. in `async_refresh_all_locks`), the
`RuntimeError` occurs. This analysis is also recorded on issue #705.

### Fix shape

Snapshot the keys with `list(self.kmlocks)` before entering each awaited loop,
then re-fetch (or re-check existence) on each iteration and skip entries that
disappeared while suspended. No behavior change beyond closing the race.

### Iteration sites audited

**Fixed (await reachable inside a live iteration over `self.kmlocks`):**

- `_async_setup` — the `_update_listeners` loop (`for lock in self.kmlocks.values()`).
- `_verify_lock_configuration` — `for lock in self.kmlocks` with an awaited
  `delete_lock_by_config_entry_id` in the body.
- `_setup_timers` — `for kmlock in self.kmlocks.values()` awaiting `_setup_timer`.
- `_update_door_and_lock_state` — the `else self.kmlocks.values()` branch was a
  live view iterated while awaiting `_lock_locked` / `_lock_unlocked` /
  `_door_opened` / `_door_closed`. Rewritten to build a key list up front and
  re-fetch per iteration. (The `entry_id_filter` branch already iterated a copied
  set and re-checked membership, so it was safe; it is preserved.)
- `async_refresh_all_locks` — both awaited loops (`_update_lock_data` loop and
  `_sync_child_locks` loop).

**Defensively snapshotted (no internal await, cannot race — wrapped in `list()`
for consistency with the sibling loops):**

- The `before_sync_status` dict comprehension in `async_refresh_all_locks`.
- The `before_sync_status` dict comprehension in the single-lock refresh
  (`_async_refresh_lock_data`). These comprehensions evaluate atomically with no
  suspension point, so they could not raise, but were named alongside the refresh
  loops in the issue and are trivially made explicit.

**Left alone (safe — verified, no await during iteration):**

- `_rebuild_lock_relationships` (`for ... in self.kmlocks.items()`, ~:930): the
  loop body contains **no** `await`, so there is no suspension point and no race.
  Note: it does mutate `child_config_entry_ids` (already iterated over a
  `list(...)` copy), but never mutates `self.kmlocks` and never awaits — so it is
  out of scope for this bug and intentionally untouched.
- `count_locks_not_pending_delete` (`for ... in self.kmlocks.values()`, ~:2164):
  a synchronous property.
- All `.get()`, `in` membership checks, subscript reads, and `dict(self.kmlocks)`
  copies — not iterations with awaits.

### How the tests prove the fix

Six regression tests in `tests/test_coordinator_lifecycle.py` interleave a
`self.kmlocks.pop("entry_2")` from an awaited collaborator (patched with an
`await asyncio.sleep(0)` + pop) while each loop is suspended after processing
`entry_1`, deterministically reproducing the deferred-delete timing:

- `test_async_refresh_all_locks_survives_entry_removal_mid_update`
- `test_async_refresh_all_locks_survives_entry_removal_mid_child_sync`
- `test_setup_timers_survives_entry_removal_mid_setup`
- `test_update_door_and_lock_state_survives_entry_removal`
- `test_verify_lock_configuration_survives_entry_removal`
- `test_async_setup_update_listeners_survives_entry_removal`

Each test was verified to **fail before** the fix with the exact
`RuntimeError: dictionary changed size during iteration`, and to **pass after**
the fix. They cover both the surviving-entry path and the removed-entry
`continue` path of every modified loop (100% patch coverage on the changed
lines). Full suite: 1167 passed, 3 skipped; overall coverage 95%.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #705
- This PR is related to issue:
