### PR TITLE
fix(coordinator): keep deferred keypad lock notification on duplicate slot 0

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1674,7 +1674,6 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                     self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
                 self._state_change_autolock_started.discard(kmlock.keymaster_config_entry_id)
             self._cancel_pending_keypad_unlock_notification(kmlock)
-            self._cancel_pending_keypad_lock_notification(kmlock)
             return
 
         if not self._throttle.is_allowed(

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -1757,3 +1757,270 @@ async def test_lock_unlocked_supersede_bypasses_throttle(hass, coordinator_for_u
     assert fired_events[0][ATTR_CODE_SLOT] == 0
     assert fired_events[1][ATTR_CODE_SLOT] == 3
     assert fired_events[1][ATTR_CODE_SLOT_NAME] == "Alice"
+
+
+async def test_keypad_lock_duplicate_slot0_still_emits_deferred_notification(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test a duplicate slot=0 keypad lock keeps the deferred notification armed.
+
+    Regression for #746: a provisional slot=0 keypad lock arms the 1-second
+    deferral. A duplicate slot=0 event arriving inside that window finds the
+    lock already LOCKED and previously cancelled the deferral unconditionally,
+    suppressing the notification entirely. The deferred "Keypad Lock" must
+    still fire.
+    """
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_dup_slot0_lock",
+    )
+    kmlock.lock_state = LockState.UNLOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Rich", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new=AsyncMock(),
+    ) as mock_notify:
+        # First provisional slot=0 lock arms the deferral.
+        await coordinator._lock_locked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Lock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+        assert kmlock.keymaster_config_entry_id in coordinator._pending_keypad_lock_notifications
+
+        # Duplicate slot=0 lock inside the deferral window (already LOCKED).
+        await coordinator._lock_locked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Lock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+        mock_notify.assert_not_called()
+        # Deferral must remain armed after the duplicate.
+        assert kmlock.keymaster_config_entry_id in coordinator._pending_keypad_lock_notifications
+
+        async_fire_time_changed(hass, fire_all=True)
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Keypad Lock",
+    )
+    assert kmlock.keymaster_config_entry_id not in coordinator._pending_keypad_lock_notifications
+
+
+async def test_keypad_unlock_duplicate_slot0_still_emits_deferred_notification(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test the equivalent duplicate slot=0 unlock still emits its notification.
+
+    Symmetry guard for #746: ensures the lock-side fix does not regress the
+    unlock path, whose already-UNLOCKED early return already preserves the
+    deferred notification on a duplicate slot=0 event.
+    """
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_dup_slot0_unlock",
+    )
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(number=1, name="Rich", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new=AsyncMock(),
+    ) as mock_notify:
+        # First provisional slot=0 unlock arms the deferral.
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+        assert kmlock.keymaster_config_entry_id in coordinator._pending_keypad_unlock_notifications
+
+        # Duplicate slot=0 unlock inside the deferral window (already UNLOCKED).
+        await coordinator._lock_unlocked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Unlock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+        mock_notify.assert_not_called()
+        assert kmlock.keymaster_config_entry_id in coordinator._pending_keypad_unlock_notifications
+
+        async_fire_time_changed(hass, fire_all=True)
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Keypad Unlock",
+    )
+
+
+async def test_keypad_lock_slot0_superseded_by_slot_notification(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test slot=0 lock superseded by a slot>0 event (0 -> 2) is unaffected.
+
+    Exercises the had_pending_notification supersede branch: the provisional
+    slot=0 deferral is cancelled and replaced by the per-code-slot lock
+    notification for the revealed slot. Behavior must match the pre-fix path.
+    """
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_lock_supersede",
+    )
+    kmlock.lock_state = LockState.UNLOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        2: KeymasterCodeSlot(number=2, name="Guest", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new=AsyncMock(),
+    ) as mock_notify:
+        # Provisional slot=0 lock arms the deferral.
+        await coordinator._lock_locked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Lock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+        assert kmlock.keymaster_config_entry_id in coordinator._pending_keypad_lock_notifications
+
+        # Revealed slot=2 supersedes the provisional slot=0.
+        await coordinator._lock_locked(
+            kmlock=kmlock,
+            code_slot_num=2,
+            source="valid_code_entered",
+            event_label="Keypad Lock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+
+        # Supersede cancels the deferral immediately.
+        assert (
+            kmlock.keymaster_config_entry_id not in coordinator._pending_keypad_lock_notifications
+        )
+
+        async_fire_time_changed(hass, fire_all=True)
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Keypad Lock by Guest [2]",
+    )
+
+
+async def test_keypad_lock_duplicate_slot0_then_superseded(
+    hass,
+    coordinator_for_unlock_test,
+):
+    """Test slot=0 duplicate then slot>0 supersede (0 -> 0 -> 2).
+
+    The duplicate slot=0 now keeps the deferral armed (the #746 fix); the
+    following slot=2 event supersedes it via the had_pending_notification
+    branch, emitting exactly one per-code-slot lock notification and leaving
+    no pending deferral.
+    """
+    coordinator = coordinator_for_unlock_test
+    kmlock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="test_entry_lock_dup_then_supersede",
+    )
+    kmlock.lock_state = LockState.UNLOCKED
+    kmlock.lock_notifications = True
+    kmlock.notify_script_name = "notify_front_door"
+    kmlock.code_slots = {
+        2: KeymasterCodeSlot(number=2, name="Guest", enabled=True, notifications=True)
+    }
+    coordinator.kmlocks[kmlock.keymaster_config_entry_id] = kmlock
+
+    with patch(
+        "custom_components.keymaster.coordinator.send_manual_notification",
+        new=AsyncMock(),
+    ) as mock_notify:
+        # Provisional slot=0 lock arms the deferral.
+        await coordinator._lock_locked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Lock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+
+        # Duplicate slot=0 keeps the deferral armed.
+        await coordinator._lock_locked(
+            kmlock=kmlock,
+            code_slot_num=0,
+            source="relay_a_triggered",
+            event_label="Keypad Lock",
+            action_code=1,
+        )
+        await hass.async_block_till_done()
+        assert kmlock.keymaster_config_entry_id in coordinator._pending_keypad_lock_notifications
+
+        # Revealed slot=2 supersedes the provisional slot=0.
+        await coordinator._lock_locked(
+            kmlock=kmlock,
+            code_slot_num=2,
+            source="valid_code_entered",
+            event_label="Keypad Lock",
+            action_code=2,
+        )
+        await hass.async_block_till_done()
+        assert (
+            kmlock.keymaster_config_entry_id not in coordinator._pending_keypad_lock_notifications
+        )
+
+        async_fire_time_changed(hass, fire_all=True)
+        await hass.async_block_till_done()
+
+    mock_notify.assert_called_once_with(
+        hass=hass,
+        script_name="notify_front_door",
+        title="Front Door",
+        message="Keypad Lock by Guest [2]",
+    )


### PR DESCRIPTION
# Summary

Fixes a lock/unlock asymmetry in `KeymasterCoordinator._lock_locked` that
suppressed the deferred keypad **lock** notification when a duplicate
provisional `slot=0` keypad lock event arrived inside the 1-second deferral
window. Closes #746.

## Proposed change

The already-`LOCKED` early return in `_lock_locked` unconditionally called
`self._cancel_pending_keypad_lock_notification(kmlock)`. A provisional
`slot=0` keypad lock event arms a 1-second deferral; when a duplicate `slot=0`
event arrives inside that window the lock is already `LOCKED`, so control
enters this early return, the deferral is cancelled, and **no notification is
ever sent**. The unlock path is not affected — its already-`UNLOCKED` early
return does not cancel the pending unlock notification. The two paths were
asymmetric.

Observed on merged `main` before the fix:

```
lock   0 -> lock   0 -> +5s    armed1=True armed2=False   notifications=[]
unlock 0 -> unlock 0 -> +5s    armed1=True armed2=True    notifications=['Keypad Unlock']
```

The fix removes the single unconditional
`self._cancel_pending_keypad_lock_notification(kmlock)` line from the
already-`LOCKED` early return, restoring symmetry with the unlock path.

### Why the removed line is redundant (independently confirmed)

I traced every path that can hold a pending keypad lock deferral. A deferral
is only ever armed on the main lock path, and only for a `slot=0`
`Keypad Lock` event (`_should_defer_keypad_lock_notification` requires
`code_slot_num == 0`), which also sets `_last_lock_code_slot = 0`. So any
subsequent already-`LOCKED` event that finds a pending deferral has
`prior_slot == 0`:

- **`0 -> 0`** (the bug): supersede branch is *not* taken (`code_slot_num`
  is not `> 0`). Pre-fix, the removed line cancelled the still-armed deferral
  and nothing fired. Post-fix, the deferral stays armed and fires once. This
  is the fix.
- **`0 -> 2`**: supersede branch *is* taken; it cancels the deferral via
  `had_pending_notification = self._cancel_pending_keypad_lock_notification(...)`
  and emits the per-slot notification. The removed line was a no-op here
  (already cancelled). Unaffected.
- **`0 -> 0 -> 2`**: the duplicate `slot=0` now keeps the deferral armed, and
  the following `slot=2` event's supersede branch cancels it and emits exactly
  one per-slot notification. No leaked/duplicate notification.
- **already-`LOCKED` with no pending deferral**: both pre- and post-fix are
  no-ops for the lock deferral.

The main lock path continues to cancel any stale pending notification before
arming a fresh deferral (unchanged). So the removed call cancelled nothing
that another path does not already cancel where appropriate — its only effect
was the bug. No path is left holding a deferral that should have been
cancelled.

### Decision on the sibling `_cancel_pending_keypad_unlock_notification`

The sibling `self._cancel_pending_keypad_unlock_notification(kmlock)` on the
line above is intentionally **kept**. Cancelling a pending *unlock*
notification when the lock is confirmed `LOCKED` is coherent, and the issue
does not challenge it.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

Reinstated the throwaway verification probe as permanent tests in
`tests/test_coordinator_events.py`:

1. `test_keypad_lock_duplicate_slot0_still_emits_deferred_notification` — the
   regression: `lock 0 -> lock 0 -> +time` now emits the deferred
   `Keypad Lock`.
2. `test_keypad_unlock_duplicate_slot0_still_emits_deferred_notification` —
   symmetry guard: the equivalent unlock sequence still emits `Keypad Unlock`.
3. `test_keypad_lock_slot0_superseded_by_slot_notification` — `0 -> 2`
   supersede unaffected.
4. `test_keypad_lock_duplicate_slot0_then_superseded` — `0 -> 0 -> 2` exercises
   the `had_pending_notification` supersede path.

**Fails-before / passes-after evidence:** with the one-line fix stashed, tests
1 and 4 FAIL (the deferral is cancelled by the duplicate `slot=0`), while tests
2 and 3 PASS both ways (proving the unlock path and the `0 -> 2` supersede path
are genuinely unaffected). With the fix applied, all four pass. Full suite:
1172 passed, 3 skipped, total coverage 94.99% (floor 80%). `tox -e lint`
(ruff check, ruff format --check, mypy, codespell) is clean.

- This PR fixes or closes issue: fixes #746
- This PR is related to issue: #744
