### PR TITLE
fix(autolock): assign timer entry after write to close start/cancel race

### DIFF
--- a/custom_components/keymaster/autolock/timer.py
+++ b/custom_components/keymaster/autolock/timer.py
@@ -25,8 +25,11 @@ State machine (recover() must be the first transition, from FRESH only):
 Invariants:
     1. The store entry mirrors the most recent ACTIVE state. cancel() and
        successful fire remove it; start() and recover() (active) write it.
-    2. cancel() awaits any in-flight callback before returning. After
-       cancel() returns, no further action firing can happen.
+    2. cancel() awaits the in-flight callback for the fire it is
+       cancelling before returning. After cancel() returns, that fire
+       can no longer run its action. This is scoped to the cancelled
+       fire: a start() that interleaved with cancel() and took ownership
+       of the timer (see cancel()'s early return) can still fire.
     3. The action snapshot is the live kmlock from `get_kmlock()` — never
        a captured reference. Reload swaps kmlocks transparently.
 """
@@ -147,6 +150,11 @@ class AutolockTimer:
             await scheduled.cancel()
             if self._scheduled is not scheduled:
                 # A start() interleaved with the await and owns the timer now.
+                _LOGGER.debug(
+                    "[AutolockTimer] %s: cancel() yielded to an interleaved"
+                    " start(); leaving the new timer armed",
+                    self._timer_id,
+                )
                 return
             self._scheduled = None
         if self._state == TimerState.ACTIVE:

--- a/custom_components/keymaster/autolock/timer.py
+++ b/custom_components/keymaster/autolock/timer.py
@@ -84,30 +84,37 @@ class AutolockTimer:
         self._entry: TimerEntry | None = None
         self._scheduled: ScheduledFire | None = None
 
-    async def recover(self) -> None:
+    async def recover(self) -> bool:
         """Load any persisted entry left over from a prior process.
 
         - No entry: stay DONE (idle).
         - Active entry: move to ACTIVE, schedule the remaining delay.
         - Expired entry: fire the action immediately. On success → DONE.
           On failure → re-persist for retry on next restart.
+
+        Returns True when a persisted entry was consumed (active or
+        expired), and False when there was nothing to recover. Callers
+        use this to decide whether to arm a fresh startup timer: an
+        expired entry that fired (whether the action succeeded or was
+        re-persisted for replay) must not be overwritten by a fresh arm.
         """
         if self._state != TimerState.FRESH:
             raise RuntimeError(f"recover() requires FRESH state, got {self._state}")
         entry = await self._store.read(self._timer_id)
         if entry is None:
             self._state = TimerState.DONE
-            return
+            return False
         if entry.end_time <= dt_util.utcnow():
             # Set state to ACTIVE before firing so _fire's success and
             # failure paths leave a usable post-recover state.
             self._entry = entry
             self._state = TimerState.ACTIVE
             await self._fire(now=dt_util.utcnow(), entry=entry)
-            return
+            return True
         self._entry = entry
         self._schedule_remaining()
         self._state = TimerState.ACTIVE
+        return True
 
     async def start(self, duration: int) -> None:
         """Start (or restart) the timer for `duration` seconds."""

--- a/custom_components/keymaster/autolock/timer.py
+++ b/custom_components/keymaster/autolock/timer.py
@@ -117,8 +117,13 @@ class AutolockTimer:
             await self._scheduled.cancel()
             self._scheduled = None
         end_time = dt_util.utcnow() + timedelta(seconds=duration)
-        self._entry = TimerEntry(end_time=end_time, duration=duration)
-        await self._store.write(self._timer_id, self._entry)
+        entry = TimerEntry(end_time=end_time, duration=duration)
+        await self._store.write(self._timer_id, entry)
+        # Assign the in-memory entry only after the awaited write returns.
+        # If we assigned before the await, a cancel() that interleaves while
+        # start() is suspended here would clear `_entry`, and start() would
+        # resume into `_schedule_remaining()` and trip its assertion. See #748.
+        self._entry = entry
         self._schedule_remaining()
         self._state = TimerState.ACTIVE
         _LOGGER.debug(

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1863,8 +1863,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         )
         recovered = await kmlock.autolock_timer.recover()
         if kmlock.lock_state == LockState.UNLOCKED and kmlock.autolock_enabled and not recovered:
-            # Already unlocked at startup: no unlocked transition will arrive
-            # to arm the timer, so arm it from the state we adopted.
+            # Unlocked with no persisted timer to honor: no unlocked
+            # transition will arrive to arm the timer, so arm it from the
+            # state we adopted. This runs both at startup and at runtime via
+            # add_lock(), so a lock added while unlocked arms immediately.
             #
             # Gate on `not recovered` rather than `not is_running`: recover()
             # may have consumed an expired entry and fired. If the recovery

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -1861,14 +1861,18 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             get_kmlock=get_kmlock,
             action=self._timer_triggered,
         )
-        await kmlock.autolock_timer.recover()
-        if (
-            kmlock.lock_state == LockState.UNLOCKED
-            and kmlock.autolock_enabled
-            and not kmlock.autolock_timer.is_running
-        ):
+        recovered = await kmlock.autolock_timer.recover()
+        if kmlock.lock_state == LockState.UNLOCKED and kmlock.autolock_enabled and not recovered:
             # Already unlocked at startup: no unlocked transition will arrive
             # to arm the timer, so arm it from the state we adopted.
+            #
+            # Gate on `not recovered` rather than `not is_running`: recover()
+            # may have consumed an expired entry and fired. If the recovery
+            # action raised, the entry is re-persisted for replay (is_running
+            # is False) and a fresh start() would overwrite it; if it
+            # succeeded, lock_state is still the pre-recovery UNLOCKED value
+            # and a fresh start() would arm a spurious timer. Either way, skip
+            # the arm when recover() already handled an entry. See #747.
             await kmlock.autolock_timer.start(duration=self.autolock_duration_seconds(kmlock))
         if kmlock.autolock_timer.is_running:
             self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])

--- a/tests/autolock/test_timer.py
+++ b/tests/autolock/test_timer.py
@@ -349,6 +349,55 @@ async def test_cancel_does_not_orphan_fire_armed_during_await(hass, store, kmloc
     await cleanup()
 
 
+async def test_start_survives_cancel_interleaving_store_write(hass, store, kmlock):
+    """Regression for FutureTense/keymaster#748.
+
+    A re-arming start() that suspends inside `await self._store.write(...)`
+    while a concurrent cancel() runs to completion must not resume into
+    `_schedule_remaining()` with a cleared `_entry`. Before the fix,
+    `_entry` was assigned before the awaited write; cancel() cleared it,
+    and start() tripped `assert self._entry is not None` (AssertionError).
+    """
+    # ACTIVE timer with a live ScheduledFire.
+    await store.write(
+        "t1", TimerEntry(end_time=dt_util.utcnow() + timedelta(seconds=300), duration=300)
+    )
+    timer, action, _, cleanup = make_timer(hass, store, kmlock=kmlock)
+    await timer.recover()
+    assert timer.is_running
+
+    write_reached = asyncio.Event()
+    release = asyncio.Event()
+    real_write = store.write
+
+    async def gated_write(timer_id: str, entry: TimerEntry) -> None:
+        """Suspend start() at the store write until released."""
+        write_reached.set()
+        await release.wait()
+        await real_write(timer_id, entry)
+
+    store.write = gated_write
+    try:
+        start_task = asyncio.create_task(timer.start(duration=600))
+        await write_reached.wait()  # start() suspended at the store write
+
+        # cancel() runs to completion: sees `_scheduled is None`, clears
+        # `_entry`, removes the store entry, transitions to DONE.
+        await timer.cancel()
+
+        release.set()
+        await start_task  # must not raise AssertionError
+    finally:
+        store.write = real_write
+
+    assert timer.state == TimerState.ACTIVE
+    assert timer.is_running
+    assert timer.duration == 600
+    assert await store.read("t1") is not None
+    assert action.await_count == 0
+    await cleanup()
+
+
 async def test_action_failure_preserves_entry_for_replay(hass, store, kmlock):
     """Preserve store entry on action failure for replay on next restart.
 

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -11,6 +11,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.keymaster.autolock.store import TimerEntry
+from custom_components.keymaster.autolock.timer import TimerState
 from custom_components.keymaster.const import (
     CONF_ADVANCED_DATE_RANGE,
     CONF_ADVANCED_DAY_OF_WEEK,
@@ -2253,6 +2254,7 @@ async def test_setup_timer_arms_lock_already_unlocked_at_startup(hass):
     """
     coordinator = KeymasterCoordinator(hass)
     kmlock = _autolock_kmlock(lock_state=LockState.UNLOCKED, autolock_enabled=True)
+    coordinator.kmlocks["entry_1"] = kmlock
 
     await coordinator._setup_timer(kmlock)
 
@@ -2266,6 +2268,7 @@ async def test_setup_timer_does_not_arm_when_autolock_disabled(hass):
     """A lock with autolock off is left alone, unlocked or not."""
     coordinator = KeymasterCoordinator(hass)
     kmlock = _autolock_kmlock(lock_state=LockState.UNLOCKED, autolock_enabled=False)
+    coordinator.kmlocks["entry_1"] = kmlock
 
     await coordinator._setup_timer(kmlock)
 
@@ -2277,6 +2280,7 @@ async def test_setup_timer_does_not_arm_locked_lock(hass):
     """A lock that is locked at startup gets no timer."""
     coordinator = KeymasterCoordinator(hass)
     kmlock = _autolock_kmlock(lock_state=LockState.LOCKED, autolock_enabled=True)
+    coordinator.kmlocks["entry_1"] = kmlock
 
     await coordinator._setup_timer(kmlock)
 
@@ -2296,6 +2300,7 @@ async def test_setup_timer_keeps_recovered_timer_over_startup_arm(hass):
         TimerEntry(end_time=dt_util.utcnow() + timedelta(seconds=900), duration=900),
     )
     kmlock = _autolock_kmlock(lock_state=LockState.UNLOCKED, autolock_enabled=True)
+    coordinator.kmlocks["entry_1"] = kmlock
 
     await coordinator._setup_timer(kmlock)
 
@@ -2303,6 +2308,61 @@ async def test_setup_timer_keeps_recovered_timer_over_startup_arm(hass):
     assert kmlock.autolock_timer.is_running
     assert kmlock.autolock_timer.duration == 900
     await kmlock.autolock_timer.cancel()
+
+
+async def test_setup_timer_recover_raises_preserves_replay_entry(hass):
+    """Recovery that consumes an expired entry and raises keeps the replay.
+
+    Regression for #747. When recover() fires an expired entry and the
+    action raises, the entry is re-persisted for replay on the next
+    restart and is_running reports False. The startup arm must be skipped
+    so a fresh start() does not overwrite the preserved replay entry.
+    """
+    coordinator = KeymasterCoordinator(hass)
+    kmlock = _autolock_kmlock(lock_state=LockState.UNLOCKED, autolock_enabled=True)
+    coordinator.kmlocks["entry_1"] = kmlock
+    # Distinctive duration so an overwrite by the startup arm is visible.
+    await coordinator._timer_store.write(
+        "entry_1_autolock",
+        TimerEntry(end_time=dt_util.utcnow() - timedelta(seconds=5), duration=123),
+    )
+    coordinator._timer_triggered = AsyncMock(side_effect=RuntimeError("lock offline"))
+
+    await coordinator._setup_timer(kmlock)
+
+    persisted = await coordinator._timer_store.read("entry_1_autolock")
+    assert persisted is not None, "replay entry must survive"
+    assert persisted.duration == 123, "startup arm overwrote the replay entry"
+    assert kmlock.autolock_timer is not None
+    assert not kmlock.autolock_timer.is_running
+    coordinator._timer_triggered.assert_awaited_once()
+    await kmlock.autolock_timer.cancel()
+
+
+async def test_setup_timer_recover_succeeds_no_spurious_arm(hass):
+    """Recovery that consumes an expired entry and succeeds does not re-arm.
+
+    Regression for #747. When recover() fires an expired entry and the
+    action succeeds, the lock is already engaged; lock_state is still the
+    pre-recovery UNLOCKED value only in memory, so a fresh startup arm
+    would schedule a spurious timer (and notification). It must be skipped.
+    """
+    coordinator = KeymasterCoordinator(hass)
+    kmlock = _autolock_kmlock(lock_state=LockState.UNLOCKED, autolock_enabled=True)
+    coordinator.kmlocks["entry_1"] = kmlock
+    await coordinator._timer_store.write(
+        "entry_1_autolock",
+        TimerEntry(end_time=dt_util.utcnow() - timedelta(seconds=5), duration=123),
+    )
+    coordinator._timer_triggered = AsyncMock()
+
+    await coordinator._setup_timer(kmlock)
+
+    assert kmlock.autolock_timer is not None
+    assert not kmlock.autolock_timer.is_running, "no spurious fresh arm"
+    assert kmlock.autolock_timer.state == TimerState.DONE
+    assert await coordinator._timer_store.read("entry_1_autolock") is None
+    coordinator._timer_triggered.assert_awaited_once()
 
 
 async def test_async_refresh_all_locks_survives_entry_removal_mid_update(hass) -> None:


### PR DESCRIPTION
# Summary

Fixes a start()/cancel() interleave crash and a startup-arm regression in
the autolock timer, plus three doc/logging nits. All three issues touch
`autolock/timer.py`'s `cancel()`/`start()` and the coordinator
`_setup_timer` block, so they ship together as three atomic commits to
avoid guaranteed conflicts.

- `fix(autolock): assign timer entry after write ...` — Closes #748
- `fix(coordinator): skip startup arm when recover() ...` — Closes #747
- `docs(autolock): scope cancel invariant, log interleave exit ...` — Closes #749

## Proposed change

### #748 — start()/cancel() interleave AssertionError (commit 1)
`start()` assigned the in-memory `_entry` before the awaited
`store.write(...)`. A `cancel()` that interleaved while `start()` was
suspended at that write cleared `_entry`, so `start()` resumed into
`_schedule_remaining()` and tripped `assert self._entry is not None`.
Fix: build the entry in a local, `await store.write(...)`, then assign
`self._entry` — keeping `start()`'s post-write tail synchronous.

**Persistence half — subsumed, no follow-up issue filed.** The issue
flagged that a `cancel()` whose `store.remove()` lands after `start()`'s
`store.write()` could leave the timer ACTIVE in memory while the store
entry is absent (lost across restart). After this fix that outcome is
unreachable in the two-actor start/cancel race: `start()`'s post-write
tail (`_entry = entry; _schedule_remaining(); _state = ACTIVE`) is
synchronous, so nothing can interleave between the write returning and
the state settling. Enumerating both store-lock orderings, every
interleaving ends in a **consistent** `(memory, disk)` pair — either
`ACTIVE + entry present` or `DONE + entry absent`; never
`ACTIVE + absent` or `DONE + present`. The committed regression test
covers the `remove`-before-`write` ordering (ends `ACTIVE + present`); a
throwaway probe confirmed the `write`-before-`remove` ordering ends
`DONE + absent`. Because the in-memory fix genuinely closes it, filing a
persistence follow-up would be redundant.

**`fire` closure debug bail** (`timer.py`) remains load-bearing, not dead:
`cancel()` (and reload/replace paths) can still clear `_entry` between
`_schedule_remaining()` capturing `self` and the closure running, so the
bail is still exercised (`test_fire_closure_bails_when_entry_cleared_race`).

### #747 — startup arm overwrites the preserved replay entry (commit 2)
`_setup_timer` gated the startup arm on `not is_running`, but a recovery
fire whose action raises deliberately keeps the entry persisted while
`is_running` is False. So after `recover()` consumed an **expired** entry:
- action raises → the arm's `start()` overwrote the preserved replay entry;
- action succeeds → a spurious fresh timer armed (lock_state was still the
  pre-recovery UNLOCKED value), scheduling a spurious notification.

**Approach chosen: `recover()` reports whether it consumed an entry**, and
the arm gates on `not recovered`. I picked this over the issue's
alternative (a speculative pre-`recover()` store read) because `recover()`
already knows the answer, avoids a second disk read, and `timer.py` is
owned by this same PR. It is also correct against the post-#748 code,
where `_entry`/`is_running` timing shifted.

**Test-gap fix:** the four `test_setup_timer_*` tests never registered
`coordinator.kmlocks["entry_1"]`, so `get_kmlock()` resolved to `None`
when a recovery timer fired and the fire branches were never exercised.
They now register the kmlock, and two new tests cover both recovery
outcomes (raises → replay entry survives `duration=123`; succeeds → no
spurious arm, store cleared).

### #749 — three doc/logging nits (commit 3)
None were subsumed by commits 1–2 (both left `cancel()` and the module
docstring untouched):
1. Module docstring invariant 2 reworded to scope the "no further firing"
   guarantee to the cancelled fire (an interleaved `start()` can still fire).
2. Added the missing `_LOGGER.debug` to `cancel()`'s interleave early return
   (previously the only unlogged exit in the class).
3. Broadened the `_setup_timer` startup-arm comment (updated on the comment
   block commit 2 touched) to note the runtime `add_lock()` path.

## Fails-before / passes-after evidence
- **#748** `test_start_survives_cancel_interleaving_store_write`: pre-fix
  raises `AssertionError` at `_schedule_remaining()`; post-fix passes.
- **#747** `test_setup_timer_recover_raises_preserves_replay_entry` and
  `test_setup_timer_recover_succeeds_no_spurious_arm`: pre-fix the replay
  entry is overwritten / a spurious arm occurs (both fail); post-fix both pass.

Verified explicitly by reverting each fix in isolation.

Test suite: `1171 passed, 3 skipped`, total coverage 94.99%.
Lint (`ruff check`, `ruff format`, `codespell`, `mypy`): clean.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #748, fixes #747, fixes #749
- This PR is related to issue: follow-up to #703
