### PR TITLE
fix(ci): constrain minimum pytest-homeassistant-custom-component version

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,7 @@ homeassistant
 pydispatcher
 pyserial
 # Test dependencies for pytest
-pytest-homeassistant-custom-component
+pytest-homeassistant-custom-component>=0.13.357
 pyudev
 serialx
 zeroconf


### PR DESCRIPTION
# Summary

Constrain `pytest-homeassistant-custom-component>=0.13.357` in `requirements_test.txt` to prevent the dependency resolver from backtracking to obsolete releases.

When Home Assistant Core 2026.9.0 was released, `pytest-homeassistant-custom-component` had not yet published a compatible release. Because `pytest-homeassistant-custom-component` was completely unconstrained, `uv` backtracked all the way to `pytest-homeassistant-custom-component==0.2.1` and `pytest==6.2.2`, triggering `TypeError: required field "lineno" missing from alias` during pytest startup under Python 3.14.

## Proposed change

Add a minimum version constraint `pytest-homeassistant-custom-component>=0.13.357` to prevent the package resolver from falling back to incompatible legacy releases.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue: #760