### PR TITLE
fix: use via_device_id instead of deprecated via_device parameter

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -9,11 +9,10 @@ import functools
 import logging
 from pathlib import Path
 import sys
-from typing import Any
 
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.core_config import Config
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
@@ -115,34 +114,58 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     return True
 
 
+@callback
 def _async_get_or_create_device(
     device_registry: dr.DeviceRegistry, config_entry: ConfigEntry
 ) -> None:
     """Register or get the device entry in the device registry."""
-    device_kwargs: dict[str, Any] = {
-        "config_entry_id": config_entry.entry_id,
-        "identifiers": {(DOMAIN, config_entry.entry_id)},
-        "name": config_entry.data.get(CONF_LOCK_NAME),
-        "configuration_url": "https://github.com/FutureTense/keymaster",
-    }
     if hasattr(device_registry, "async_get_device_by_identifier"):
         # Home Assistant 2026.8+ supports via_device_id
-        via_device_id: str | None = None
         if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
             if parent_device := device_registry.async_get_device_by_identifier(
                 (DOMAIN, parent_entry_id),
                 config_entry_id=parent_entry_id,
             ):
-                via_device_id = parent_device.id
-        device_kwargs["via_device_id"] = via_device_id
+                device_registry.async_get_or_create(
+                    config_entry_id=config_entry.entry_id,
+                    identifiers={(DOMAIN, config_entry.entry_id)},
+                    name=config_entry.data.get(CONF_LOCK_NAME),
+                    configuration_url="https://github.com/FutureTense/keymaster",
+                    via_device_id=parent_device.id,
+                )
+            else:
+                # Parent device not registered yet; leave any existing link intact
+                _LOGGER.debug(
+                    "[init] Parent device for entry %s not registered yet; skipping via_device_id",
+                    parent_entry_id,
+                )
+                device_registry.async_get_or_create(
+                    config_entry_id=config_entry.entry_id,
+                    identifiers={(DOMAIN, config_entry.entry_id)},
+                    name=config_entry.data.get(CONF_LOCK_NAME),
+                    configuration_url="https://github.com/FutureTense/keymaster",
+                )
+        else:
+            # Genuinely parentless; explicitly clear any stale via link
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry.entry_id,
+                identifiers={(DOMAIN, config_entry.entry_id)},
+                name=config_entry.data.get(CONF_LOCK_NAME),
+                configuration_url="https://github.com/FutureTense/keymaster",
+                via_device_id=None,
+            )
     else:
         # Fallback for earlier Home Assistant versions
         via_device: tuple[str, str] | None = None
         if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
             via_device = (DOMAIN, parent_entry_id)
-        device_kwargs["via_device"] = via_device
-
-    device_registry.async_get_or_create(**device_kwargs)
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={(DOMAIN, config_entry.entry_id)},
+            name=config_entry.data.get(CONF_LOCK_NAME),
+            configuration_url="https://github.com/FutureTense/keymaster",
+            via_device=via_device,
+        )
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -9,6 +9,7 @@ import functools
 import logging
 from pathlib import Path
 import sys
+from typing import Any
 
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
@@ -114,6 +115,36 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     return True
 
 
+def _async_get_or_create_device(
+    device_registry: dr.DeviceRegistry, config_entry: ConfigEntry
+) -> None:
+    """Register or get the device entry in the device registry."""
+    device_kwargs: dict[str, Any] = {
+        "config_entry_id": config_entry.entry_id,
+        "identifiers": {(DOMAIN, config_entry.entry_id)},
+        "name": config_entry.data.get(CONF_LOCK_NAME),
+        "configuration_url": "https://github.com/FutureTense/keymaster",
+    }
+    if hasattr(device_registry, "async_get_device_by_identifier"):
+        # Home Assistant 2026.8+ supports via_device_id
+        via_device_id: str | None = None
+        if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
+            if parent_device := device_registry.async_get_device_by_identifier(
+                (DOMAIN, parent_entry_id),
+                config_entry_id=parent_entry_id,
+            ):
+                via_device_id = parent_device.id
+        device_kwargs["via_device_id"] = via_device_id
+    else:
+        # Fallback for earlier Home Assistant versions
+        via_device: tuple[str, str] | None = None
+        if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
+            via_device = (DOMAIN, parent_entry_id)
+        device_kwargs["via_device"] = via_device
+
+    device_registry.async_get_or_create(**device_kwargs)
+
+
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up is called when Home Assistant is loading our component."""
     updated_config = config_entry.data.copy()
@@ -179,25 +210,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         coordinator = hass.data[DOMAIN][COORDINATOR]
 
     device_registry = dr.async_get(hass)
-
-    via_device: tuple[str, str] | None = None
-    if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
-        via_device = (DOMAIN, parent_entry_id)
-
-    # _LOGGER.debug(
-    #     f"[init async_setup_entry] name: {config_entry.data.get(CONF_LOCK_NAME)}, "
-    #     f"parent_name: {config_entry.data.get(CONF_PARENT)}, "
-    #     f"parent_entry_id: {config_entry.data.get(CONF_PARENT_ENTRY_ID)}, "
-    #     f"via_device: {via_device}"
-    # )
-
-    device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
-        identifiers={(DOMAIN, config_entry.entry_id)},
-        name=config_entry.data.get(CONF_LOCK_NAME),
-        configuration_url="https://github.com/FutureTense/keymaster",
-        via_device=via_device,
-    )
+    _async_get_or_create_device(device_registry, config_entry)
 
     # _LOGGER.debug(f"[init async_setup_entry] device: {device}")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -308,6 +308,10 @@ async def test_parent_title_resolves_to_parent_entry_id_during_setup(hass):
 
     device_registry_call = mock_device_registry.async_get_or_create.call_args.kwargs
     assert device_registry_call["via_device_id"] == "parent_device_123"
+    assert "via_device" not in device_registry_call
+    mock_device_registry.async_get_device_by_identifier.assert_called_once_with(
+        (DOMAIN, parent_entry.entry_id), config_entry_id=parent_entry.entry_id
+    )
 
     lovelace_await_args = mock_generate_lovelace.await_args
     assert lovelace_await_args is not None
@@ -359,6 +363,57 @@ async def test_parent_via_device_fallback_for_older_ha_versions(hass):
     device_registry_call = mock_device_registry.async_get_or_create.call_args.kwargs
     assert device_registry_call["via_device"] == (DOMAIN, parent_entry.entry_id)
     assert "via_device_id" not in device_registry_call
+
+
+async def test_parent_device_not_registered_yet_skips_via_device_id(hass):
+    """Test via_device_id is omitted when parent entry exists but parent device is not yet registered."""
+    parent_data = _build_entry_data("front_door", "lock.front_door")
+    parent_entry = MockConfigEntry(domain=DOMAIN, title="Front Door", data=parent_data, version=4)
+    parent_entry.add_to_hass(hass)
+
+    child_data = _build_entry_data("garage_door", "lock.garage_door")
+    child_data[CONF_PARENT] = "Front Door"
+    child_data[CONF_PARENT_ENTRY_ID] = parent_entry.entry_id
+    child_entry = MockConfigEntry(domain=DOMAIN, title="Garage Door", data=child_data, version=4)
+    child_entry.add_to_hass(hass)
+
+    hass.data.setdefault(DOMAIN, {})
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch("custom_components.keymaster.KeymasterCoordinator") as mock_coordinator_class,
+        patch("custom_components.keymaster.dr.async_get") as mock_device_registry_get,
+        patch(
+            "custom_components.keymaster.async_generate_lovelace",
+            new_callable=AsyncMock,
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+        ),
+    ):
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.initial_setup = AsyncMock()
+        mock_coordinator.async_refresh = AsyncMock()
+        mock_coordinator.last_update_success = True
+        mock_coordinator.kmlocks = {}
+        mock_coordinator.add_lock = AsyncMock()
+        mock_coordinator.async_flush_pending_save_data_if_setup_complete = AsyncMock()
+
+        mock_device_registry = Mock()
+        mock_device_registry.async_get_or_create = Mock()
+        mock_device_registry.async_get_device_by_identifier = Mock(return_value=None)
+        mock_device_registry_get.return_value = mock_device_registry
+
+        assert await async_setup_entry(hass, child_entry)
+
+    device_registry_call = mock_device_registry.async_get_or_create.call_args.kwargs
+    assert "via_device_id" not in device_registry_call
+    assert "via_device" not in device_registry_call
+    mock_device_registry.async_get_device_by_identifier.assert_called_once_with(
+        (DOMAIN, parent_entry.entry_id), config_entry_id=parent_entry.entry_id
+    )
 
 
 async def test_setup_entry_calls_add_lock_with_update_true_for_existing_lock(hass):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -290,6 +290,9 @@ async def test_parent_title_resolves_to_parent_entry_id_during_setup(hass):
 
         mock_device_registry = Mock()
         mock_device_registry.async_get_or_create = Mock()
+        mock_parent_device = Mock(id="parent_device_123")
+        mock_device_registry.async_get_device_by_identifier = Mock(return_value=mock_parent_device)
+        mock_device_registry.async_get_device = Mock(return_value=mock_parent_device)
         mock_device_registry_get.return_value = mock_device_registry
 
         assert await async_setup_entry(hass, child_entry)
@@ -304,12 +307,58 @@ async def test_parent_title_resolves_to_parent_entry_id_during_setup(hass):
     assert add_lock_call["kmlock"].parent_config_entry_id == parent_entry.entry_id
 
     device_registry_call = mock_device_registry.async_get_or_create.call_args.kwargs
-    assert device_registry_call["via_device"] == (DOMAIN, parent_entry.entry_id)
+    assert device_registry_call["via_device_id"] == "parent_device_123"
 
     lovelace_await_args = mock_generate_lovelace.await_args
     assert lovelace_await_args is not None
     lovelace_call = lovelace_await_args.kwargs
     assert lovelace_call["parent_config_entry_id"] == parent_entry.entry_id
+
+
+async def test_parent_via_device_fallback_for_older_ha_versions(hass):
+    """Test legacy via_device fallback when async_get_device_by_identifier is not present."""
+    parent_data = _build_entry_data("front_door", "lock.front_door")
+    parent_entry = MockConfigEntry(domain=DOMAIN, title="Front Door", data=parent_data, version=4)
+    parent_entry.add_to_hass(hass)
+
+    child_data = _build_entry_data("garage_door", "lock.garage_door")
+    child_data[CONF_PARENT] = "Front Door"
+    child_data[CONF_PARENT_ENTRY_ID] = parent_entry.entry_id
+    child_entry = MockConfigEntry(domain=DOMAIN, title="Garage Door", data=child_data, version=4)
+    child_entry.add_to_hass(hass)
+
+    hass.data.setdefault(DOMAIN, {})
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch("custom_components.keymaster.KeymasterCoordinator") as mock_coordinator_class,
+        patch("custom_components.keymaster.dr.async_get") as mock_device_registry_get,
+        patch(
+            "custom_components.keymaster.async_generate_lovelace",
+            new_callable=AsyncMock,
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+        ),
+    ):
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.initial_setup = AsyncMock()
+        mock_coordinator.async_refresh = AsyncMock()
+        mock_coordinator.last_update_success = True
+        mock_coordinator.kmlocks = {}
+        mock_coordinator.add_lock = AsyncMock()
+        mock_coordinator.async_flush_pending_save_data_if_setup_complete = AsyncMock()
+
+        mock_device_registry = Mock(spec=["async_get_or_create"])
+        mock_device_registry_get.return_value = mock_device_registry
+
+        assert await async_setup_entry(hass, child_entry)
+
+    device_registry_call = mock_device_registry.async_get_or_create.call_args.kwargs
+    assert device_registry_call["via_device"] == (DOMAIN, parent_entry.entry_id)
+    assert "via_device_id" not in device_registry_call
 
 
 async def test_setup_entry_calls_add_lock_with_update_true_for_existing_lock(hass):
@@ -344,6 +393,9 @@ async def test_setup_entry_calls_add_lock_with_update_true_for_existing_lock(has
         mock_device_registry_get.return_value = mock_device_registry
 
         assert await async_setup_entry(hass, entry)
+
+    device_registry_call = mock_device_registry.async_get_or_create.call_args.kwargs
+    assert device_registry_call["via_device_id"] is None
 
     add_lock_await_args = mock_coordinator.add_lock.await_args
     assert add_lock_await_args is not None


### PR DESCRIPTION
# Summary

Resolves deprecation warning reported in #763 where Home Assistant 2026.9 warns that `via_device` in `device_registry.async_get_or_create` is deprecated and will be removed in Home Assistant 2027.8.0.

## Proposed change

- In `custom_components/keymaster/__init__.py`, update device creation to check for `async_get_device_by_identifier` and pass `via_device_id` containing the parent device's ID instead of the deprecated `via_device` parameter.
- Maintain fallback to `via_device` when running on earlier Home Assistant versions where `async_get_device_by_identifier` is not available.
- Update `tests/test_init.py` to verify `via_device_id` is supplied on supported versions, verify `via_device_id` is `None` when no parent entry is configured, and verify the fallback behavior on older versions.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #763