### PR TITLE
fix(coordinator): respect authoritative provider event labels

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -971,18 +971,26 @@ class KeymasterCoordinator(DataUpdateCoordinator):
 
         # Disambiguate between the event label and the entity state:
         # - If the entity state differs from our last-tracked state, the state
-        #   has genuinely changed and is authoritative. This handles providers
-        #   that derive event_label from a sensor which may be stale (e.g.
-        #   Z-Wave JS alarm_type/access_control fallback in handle_lock_state_change).
-        # - Otherwise, trust the label's semantics. Some providers (e.g. Akuvox
-        #   webhooks) fire events before the entity state updates, so falling
-        #   back to `new_state` in that case would drop the event.
+        #   has genuinely changed and is authoritative for providers that can
+        #   derive event_label from a stale sensor (e.g. Z-Wave JS
+        #   alarm_type/access_control fallback in handle_lock_state_change).
+        # - Some providers dispatch an operation event before the entity state
+        #   updates (e.g. Zigbee2MQTT, ZHA, Akuvox). For those provider-declared
+        #   authoritative labels, trust an unambiguous label before new_state.
         # - If the label is ambiguous, fall back to new_state.
         label_lower = event_label.lower() if event_label else ""
+        provider_label_is_authoritative = (
+            kmlock.provider is not None
+            and kmlock.provider.lock_event_label_is_authoritative is True
+        )
         state_changed = (
             new_state in (LockState.LOCKED, LockState.UNLOCKED) and new_state != kmlock.lock_state
         )
-        if state_changed:
+        if provider_label_is_authoritative and "unlock" in label_lower:
+            inferred_action = LockState.UNLOCKED
+        elif provider_label_is_authoritative and "lock" in label_lower and "jam" not in label_lower:
+            inferred_action = LockState.LOCKED
+        elif state_changed:
             inferred_action = new_state
         elif "unlock" in label_lower:
             inferred_action = LockState.UNLOCKED

--- a/custom_components/keymaster/providers/_base.py
+++ b/custom_components/keymaster/providers/_base.py
@@ -125,6 +125,17 @@ class BaseLockProvider(ABC):
         return False
 
     @property
+    def lock_event_label_is_authoritative(self) -> bool:
+        """Whether provider event labels should take precedence over entity state.
+
+        Providers that dispatch callbacks from an operation event payload can set
+        this to True when the entity state may still contain the pre-operation
+        value. The default preserves the existing behavior for providers whose
+        labels may be derived from stale state or sensor data.
+        """
+        return False
+
+    @property
     def supports_connection_status(self) -> bool:
         """Whether provider can report lock connection status.
 

--- a/custom_components/keymaster/providers/akuvox.py
+++ b/custom_components/keymaster/providers/akuvox.py
@@ -113,6 +113,11 @@ class AkuvoxLockProvider(BaseLockProvider):
         """Whether provider supports real-time event updates."""
         return True
 
+    @property
+    def lock_event_label_is_authoritative(self) -> bool:
+        """Akuvox webhook events describe the operation before entity state updates."""
+        return True
+
     async def async_connect(self) -> bool:
         """Connect to the Akuvox lock."""
         self._connected = False

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -49,6 +49,11 @@ class ZHALockProvider(BaseLockProvider):
         return True
 
     @property
+    def lock_event_label_is_authoritative(self) -> bool:
+        """ZHA operation reports describe the operation before entity state updates."""
+        return True
+
+    @property
     def supports_connection_status(self) -> bool:
         """ZHA can report connection status."""
         return True

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -68,6 +68,11 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         return True
 
     @property
+    def lock_event_label_is_authoritative(self) -> bool:
+        """Zigbee2MQTT action payloads can arrive with the pre-operation state."""
+        return True
+
+    @property
     def supports_connection_status(self) -> bool:
         """Zigbee2MQTT can report connection status."""
         return True

--- a/tests/providers/test_akuvox.py
+++ b/tests/providers/test_akuvox.py
@@ -197,6 +197,10 @@ class TestProperties:
         """Test supports_push_updates property."""
         assert provider.supports_push_updates is True
 
+    def test_lock_event_label_is_authoritative(self, provider):
+        """Test lock_event_label_is_authoritative property."""
+        assert provider.lock_event_label_is_authoritative is True
+
 
 # ---------------------------------------------------------------------------
 # async_connect

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -171,6 +171,7 @@ class TestBaseLockProviderDefaultImplementations:
         # Test defaults
         assert provider.supports_push_updates is False
         assert provider.supports_connection_status is False
+        assert provider.lock_event_label_is_authoritative is False
         assert provider.connected is False
         provider._connected = True
         assert provider.connected is True

--- a/tests/providers/test_schlage.py
+++ b/tests/providers/test_schlage.py
@@ -126,6 +126,10 @@ class TestProperties:
         """Test connection status is supported."""
         assert schlage_provider.supports_connection_status is True
 
+    def test_lock_event_label_is_authoritative(self, schlage_provider):
+        """Test lock_event_label_is_authoritative inherits the base default."""
+        assert schlage_provider.lock_event_label_is_authoritative is False
+
     def test_redact_slot_names_default(self, schlage_provider):
         """Test redact_slot_names property default."""
         schlage_provider.keymaster_config_entry.options = {}

--- a/tests/providers/test_zha.py
+++ b/tests/providers/test_zha.py
@@ -162,6 +162,10 @@ class TestProperties:
         """Test supports_connection_status property."""
         assert provider.supports_connection_status is True
 
+    def test_lock_event_label_is_authoritative(self, provider):
+        """Test lock_event_label_is_authoritative property."""
+        assert provider.lock_event_label_is_authoritative is True
+
 
 class TestConnect:
     """Test ZHALockProvider async_connect."""

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -147,6 +147,10 @@ class TestProperties:
         """Test supports_connection_status property."""
         assert provider.supports_connection_status is True
 
+    def test_lock_event_label_is_authoritative(self, provider):
+        """Test lock_event_label_is_authoritative property."""
+        assert provider.lock_event_label_is_authoritative is True
+
 
 class TestConnect:
     """Test Zigbee2MQTTLockProvider async_connect."""

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -178,6 +178,10 @@ class TestZWaveJSLockProviderProperties:
         """Test supports_connection_status returns True."""
         assert zwave_provider.supports_connection_status is True
 
+    def test_lock_event_label_is_authoritative(self, zwave_provider):
+        """Test lock_event_label_is_authoritative inherits the base default."""
+        assert zwave_provider.lock_event_label_is_authoritative is False
+
     def test_node_returns_none_initially(self, zwave_provider):
         """Test node property returns None before connection."""
         assert zwave_provider.node is None

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -1,10 +1,13 @@
 """Tests for KeymasterCoordinator event handling."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from custom_components.keymaster.const import (
+    ATTR_ACTION_CODE,
+    ATTR_ACTION_TEXT,
     ATTR_CODE_SLOT,
     ATTR_CODE_SLOT_NAME,
     ATTR_NOTIFICATION_SOURCE,
@@ -163,6 +166,102 @@ async def test_handle_provider_lock_event_lock_label_overrides_stale_state(
 
     mock_coordinator._lock_locked.assert_called_once()
     mock_coordinator._lock_unlocked.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_provider_lock_event_zigbee2mqtt_label_overrides_changed_state(
+    hass, coordinator_for_unlock_test
+):
+    """Test that Z2M authoritative labels beat stale pre-operation entity state."""
+    coordinator = coordinator_for_unlock_test
+    events: list[dict[str, Any]] = []
+    hass.bus.async_listen(
+        EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+        lambda event: events.append(event.data),
+    )
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.provider = MagicMock()
+    kmlock.provider.lock_event_label_is_authoritative = True
+    kmlock.lock_state = LockState.UNLOCKED
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(
+            number=1,
+            name="Rich",
+            enabled=True,
+        )
+    }
+    coordinator.kmlocks["test_entry"] = kmlock
+    coordinator._pending_provider_unlock_event.add(kmlock.keymaster_config_entry_id)
+    hass.states.async_set(kmlock.lock_entity_id, LockState.LOCKED)
+
+    await coordinator._handle_provider_lock_event(
+        kmlock=kmlock,
+        code_slot_num=1,
+        event_label="Unlocked via Keypad",
+        action_code=1,
+    )
+    await hass.async_block_till_done()
+
+    assert kmlock.lock_state == LockState.UNLOCKED
+    assert len(events) == 1
+    assert events[0][ATTR_STATE] == LockState.UNLOCKED
+    assert events[0][ATTR_ACTION_TEXT] == "Unlocked via Keypad"
+    assert events[0][ATTR_ACTION_CODE] == 1
+    assert events[0][ATTR_CODE_SLOT] == 1
+    assert events[0][ATTR_CODE_SLOT_NAME] == "Rich"
+
+
+@pytest.mark.asyncio
+async def test_handle_provider_lock_event_authoritative_lock_label_overrides_changed_state(
+    hass, coordinator_for_unlock_test
+):
+    """Test that authoritative lock labels beat stale pre-operation entity state."""
+    coordinator = coordinator_for_unlock_test
+    events: list[dict[str, Any]] = []
+    hass.bus.async_listen(
+        EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+        lambda event: events.append(event.data),
+    )
+
+    kmlock = KeymasterLock(
+        lock_name="test_lock",
+        lock_entity_id="lock.test_lock",
+        keymaster_config_entry_id="test_entry",
+    )
+    kmlock.provider = MagicMock()
+    kmlock.provider.lock_event_label_is_authoritative = True
+    kmlock.lock_state = LockState.LOCKED
+    kmlock.code_slots = {
+        1: KeymasterCodeSlot(
+            number=1,
+            name="Rich",
+            enabled=True,
+        )
+    }
+    coordinator.kmlocks["test_entry"] = kmlock
+    coordinator._pending_provider_lock_event.add(kmlock.keymaster_config_entry_id)
+    hass.states.async_set(kmlock.lock_entity_id, LockState.UNLOCKED)
+
+    await coordinator._handle_provider_lock_event(
+        kmlock=kmlock,
+        code_slot_num=1,
+        event_label="Locked via Keypad",
+        action_code=5,
+    )
+    await hass.async_block_till_done()
+
+    assert kmlock.lock_state == LockState.LOCKED
+    assert len(events) == 1
+    assert events[0][ATTR_STATE] == LockState.LOCKED
+    assert events[0][ATTR_ACTION_TEXT] == "Locked via Keypad"
+    assert events[0][ATTR_ACTION_CODE] == 5
+    assert events[0][ATTR_CODE_SLOT] == 1
+    assert events[0][ATTR_CODE_SLOT_NAME] == "Rich"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Summary

Fixes the remaining Bug 3 from #699 by making provider event/action inference explicitly provider-aware. Bugs 1, 2, 4, and 5 from #699 were already fixed by prior work, so this completes the issue.

## Proposed change

Zigbee2MQTT delivers its keypad action and the pre-operation `lock_state` in the same MQTT payload. That means the provider callback can report `Unlocked via Keypad` while Home Assistant still exposes `locked`, causing the coordinator's state-first inference to route the event to `_lock_locked`.

This PR adds a narrow `BaseLockProvider.lock_event_label_is_authoritative` hook. Direct operation-event providers (Zigbee2MQTT, ZHA, and Akuvox) opt in so unambiguous labels such as `Unlocked via Keypad` win over stale entity state. Z-Wave JS keeps the default `False`, preserving the existing protection where its fallback path may derive labels from stale alarm/access-control sensors and a genuinely changed entity state should remain authoritative.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: Closes #699
- This PR is related to issue:

Validation:

- `/home/tykeal/repos/personal/homeassistant/keymaster/.tox/py314/bin/pytest`
- `tox --workdir /home/tykeal/repos/personal/homeassistant/keymaster/.tox -e lint` with the ruff commands temporarily adjusted locally to use explicit `custom_components/ tests/` paths
- Regression proof: with only the production changes reverted, `tests/test_coordinator_events.py::test_handle_provider_lock_event_zigbee2mqtt_label_overrides_changed_state` fails because `kmlock.lock_state` becomes `locked` instead of remaining `unlocked`.
