### PR TITLE
chore: disable aislop skipped audit finding

### DIFF
--- a/.aislop/config.yml
+++ b/.aislop/config.yml
@@ -1,0 +1,21 @@
+# aislop static-analysis configuration.
+#
+# Only the keys set here override aislop's built-in defaults; everything else
+# (exclude paths, engine toggles, quality thresholds, scoring weights) still
+# comes from aislop's defaults.
+version: 1
+
+rules:
+  # keymaster is a Home Assistant custom integration - effectively a plugin.
+  # Much of its dependency surface is dictated by the Home Assistant runtime
+  # and cannot be pinned by this repository, so committing lockfiles produces
+  # constant Dependabot churn on dependencies the maintainers cannot update.
+  # `uv.lock`, `yarn.lock`, and `package-lock.json` are therefore intentionally
+  # gitignored.
+  #
+  # With no lockfile present, `npm audit` returns ENOLOCK and aislop emits an
+  # informational "dependency audit skipped" finding on every scan. That is a
+  # deliberate trade-off, not a defect, so the rule is disabled.
+  #
+  # See https://github.com/FutureTense/keymaster/issues/652
+  security/dependency-audit-skipped: off


### PR DESCRIPTION
# Summary

Add an aislop rule-level configuration override to disable only `security/dependency-audit-skipped`.

## Proposed change

keymaster deliberately does not commit `uv.lock`, `yarn.lock`, or `package-lock.json` because it is a Home Assistant custom integration, effectively a plugin. Much of the dependency surface is dictated by the Home Assistant runtime, so committing lockfiles creates Dependabot churn for dependencies maintainers cannot update.

With no lockfile present, aislop shells out to `npm audit --json`, receives ENOLOCK, and emits:

> Dependency audit skipped (npm audit): lockfile is missing

This PR disables only that informational rule and leaves the security engine available for other audits such as `pip-audit` or `govulncheck` if those tools are installed.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: Closes #652
- This PR is related to issue:
