### PR TITLE
refactor: preserve ordered isinstance dispatch

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -902,35 +902,40 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             result: MutableMapping = {}
             for field in _serializable_dataclass_fields(instance.__class__):
                 field_name: str = field.name
-
-                field_value: Any = getattr(instance, field_name)
-
-                # Convert datetime object to ISO string
-                if isinstance(field_value, dt):
-                    field_value = field_value.isoformat()
-
-                # Convert time object to ISO string
-                if isinstance(field_value, dt_time):
-                    field_value = field_value.isoformat()
-
-                if isinstance(field_value, list):
-                    result[field_name] = [
-                        (
-                            self._kmlocks_to_dict(item)
-                            if hasattr(item, "__dataclass_fields__")
-                            else item
-                        )
-                        for item in field_value
-                    ]
-                elif isinstance(field_value, dict):
-                    result[field_name] = {
-                        k: (self._kmlocks_to_dict(v) if hasattr(v, "__dataclass_fields__") else v)
-                        for k, v in field_value.items()
-                    }
-                else:
-                    result[field_name] = field_value
+                result[field_name] = self._kmlock_field_to_dict(getattr(instance, field_name))
             return result
         return instance
+
+    def _kmlock_field_to_dict(self, field_value: Any) -> object:
+        """Convert a dataclass field value to a JSON-compatible value."""
+        field_value = self._kmlock_temporal_value_to_dict(field_value)
+        return self._kmlock_collection_value_to_dict(field_value)
+
+    def _kmlock_temporal_value_to_dict(self, field_value: Any) -> Any:
+        """Convert temporal field values while preserving existing ordered checks."""
+        if isinstance(field_value, dt):
+            field_value = field_value.isoformat()
+
+        if isinstance(field_value, dt_time):
+            field_value = field_value.isoformat()
+
+        return field_value
+
+    def _kmlock_collection_value_to_dict(self, field_value: Any) -> object:
+        """Convert collection field values while preserving existing recursive behavior."""
+        if isinstance(field_value, list):
+            return [
+                self._kmlocks_to_dict(item) if hasattr(item, "__dataclass_fields__") else item
+                for item in field_value
+            ]
+
+        if isinstance(field_value, dict):
+            return {
+                k: (self._kmlocks_to_dict(v) if hasattr(v, "__dataclass_fields__") else v)
+                for k, v in field_value.items()
+            }
+
+        return field_value
 
     async def _rebuild_lock_relationships(self) -> None:
         for keymaster_config_entry_id, kmlock in self.kmlocks.items():

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -343,22 +343,7 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
             coros = [self._async_query_slot(i) for i in missing_slots]
             results = await asyncio.gather(*coros, return_exceptions=True)
             for slot_num, res in zip(missing_slots, results, strict=False):
-                if isinstance(res, CodeSlot):
-                    self._usercodes_cache[slot_num] = res
-                elif isinstance(res, HomeAssistantError):
-                    _LOGGER.warning(
-                        "[Zigbee2MQTTProvider] Error querying slot %s: %s",
-                        slot_num,
-                        res,
-                    )
-                elif isinstance(res, Exception):
-                    _LOGGER.error(
-                        "[Zigbee2MQTTProvider] Unexpected error querying slot %s: %s",
-                        slot_num,
-                        res,
-                    )
-                elif isinstance(res, BaseException):
-                    raise res
+                self._handle_usercode_query_result(slot_num, res)
 
         result: list[CodeSlot] = []
         for i in range(slot_start, slot_start + slot_count):
@@ -366,6 +351,26 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
             if slot_data:
                 result.append(slot_data)
         return result
+
+    def _handle_usercode_query_result(self, slot_num: int, res: CodeSlot | BaseException) -> None:
+        """Handle one slot query result using most-specific-first matching."""
+        match res:
+            case CodeSlot():
+                self._usercodes_cache[slot_num] = res
+            case HomeAssistantError():
+                _LOGGER.warning(
+                    "[Zigbee2MQTTProvider] Error querying slot %s: %s",
+                    slot_num,
+                    res,
+                )
+            case Exception():
+                _LOGGER.error(
+                    "[Zigbee2MQTTProvider] Unexpected error querying slot %s: %s",
+                    slot_num,
+                    res,
+                )
+            case BaseException():
+                raise res
 
     async def async_get_usercode(self, slot_num: int) -> CodeSlot | None:
         """Get a specific user code from the lock cache."""

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import Any, NamedTuple
 from unittest.mock import ANY, AsyncMock, MagicMock, PropertyMock, patch
 
@@ -994,6 +995,45 @@ class TestCoverageExtra:
             pytest.raises(CustomBaseException),
         ):
             await provider.async_get_usercodes()
+
+    async def test_get_usercodes_preserves_ordered_query_result_handling(
+        self,
+        provider,
+        mock_hass,
+        caplog,
+    ):
+        """Test query result handling preserves specific-before-generic exception order."""
+        await connect_provider(provider, mock_hass)
+        caplog.set_level(logging.DEBUG)
+
+        with patch.object(
+            provider,
+            "_async_query_slot",
+            side_effect=[
+                CodeSlot(1, "1111", True),
+                HomeAssistantError("expected"),
+                RuntimeError("unexpected"),
+                CodeSlot(4, "4444", True),
+                CodeSlot(5, "5555", True),
+                CodeSlot(6, "6666", True),
+            ],
+        ):
+            result = await provider.async_get_usercodes()
+
+        assert provider._usercodes_cache[1] == CodeSlot(1, "1111", True)
+        assert CodeSlot(1, "1111", True) in result
+        assert CodeSlot(4, "4444", True) in result
+        warning_messages = [
+            record.getMessage() for record in caplog.records if record.levelno == logging.WARNING
+        ]
+        error_messages = [
+            record.getMessage() for record in caplog.records if record.levelno == logging.ERROR
+        ]
+        assert "[Zigbee2MQTTProvider] Error querying slot 2: expected" in warning_messages
+        assert not any("slot 2" in message for message in error_messages)
+        assert (
+            "[Zigbee2MQTTProvider] Unexpected error querying slot 3: unexpected" in error_messages
+        )
 
     async def test_base_topic_prefers_device_name_over_ieee_identifier(self, provider, mock_hass):
         """Test that base_topic prefers device_entry.name over identifier suffix."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2955,6 +2955,41 @@ class TestKmlocksToDict:
         assert result["slots"][1]["name"] == "slot1"
         assert result["slots"][2]["name"] == "slot2"
 
+    def test_kmlocks_to_dict_preserves_ordered_field_serialization(self, coordinator_for_dict):
+        """Test field serialization preserves temporal, collection, and scalar semantics."""
+
+        @dataclass
+        class Inner:
+            value: int
+
+        @dataclass
+        class Outer:
+            timestamp: dt
+            start_time: dt_time
+            items: list
+            slots: dict
+            name: str
+
+        timestamp = dt(2025, 1, 15, 12, 30, 0)
+        start_time = dt_time(8, 30, 0)
+        instance = Outer(
+            timestamp=timestamp,
+            start_time=start_time,
+            items=[Inner(value=1), "plain-list-item"],
+            slots={"nested": Inner(value=2), "plain": "plain-dict-value"},
+            name="plain-scalar",
+        )
+
+        result = coordinator_for_dict._kmlocks_to_dict(instance)
+
+        assert isinstance(result, dict)
+        assert result["timestamp"] == timestamp.isoformat()
+        assert isinstance(result["timestamp"], str)
+        assert result["start_time"] == start_time.isoformat()
+        assert result["items"] == [{"value": 1}, "plain-list-item"]
+        assert result["slots"] == {"nested": {"value": 2}, "plain": "plain-dict-value"}
+        assert result["name"] == "plain-scalar"
+
 
 class TestStorageAndMigration:
     """Test cases for Home Assistant Store persistence and legacy JSON migration."""


### PR DESCRIPTION
# Summary
Refactors the two ordered type-dispatch sites reported by `ai-slop/python-isinstance-ladder` without changing observable behavior.

Closes #656.

## Proposed change
Coordinator `_kmlocks_to_dict` before:
- Dataclass fields were serialized inline.
- `datetime` was converted first, then the resulting value continued into the separate `time` / `list` / `dict` / scalar chain.

Coordinator `_kmlocks_to_dict` after:
- Field conversion is delegated to `_kmlock_field_to_dict()`.
- Temporal conversion is isolated in `_kmlock_temporal_value_to_dict()` and still uses the same two sequential checks, so a `datetime` is converted to an ISO string before collection/scalar handling sees it.
- List, dict, and scalar serialization are isolated in `_kmlock_collection_value_to_dict()` with the same recursive behavior as before.

Zigbee2MQTT `async_get_usercodes` before:
- Gathered slot query results were handled inline with `CodeSlot`, `HomeAssistantError`, `Exception`, then `BaseException` checks.

Zigbee2MQTT `async_get_usercodes` after:
- Per-result handling is delegated to `_handle_usercode_query_result()`.
- `match` class patterns keep the same most-specific-first order: `HomeAssistantError` is matched before generic `Exception`, and `BaseException` remains last and is re-raised.

Ordering subtleties preserved:
- Coordinator: the original sequential-`if` reassignment is preserved by running temporal conversion first, then collection/scalar conversion. A `datetime` still becomes an ISO string and is not treated as `time`, `list`, or `dict`.
- Zigbee2MQTT: exception subclass dispatch remains ordered by specificity, so `HomeAssistantError` takes the warning path, generic `Exception` takes the error path, and `BaseException` propagates.

Validation:
- `tox -e py314`: 1186 passed, 3 skipped, 1 deselected; coverage 95.02%.
- `tox -e lint`: passed.
- Pristine `aislop` scan: total findings 34 → 32; `ai-slop/python-isinstance-ladder` 2 → 0; `ai-slop/python-chained-dict-get` remains 2.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #656
- This PR is related to issue: #656
