### PR TITLE
fix: expand coordinator lookups

### DIFF
--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -267,7 +267,9 @@ def _has_value(value: Any) -> bool:
 
 def _get_kmlock_for_entry(hass: HomeAssistant, entry_id: str) -> KeymasterLock | None:
     """Return the loaded lock for a config entry if the coordinator exists."""
-    coordinator = hass.data.get(DOMAIN, {}).get(COORDINATOR)
+    coordinator = None
+    if DOMAIN in hass.data:
+        coordinator = hass.data[DOMAIN].get(COORDINATOR)
     if coordinator is None:
         return None
     return coordinator.sync_get_lock_by_config_entry_id(entry_id)

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -484,7 +484,9 @@ class ZHALockProvider(BaseLockProvider):
 
             command = event.data.get("command")
             if command == "programming_event_notification":
-                coordinator = self.hass.data.get(DOMAIN, {}).get(COORDINATOR)
+                coordinator = None
+                if DOMAIN in self.hass.data:
+                    coordinator = self.hass.data[DOMAIN].get(COORDINATOR)
                 if coordinator:
                     self.hass.async_create_task(
                         coordinator.async_refresh(),

--- a/tests/providers/test_zha.py
+++ b/tests/providers/test_zha.py
@@ -861,6 +861,80 @@ class TestLockEvents:
         unsub()
         assert provider._event_unsub is None
 
+    @pytest.mark.parametrize("hass_data", [{}, {DOMAIN: {}}])
+    async def test_programming_event_without_coordinator_skips_refresh_task(
+        self, provider, mock_hass, mock_zha_gateway, hass_data
+    ):
+        """Test programming events do not schedule refreshes when coordinator data is absent."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        captured_callback = None
+
+        def mock_listen(event_type, callback_fn):
+            nonlocal captured_callback
+            captured_callback = callback_fn
+            return lambda: None
+
+        mock_hass.bus.async_listen = MagicMock(side_effect=mock_listen)
+        unsub = provider.subscribe_lock_events(MagicMock(), AsyncMock())
+        assert captured_callback is not None
+
+        mock_hass.data = hass_data
+        mock_hass.async_create_task.reset_mock()
+
+        captured_callback(
+            Event(
+                "zha_event",
+                {
+                    "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                    "command": "programming_event_notification",
+                },
+            )
+        )
+        await asyncio.sleep(0.01)
+
+        mock_hass.async_create_task.assert_not_called()
+        unsub()
+
+    async def test_programming_event_with_coordinator_schedules_refresh_task(
+        self, provider, mock_hass, mock_zha_gateway
+    ):
+        """Test programming events schedule a refresh when coordinator data is present."""
+        setup_successful_connect(provider)
+        await provider.async_connect()
+
+        captured_callback = None
+
+        def mock_listen(event_type, callback_fn):
+            nonlocal captured_callback
+            captured_callback = callback_fn
+            return lambda: None
+
+        mock_hass.bus.async_listen = MagicMock(side_effect=mock_listen)
+        unsub = provider.subscribe_lock_events(MagicMock(), AsyncMock())
+        assert captured_callback is not None
+
+        coordinator = MagicMock()
+        coordinator.async_refresh = AsyncMock()
+        mock_hass.data = {DOMAIN: {COORDINATOR: coordinator}}
+        mock_hass.async_create_task.reset_mock()
+
+        captured_callback(
+            Event(
+                "zha_event",
+                {
+                    "device_ieee": "00:0d:6f:00:0b:90:57:f6",
+                    "command": "programming_event_notification",
+                },
+            )
+        )
+        await asyncio.sleep(0.01)
+
+        mock_hass.async_create_task.assert_called_once()
+        coordinator.async_refresh.assert_called_once()
+        unsub()
+
     def test_get_platform_data(self, provider):
         """Test get_platform_data returns ZHA specific data."""
         provider._device_ieee = "00:0d:6f:00:0b:90:57:f6"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,9 +2,10 @@
 
 from unittest.mock import MagicMock, patch
 
-from custom_components.keymaster.const import DOMAIN
+from custom_components.keymaster.const import COORDINATOR, DOMAIN
 from custom_components.keymaster.helpers import (
     Throttle,
+    _get_kmlock_for_entry,
     async_has_supported_provider,
     call_hass_service,
     delete_code_slot_entities,
@@ -244,6 +245,31 @@ def test_async_has_supported_provider_no_args(hass):
     """Test async_has_supported_provider returns False with no arguments."""
     result = async_has_supported_provider(hass)
     assert result is False
+
+
+def test_get_kmlock_for_entry_without_domain_data(hass):
+    """Test loaded lock lookup returns None when domain data is absent."""
+    hass.data.pop(DOMAIN, None)
+
+    assert _get_kmlock_for_entry(hass, "entry-id") is None
+
+
+def test_get_kmlock_for_entry_without_coordinator(hass):
+    """Test loaded lock lookup returns None when coordinator data is absent."""
+    hass.data[DOMAIN] = {}
+
+    assert _get_kmlock_for_entry(hass, "entry-id") is None
+
+
+def test_get_kmlock_for_entry_with_coordinator(hass):
+    """Test loaded lock lookup delegates to the coordinator when present."""
+    kmlock = MagicMock()
+    coordinator = MagicMock()
+    coordinator.sync_get_lock_by_config_entry_id.return_value = kmlock
+    hass.data[DOMAIN] = {COORDINATOR: coordinator}
+
+    assert _get_kmlock_for_entry(hass, "entry-id") is kmlock
+    coordinator.sync_get_lock_by_config_entry_id.assert_called_once_with("entry-id")
 
 
 def test_throttle_reset_existing_func_missing_key():


### PR DESCRIPTION
# Summary
Fixes #650 / Closes #650 by replacing the two remaining chained coordinator lookups with explicit, local Home Assistant data checks.

The changed sites preserve the existing missing-data behavior for both absent `DOMAIN` data and present domain data without a `COORDINATOR` entry.

## Proposed change
Both call sites now make their shape assumptions visible without introducing shared helper coupling:

`custom_components/keymaster/providers/zha.py` before:

```python
coordinator = self.hass.data.get(DOMAIN, {}).get(COORDINATOR)
if coordinator:
```

`custom_components/keymaster/providers/zha.py` after:

```python
coordinator = None
if DOMAIN in self.hass.data:
    coordinator = self.hass.data[DOMAIN].get(COORDINATOR)
if coordinator:
```

`custom_components/keymaster/helpers.py` before:

```python
coordinator = hass.data.get(DOMAIN, {}).get(COORDINATOR)
if coordinator is None:
```

`custom_components/keymaster/helpers.py` after:

```python
coordinator = None
if DOMAIN in hass.data:
    coordinator = hass.data[DOMAIN].get(COORDINATOR)
if coordinator is None:
```

A shared helper was intentionally not added to `helpers.py` because importing it from `providers/zha.py` would create a circular import through `helpers.py` -> `providers` -> `providers/zha.py`. The lookups are kept local and independent.

Focused tests cover:

- missing `hass.data[DOMAIN]`
- present domain data without `COORDINATOR`
- normal coordinator-present behavior

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #650
- This PR is related to issue:

Validation completed locally:

- `tox -e py314` — 1193 passed, 95.02% coverage
- `tox -e lint` — passed
- aislop before/after: `ai-slop/python-chained-dict-get` reduced from 2 to 0; total findings reduced from 34 to 32; `ai-slop/python-isinstance-ladder` remains 2
