### PR TITLE
refactor: reduce kmlock deserialization nesting

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -789,112 +789,181 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             field_values: MutableMapping = {}
 
             for field in _serializable_dataclass_fields(cls):
-                field_name: str = field.name
-
-                field_type: type | None = keymasterlock_type_lookup.get(field_name)
-                if not field_type and isinstance(field.type, type):
-                    field_type = field.type
-
-                field_value: Any = data.get(field_name)
-
-                origin_type = get_origin(field_type)
-                type_args = get_args(field_type)
-
-                # _LOGGER.debug(
-                #     f"[dict_to_kmlocks] field_name: {field_name}, field_type: {field_type}, "
-                #     f"origin_type: {origin_type}, type_args: {type_args}, "
-                #     f"field_value_type: {type(field_value)}, field_value: {field_value}"
-                # )
-
-                # Handle optional types (Union)
-                if origin_type is Union:
-                    non_optional_types = [t for t in type_args if t is not type(None)]
-                    if len(non_optional_types) == 1:
-                        field_type = non_optional_types[0]
-                        origin_type = get_origin(field_type)
-                        type_args = get_args(field_type)
-                        # _LOGGER.debug(
-                        #     f"[dict_to_kmlocks] Updated for Union: "
-                        #     f"field_name: {field_name}, field_type: {field_type}, "
-                        #     f"origin_type: {origin_type}, type_args: {type_args}"
-                        # )
-
-                # Convert datetime string to datetime object
-                if isinstance(field_value, str) and field_type == dt:
-                    # _LOGGER.debug(f"[dict_to_kmlocks] field_name: {field_name}: Converting to datetime")
-                    with contextlib.suppress(ValueError):
-                        field_value = dt.fromisoformat(field_value)
-
-                # Convert time string to time object
-                elif isinstance(field_value, str) and field_type == dt_time:
-                    # _LOGGER.debug(f"[dict_to_kmlocks] field_name: {field_name}: Converting to time")
-                    with contextlib.suppress(ValueError):
-                        field_value = dt_time.fromisoformat(field_value)
-
-                # _LOGGER.debug(f"[dict_to_kmlocks] isinstance(origin_type, type): {isinstance(origin_type, type)}")
-                # if isinstance(origin_type, type):
-                # _LOGGER.debug(f"[dict_to_kmlocks] issubclass(origin_type, MutableMapping): {issubclass(origin_type, MutableMapping)}, origin_type == dict: {origin_type == dict}")
-
-                # Handle MutableMapping types: when origin_type is MutableMapping
-                if isinstance(origin_type, type) and (
-                    issubclass(origin_type, MutableMapping) or origin_type is dict
-                ):
-                    if len(type_args) == 2:
-                        key_type, value_type = type_args
-                        # _LOGGER.debug(
-                        #     f"[dict_to_kmlocks] field_name: {field_name}: Is MutableMapping or dict. key_type: {key_type}, "
-                        #     f"value_type: {value_type}, isinstance(field_value, dict): {isinstance(field_value, dict)}, "
-                        #     f"is_dataclass(value_type): {is_dataclass(value_type)}"
-                        # )
-                        if isinstance(field_value, dict):
-                            # If the value_type is a dataclass, recursively process it
-                            if is_dataclass(value_type) and isinstance(value_type, type):
-                                # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting dict items for {field_name}")
-                                field_value = {
-                                    (
-                                        int(k)
-                                        if key_type is int and isinstance(k, str) and k.isdigit()
-                                        else k
-                                    ): self._dict_to_kmlocks(v, value_type)
-                                    for k, v in field_value.items()
-                                }
-                            else:
-                                # If value_type is not a dataclass, just copy the value
-                                field_value = {
-                                    (
-                                        int(k)
-                                        if key_type is int and isinstance(k, str) and k.isdigit()
-                                        else k
-                                    ): v
-                                    for k, v in field_value.items()
-                                }
-
-                elif (
-                    isinstance(field_value, dict)
-                    and is_dataclass(field_type)
-                    and isinstance(field_type, type)
-                ):
-                    # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting nested dataclass: {field_name}")
-                    field_value = self._dict_to_kmlocks(field_value, field_type)
-
-                elif isinstance(field_value, list) and type_args:
-                    list_type = type_args[0]
-                    if is_dataclass(list_type) and isinstance(list_type, type):
-                        # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting list of dataclasses: {field_name}")
-                        field_value = [
-                            (
-                                self._dict_to_kmlocks(item, list_type)
-                                if isinstance(item, dict)
-                                else item
-                            )
-                            for item in field_value
-                        ]
-
-                field_values[field_name] = field_value
+                field_values[field.name] = self._kmlock_field_from_dict(data, field)
 
             return cls(**field_values)
 
         return data
+
+    def _kmlock_field_type_from_dict(self, field_name: str, field_type: Any) -> Any:
+        """Resolve the stored type metadata for a Keymaster lock field."""
+        resolved_type = keymasterlock_type_lookup.get(field_name)
+        if not resolved_type and isinstance(field_type, type):
+            resolved_type = field_type
+        return resolved_type
+
+    def _kmlock_field_from_dict(self, data: dict, field: Any) -> Any:
+        """Convert one serialized dataclass field to its runtime value."""
+        field_name: str = field.name
+        field_type = self._kmlock_field_type_from_dict(field_name, field.type)
+        field_value: Any = data.get(field_name)
+
+        origin_type = get_origin(field_type)
+        type_args = get_args(field_type)
+
+        # _LOGGER.debug(
+        #     f"[dict_to_kmlocks] field_name: {field_name}, field_type: {field_type}, "
+        #     f"origin_type: {origin_type}, type_args: {type_args}, "
+        #     f"field_value_type: {type(field_value)}, field_value: {field_value}"
+        # )
+
+        field_type, origin_type, type_args = self._kmlock_optional_type_from_dict(
+            field_name,
+            field_type,
+            origin_type,
+            type_args,
+        )
+        field_value = self._kmlock_temporal_value_from_dict(field_name, field_value, field_type)
+        return self._kmlock_collection_value_from_dict(
+            field_name,
+            field_value,
+            field_type,
+            origin_type,
+            type_args,
+        )
+
+    def _kmlock_optional_type_from_dict(
+        self,
+        field_name: str,
+        field_type: Any,
+        origin_type: Any,
+        type_args: tuple[Any, ...],
+    ) -> tuple[Any, Any, tuple[Any, ...]]:
+        """Unwrap Optional fields while preserving existing Union handling."""
+        # Handle optional types (Union)
+        if origin_type is not Union:
+            return field_type, origin_type, type_args
+
+        non_optional_types = [t for t in type_args if t is not type(None)]
+        if len(non_optional_types) != 1:
+            return field_type, origin_type, type_args
+
+        field_type = non_optional_types[0]
+        origin_type = get_origin(field_type)
+        type_args = get_args(field_type)
+        # _LOGGER.debug(
+        #     f"[dict_to_kmlocks] Updated for Union: "
+        #     f"field_name: {field_name}, field_type: {field_type}, "
+        #     f"origin_type: {origin_type}, type_args: {type_args}"
+        # )
+        return field_type, origin_type, type_args
+
+    def _kmlock_temporal_value_from_dict(
+        self,
+        field_name: str,
+        field_value: Any,
+        field_type: Any,
+    ) -> Any:
+        """Convert serialized temporal strings while preserving fallback behavior."""
+        # Convert datetime string to datetime object
+        if isinstance(field_value, str) and field_type == dt:
+            # _LOGGER.debug(f"[dict_to_kmlocks] field_name: {field_name}: Converting to datetime")
+            with contextlib.suppress(ValueError):
+                field_value = dt.fromisoformat(field_value)
+
+        # Convert time string to time object
+        elif isinstance(field_value, str) and field_type == dt_time:
+            # _LOGGER.debug(f"[dict_to_kmlocks] field_name: {field_name}: Converting to time")
+            with contextlib.suppress(ValueError):
+                field_value = dt_time.fromisoformat(field_value)
+
+        return field_value
+
+    @staticmethod
+    def _kmlock_key_from_dict(key: Any, key_type: Any) -> Any:
+        """Convert serialized dictionary keys to their runtime type when required."""
+        if key_type is int and isinstance(key, str) and key.isdigit():
+            return int(key)
+        return key
+
+    def _kmlock_collection_value_from_dict(
+        self,
+        field_name: str,
+        field_value: Any,
+        field_type: Any,
+        origin_type: Any,
+        type_args: tuple[Any, ...],
+    ) -> Any:
+        """Convert serialized collection and nested dataclass values."""
+        # _LOGGER.debug(f"[dict_to_kmlocks] isinstance(origin_type, type): {isinstance(origin_type, type)}")
+        # if isinstance(origin_type, type):
+        # _LOGGER.debug(f"[dict_to_kmlocks] issubclass(origin_type, MutableMapping): {issubclass(origin_type, MutableMapping)}, origin_type == dict: {origin_type == dict}")
+
+        # Handle MutableMapping types: when origin_type is MutableMapping
+        if isinstance(origin_type, type) and (
+            issubclass(origin_type, MutableMapping) or origin_type is dict
+        ):
+            return self._kmlock_mapping_value_from_dict(field_name, field_value, type_args)
+
+        if (
+            isinstance(field_value, dict)
+            and is_dataclass(field_type)
+            and isinstance(field_type, type)
+        ):
+            # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting nested dataclass: {field_name}")
+            return self._dict_to_kmlocks(field_value, field_type)
+
+        if isinstance(field_value, list) and type_args:
+            return self._kmlock_list_value_from_dict(field_name, field_value, type_args)
+
+        return field_value
+
+    def _kmlock_mapping_value_from_dict(
+        self,
+        field_name: str,
+        field_value: Any,
+        type_args: tuple[Any, ...],
+    ) -> Any:
+        """Convert serialized mapping values without falling through to other branches."""
+        if len(type_args) != 2:
+            return field_value
+
+        key_type, value_type = type_args
+        # _LOGGER.debug(
+        #     f"[dict_to_kmlocks] field_name: {field_name}: Is MutableMapping or dict. key_type: {key_type}, "
+        #     f"value_type: {value_type}, isinstance(field_value, dict): {isinstance(field_value, dict)}, "
+        #     f"is_dataclass(value_type): {is_dataclass(value_type)}"
+        # )
+        if not isinstance(field_value, dict):
+            return field_value
+
+        # If the value_type is a dataclass, recursively process it
+        if is_dataclass(value_type) and isinstance(value_type, type):
+            # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting dict items for {field_name}")
+            return {
+                self._kmlock_key_from_dict(k, key_type): self._dict_to_kmlocks(v, value_type)
+                for k, v in field_value.items()
+            }
+
+        # If value_type is not a dataclass, just copy the value
+        return {self._kmlock_key_from_dict(k, key_type): v for k, v in field_value.items()}
+
+    def _kmlock_list_value_from_dict(
+        self,
+        field_name: str,
+        field_value: list,
+        type_args: tuple[Any, ...],
+    ) -> Any:
+        """Convert serialized lists containing nested dataclass dictionaries."""
+        list_type = type_args[0]
+        if not (is_dataclass(list_type) and isinstance(list_type, type)):
+            return field_value
+
+        # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting list of dataclasses: {field_name}")
+        return [
+            self._dict_to_kmlocks(item, list_type) if isinstance(item, dict) else item
+            for item in field_value
+        ]
 
     def _kmlocks_to_dict(self, instance: object) -> object:
         """Recursively convert a dataclass instance to a dictionary for JSON export."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,11 +1,12 @@
 """Tests for the Coordinator."""
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass, field
 from datetime import datetime as dt, time as dt_time, timedelta
 import json
 import random
+import typing
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -2853,6 +2854,275 @@ class TestDictToKmlocksConversion:
         new_lock.inherit_state_from(old_lock)
 
         assert new_lock.child_config_entry_ids == []
+
+    def test_dict_to_kmlocks_converts_datetime_and_time_strings(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Temporal ISO strings convert to datetime and time instances."""
+        data = {
+            "number": 1,
+            "accesslimit_date_range_start": "2025-01-15T12:30:00",
+            "time_start": "08:30:00",
+        }
+
+        slot = coordinator_for_conversion._dict_to_kmlocks(data, KeymasterCodeSlot)
+        day = coordinator_for_conversion._dict_to_kmlocks(data, KeymasterCodeSlotDayOfWeek)
+
+        assert slot.accesslimit_date_range_start == dt(2025, 1, 15, 12, 30, 0)
+        assert day.time_start == dt_time(8, 30, 0)
+
+    def test_dict_to_kmlocks_preserves_malformed_datetime_string(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Malformed temporal strings remain unchanged instead of raising."""
+        data = {"number": 1, "accesslimit_date_range_start": "not-a-datetime"}
+
+        result = coordinator_for_conversion._dict_to_kmlocks(data, KeymasterCodeSlot)
+
+        assert result.accesslimit_date_range_start == "not-a-datetime"
+
+    def test_dict_to_kmlocks_converts_mapping_dataclass_values_and_int_keys(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Mapping dataclass values recurse and digit-string int keys are coerced."""
+        data = {
+            "number": 1,
+            "accesslimit_day_of_week": {
+                "0": {
+                    "day_of_week_num": 0,
+                    "day_of_week_name": "monday",
+                    "dow_enabled": False,
+                },
+                "not-digit": {
+                    "day_of_week_num": 1,
+                    "day_of_week_name": "tuesday",
+                },
+            },
+        }
+
+        result = coordinator_for_conversion._dict_to_kmlocks(data, KeymasterCodeSlot)
+
+        assert isinstance(result.accesslimit_day_of_week[0], KeymasterCodeSlotDayOfWeek)
+        assert result.accesslimit_day_of_week[0].dow_enabled is False
+        assert isinstance(
+            result.accesslimit_day_of_week["not-digit"],
+            KeymasterCodeSlotDayOfWeek,
+        )
+
+    def test_dict_to_kmlocks_copies_plain_mapping_values_without_key_coercion(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Plain mapping values are copied and string keys remain strings."""
+
+        @dataclass
+        class PlainMapping:
+            values: dict[str, int]
+
+        data = {"values": {"1": 1, "two": 2}}
+
+        with patch.dict(
+            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            {"values": MutableMapping[str, int]},
+        ):
+            result = coordinator_for_conversion._dict_to_kmlocks(data, PlainMapping)
+
+        assert result.values == {"1": 1, "two": 2}
+
+    def test_dict_to_kmlocks_mapping_non_dict_value_does_not_fall_through(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Mapping-typed non-dict values are not processed as dataclasses or lists."""
+
+        @dataclass
+        class Inner:
+            value: int
+
+        @dataclass
+        class MappingWithListValue:
+            ambiguous: Any
+
+        data = {"ambiguous": [{"value": 1}, "plain"]}
+
+        with patch.dict(
+            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            {"ambiguous": MutableMapping[Inner, str]},
+        ):
+            result = coordinator_for_conversion._dict_to_kmlocks(data, MappingWithListValue)
+
+        assert result.ambiguous == [{"value": 1}, "plain"]
+
+    def test_dict_to_kmlocks_mapping_without_type_args_preserves_value(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Mapping-typed fields without key/value args pass through unchanged."""
+
+        @dataclass
+        class BareMapping:
+            ambiguous: Any
+
+        data = {"ambiguous": {"1": "one"}}
+
+        with patch.dict(
+            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            {"ambiguous": typing.MutableMapping},
+        ):
+            result = coordinator_for_conversion._dict_to_kmlocks(data, BareMapping)
+
+        assert result.ambiguous == {"1": "one"}
+
+    def test_dict_to_kmlocks_converts_nested_dataclass_field(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Nested dataclass fields recurse when serialized as dictionaries."""
+
+        @dataclass
+        class Inner:
+            value: int
+
+        @dataclass
+        class Outer:
+            inner: Any
+
+        data = {"inner": {"value": 1}}
+
+        with patch.dict(
+            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            {"inner": Inner},
+        ):
+            result = coordinator_for_conversion._dict_to_kmlocks(data, Outer)
+
+        assert result.inner == Inner(value=1)
+
+    def test_dict_to_kmlocks_preserves_list_when_item_type_is_not_dataclass(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Lists are unchanged when their item type is not a dataclass."""
+
+        @dataclass
+        class ListContainer:
+            items: list
+
+        data = {"items": [{"value": 1}, "plain"]}
+
+        with patch.dict(
+            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            {"items": list[int]},
+        ):
+            result = coordinator_for_conversion._dict_to_kmlocks(data, ListContainer)
+
+        assert result.items == [{"value": 1}, "plain"]
+
+    def test_dict_to_kmlocks_optional_union_unwraps_single_non_none_type(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Optional-style Unions unwrap only when one non-None type remains."""
+
+        @dataclass
+        class OptionalDate:
+            maybe_timestamp: Any
+
+        data = {"maybe_timestamp": "2025-01-15T12:30:00"}
+
+        with patch.dict(
+            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            {"maybe_timestamp": typing.Union[dt, None]},  # noqa: UP007
+        ):
+            result = coordinator_for_conversion._dict_to_kmlocks(data, OptionalDate)
+
+        assert result.maybe_timestamp == dt(2025, 1, 15, 12, 30, 0)
+
+    def test_dict_to_kmlocks_union_with_multiple_non_none_types_stays_wrapped(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Multi-type Unions are not unwrapped or converted."""
+
+        @dataclass
+        class MultiTypeUnion:
+            maybe_timestamp: Any
+
+        timestamp = "2025-01-15T12:30:00"
+        data = {"maybe_timestamp": timestamp}
+
+        with patch.dict(
+            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            {"maybe_timestamp": typing.Union[dt, str, None]},  # noqa: UP007
+        ):
+            result = coordinator_for_conversion._dict_to_kmlocks(data, MultiTypeUnion)
+
+        assert result.maybe_timestamp == timestamp
+
+    def test_dict_to_kmlocks_converts_list_dataclasses_and_preserves_plain_items(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Lists recurse only for dict items when their item type is a dataclass."""
+
+        @dataclass
+        class Inner:
+            value: int
+
+        @dataclass
+        class ListContainer:
+            items: list
+
+        data = {"items": [{"value": 1}, "plain"]}
+
+        with patch.dict(
+            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            {"items": list[Inner]},
+        ):
+            result = coordinator_for_conversion._dict_to_kmlocks(data, ListContainer)
+
+        assert result.items == [Inner(value=1), "plain"]
+
+    def test_dict_to_kmlocks_round_trips_kmlocks_to_dict_output(
+        self,
+        coordinator_for_conversion,
+    ):
+        """Serialized lock output deserializes back to the expected dataclasses."""
+        lock = KeymasterLock(
+            lock_name="Test",
+            lock_entity_id="lock.test",
+            keymaster_config_entry_id="entry_1",
+            code_slots={
+                1: KeymasterCodeSlot(
+                    number=1,
+                    accesslimit_date_range_start=dt(2025, 1, 15, 12, 30, 0),
+                    accesslimit_day_of_week={
+                        0: KeymasterCodeSlotDayOfWeek(
+                            day_of_week_num=0,
+                            day_of_week_name="monday",
+                            time_start=dt_time(8, 30, 0),
+                        ),
+                    },
+                ),
+            },
+        )
+
+        stored = coordinator_for_conversion._kmlocks_to_dict(lock)
+        result = coordinator_for_conversion._dict_to_kmlocks(stored, KeymasterLock)
+
+        assert isinstance(result, KeymasterLock)
+        assert result.code_slots is not None
+        result_slot = result.code_slots[1]
+        assert isinstance(result_slot, KeymasterCodeSlot)
+        assert result_slot.accesslimit_date_range_start == dt(2025, 1, 15, 12, 30, 0)
+        assert result_slot.accesslimit_day_of_week is not None
+        assert isinstance(
+            result_slot.accesslimit_day_of_week[0],
+            KeymasterCodeSlotDayOfWeek,
+        )
+        assert result_slot.accesslimit_day_of_week[0].time_start == dt_time(8, 30, 0)
 
 
 class TestKmlocksToDict:


### PR DESCRIPTION
# Summary
Refactors `_dict_to_kmlocks` to address the coordinator deep-nesting
finding reported in Refs #651 while preserving persisted lock storage
behavior.

## Proposed change
The method now delegates per-field deserialization to focused helpers for
field type resolution, Optional-style Union unwrapping, temporal parsing,
collection dispatch, mapping key coercion, and list conversion. The
commented-out debug statements were kept with the conversion steps they
document.

The mapping branch fall-through behavior is preserved explicitly: once a
field is recognized as mapping-typed, `_kmlock_mapping_value_from_dict`
returns the value for unsupported mapping shapes such as `len(type_args)
!= 2` or non-dict runtime values. Those values therefore do not continue
into the nested dataclass or list conversion branches.

Tests cover temporal parsing and malformed temporal fallback, mapping key
coercion, plain mapping copies, mapping fall-through guards, Union
unwrapping rules, list conversion, non-dataclass fallback, and a
serialize/deserialize lock round trip.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue:
- This PR is related to issue: Refs #651
