### PR TITLE
refactor: split Zigbee2MQTT connect handling

### DIFF
--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -138,8 +138,6 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         @callback
         def handle_state_message(msg: mqtt.ReceiveMessage) -> None:
             """Handle incoming state updates."""
-            if self._initial_state_received:
-                self._initial_state_received.set()
             try:
                 payload = json.loads(msg.payload)
             except ValueError:
@@ -148,6 +146,8 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
                 return
 
             self._handle_state_payload(payload)
+            if self._initial_state_received:
+                self._initial_state_received.set()
 
         # Listen to state topic for code changes
         state_topic = self.state_topic

--- a/custom_components/keymaster/providers/zigbee2mqtt.py
+++ b/custom_components/keymaster/providers/zigbee2mqtt.py
@@ -131,6 +131,44 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
         self._connected = False
         self._initial_state_received = asyncio.Event()
 
+        if not self._validate_zigbee2mqtt_device():
+            return False
+
+        # Subscribe to lock's state topic to cache user code updates
+        @callback
+        def handle_state_message(msg: mqtt.ReceiveMessage) -> None:
+            """Handle incoming state updates."""
+            if self._initial_state_received:
+                self._initial_state_received.set()
+            try:
+                payload = json.loads(msg.payload)
+            except ValueError:
+                return
+            if not isinstance(payload, dict):
+                return
+
+            self._handle_state_payload(payload)
+
+        # Listen to state topic for code changes
+        state_topic = self.state_topic
+        if not state_topic:
+            _LOGGER.error("[Zigbee2MQTTProvider] Base topic could not be derived from device name")
+            return False
+
+        self._listeners.append(
+            await mqtt.async_subscribe(self.hass, state_topic, handle_state_message)
+        )
+
+        self._connected = True
+        _LOGGER.debug(
+            "[Zigbee2MQTTProvider] Connected to lock %s (base_topic: %s)",
+            self.lock_entity_id,
+            self.base_topic,
+        )
+        return True
+
+    def _validate_zigbee2mqtt_device(self) -> bool:
+        """Validate that the configured lock entity is a Zigbee2MQTT MQTT device."""
         lock_entry = self.entity_registry.async_get(self.lock_entity_id)
         if not lock_entry:
             _LOGGER.error(
@@ -171,102 +209,84 @@ class Zigbee2MQTTLockProvider(BaseLockProvider):
             )
             return False
 
-        # Subscribe to lock's state topic to cache user code updates
-        @callback
-        def handle_state_message(msg: mqtt.ReceiveMessage) -> None:
-            """Handle incoming state updates."""
-            if self._initial_state_received:
-                self._initial_state_received.set()
-            try:
-                payload = json.loads(msg.payload)
-            except ValueError:
-                return
-
-            action = payload.get("action")
-            action_slot_num = payload.get("action_user")
-            if action or action_slot_num:
-                self.hass.async_create_task(
-                    self._async_handle_action(action, action_slot_num, payload)
-                )
-
-            # Parse bulk users list if available.
-            if "users" in payload and isinstance(payload["users"], dict):
-                for slot_str, info in payload["users"].items():
-                    try:
-                        km_slot_num = int(slot_str)
-                    except ValueError:
-                        continue
-
-                    status = info.get("status")
-                    if "pin_code" not in info:
-                        in_use = status == "enabled"
-                        code = None
-                    else:
-                        code_val = info["pin_code"]
-                        code = _get_pin_code_value(code_val)
-                        in_use = bool(code and status == "enabled")
-
-                    slot_data = CodeSlot(
-                        slot_num=km_slot_num,
-                        code=code,
-                        in_use=in_use,
-                    )
-                    self._usercodes_cache[km_slot_num] = slot_data
-
-                    # Resolve pending future if any
-                    if km_slot_num in self._pending_usercode_futures:
-                        fut = self._pending_usercode_futures[km_slot_num]
-                        if not fut.done():
-                            fut.set_result(slot_data)
-
-            if "pin_code" in payload and isinstance(payload["pin_code"], dict):
-                pin_data = payload["pin_code"]
-                user_slot = pin_data.get("user")
-                if isinstance(user_slot, int):
-                    user_enabled = pin_data.get("user_enabled", False)
-                    if "pin_code" not in pin_data:
-                        slot_data = CodeSlot(
-                            slot_num=user_slot,
-                            code=None,
-                            in_use=bool(user_enabled),
-                        )
-                        self._usercodes_cache[user_slot] = slot_data
-                        if user_slot in self._pending_usercode_futures:
-                            fut = self._pending_usercode_futures[user_slot]
-                            if not fut.done():
-                                fut.set_result(slot_data)
-                    else:
-                        code_val = pin_data["pin_code"]
-                        code = _get_pin_code_value(code_val)
-                        in_use = bool(code and user_enabled)
-                        slot_data = CodeSlot(
-                            slot_num=user_slot,
-                            code=code,
-                            in_use=in_use,
-                        )
-                        self._usercodes_cache[user_slot] = slot_data
-                        if user_slot in self._pending_usercode_futures:
-                            fut = self._pending_usercode_futures[user_slot]
-                            if not fut.done():
-                                fut.set_result(slot_data)
-
-        # Listen to state topic for code changes
-        state_topic = self.state_topic
-        if not state_topic:
-            _LOGGER.error("[Zigbee2MQTTProvider] Base topic could not be derived from device name")
-            return False
-
-        self._listeners.append(
-            await mqtt.async_subscribe(self.hass, state_topic, handle_state_message)
-        )
-
-        self._connected = True
-        _LOGGER.debug(
-            "[Zigbee2MQTTProvider] Connected to lock %s (base_topic: %s)",
-            self.lock_entity_id,
-            self.base_topic,
-        )
         return True
+
+    def _handle_state_payload(self, payload: dict[str, Any]) -> None:
+        """Handle a decoded Zigbee2MQTT state payload."""
+        action = payload.get("action")
+        action_slot_num = payload.get("action_user")
+        if action or action_slot_num:
+            self.hass.async_create_task(self._async_handle_action(action, action_slot_num, payload))
+
+        # Parse bulk users list if available.
+        if "users" in payload and isinstance(payload["users"], dict):
+            self._handle_bulk_users_payload(payload["users"])
+
+        if "pin_code" in payload and isinstance(payload["pin_code"], dict):
+            self._handle_pin_code_payload(payload["pin_code"])
+
+    def _handle_bulk_users_payload(self, users: dict[str, Any]) -> None:
+        """Update cached slots from a Zigbee2MQTT bulk users payload."""
+        for slot_str, info in users.items():
+            try:
+                km_slot_num = int(slot_str)
+            except ValueError:
+                continue
+            if not isinstance(info, dict):
+                continue
+
+            self._cache_slot_and_resolve(self._code_slot_from_bulk_user(km_slot_num, info))
+
+    def _code_slot_from_bulk_user(self, slot_num: int, info: dict[str, Any]) -> CodeSlot:
+        """Create a code slot from one bulk users payload entry."""
+        status = info.get("status")
+        if "pin_code" not in info:
+            in_use = status == "enabled"
+            code = None
+        else:
+            code_val = info["pin_code"]
+            code = _get_pin_code_value(code_val)
+            in_use = bool(code and status == "enabled")
+
+        return CodeSlot(
+            slot_num=slot_num,
+            code=code,
+            in_use=in_use,
+        )
+
+    def _handle_pin_code_payload(self, pin_data: dict[str, Any]) -> None:
+        """Update cached slots from a Zigbee2MQTT single pin_code payload."""
+        user_slot = pin_data.get("user")
+        if isinstance(user_slot, int):
+            self._cache_slot_and_resolve(self._code_slot_from_pin_data(user_slot, pin_data))
+
+    def _code_slot_from_pin_data(self, user_slot: int, pin_data: dict[str, Any]) -> CodeSlot:
+        """Create a code slot from one single pin_code payload."""
+        user_enabled = pin_data.get("user_enabled", False)
+        if "pin_code" not in pin_data:
+            return CodeSlot(
+                slot_num=user_slot,
+                code=None,
+                in_use=bool(user_enabled),
+            )
+
+        code_val = pin_data["pin_code"]
+        code = _get_pin_code_value(code_val)
+        in_use = bool(code and user_enabled)
+        return CodeSlot(
+            slot_num=user_slot,
+            code=code,
+            in_use=in_use,
+        )
+
+    def _cache_slot_and_resolve(self, slot_data: CodeSlot) -> None:
+        """Cache a code slot and resolve any pending query future."""
+        slot_num = slot_data.slot_num
+        self._usercodes_cache[slot_num] = slot_data
+        if slot_num in self._pending_usercode_futures:
+            fut = self._pending_usercode_futures[slot_num]
+            if not fut.done():
+                fut.set_result(slot_data)
 
     async def async_is_connected(self) -> bool:
         """Check if Zigbee2MQTT lock connection is active."""

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -189,10 +189,15 @@ class TestConnect:
         """Test connection fails when lock entity is not found in Entity Registry."""
         provider.entity_registry.async_get.return_value = None
 
-        result = await provider.async_connect()
+        with patch("custom_components.keymaster.providers.zigbee2mqtt._LOGGER.error") as mock_log:
+            result = await provider.async_connect()
 
         assert result is False
         assert provider.connected is False
+        mock_log.assert_called_once_with(
+            "[Zigbee2MQTTProvider] Can't find lock in Entity Registry: %s",
+            "lock.test_lock",
+        )
 
     async def test_connect_platform_not_mqtt(self, provider):
         """Test connection fails when lock entity platform is not mqtt."""
@@ -200,10 +205,16 @@ class TestConnect:
         lock_entry.platform = "zwave_js"
         provider.entity_registry.async_get.return_value = lock_entry
 
-        result = await provider.async_connect()
+        with patch("custom_components.keymaster.providers.zigbee2mqtt._LOGGER.error") as mock_log:
+            result = await provider.async_connect()
 
         assert result is False
         assert provider.connected is False
+        mock_log.assert_called_once_with(
+            "[Zigbee2MQTTProvider] Lock platform is not mqtt: %s (%s)",
+            "lock.test_lock",
+            "zwave_js",
+        )
 
     async def test_connect_device_not_found(self, provider):
         """Test connection fails when lock device is not found in registry."""
@@ -214,17 +225,27 @@ class TestConnect:
         provider.entity_registry.async_get.return_value = lock_entry
         provider.device_registry.async_get.return_value = None
 
-        result = await provider.async_connect()
+        with patch("custom_components.keymaster.providers.zigbee2mqtt._LOGGER.error") as mock_log:
+            result = await provider.async_connect()
 
         assert result is False
         assert provider.connected is False
+        mock_log.assert_called_once_with(
+            "[Zigbee2MQTTProvider] Can't find lock device in Device Registry: %s",
+            "lock.test_lock",
+        )
 
     async def test_connect_platform_not_z2m(self, provider, mock_hass):
         """Test connection fails when lock device is not a Z2M device."""
         setup_successful_connect(provider, mock_hass, identifiers={("mqtt", "not_z2m_device")})
-        result = await provider.async_connect()
+        with patch("custom_components.keymaster.providers.zigbee2mqtt._LOGGER.error") as mock_log:
+            result = await provider.async_connect()
         assert result is False
         assert provider.connected is False
+        mock_log.assert_called_once_with(
+            "[Zigbee2MQTTProvider] Lock device is not a Zigbee2MQTT device: %s",
+            "lock.test_lock",
+        )
 
     async def test_connect_handles_bulk_users_message(self, provider, mock_hass):
         """Test that incoming bulk users messages update the cache."""
@@ -245,7 +266,6 @@ class TestConnect:
 
         assert callback_captured is not None
 
-        # Test bulk update.
         payload = {
             "users": {
                 "1": {"pin_code": "1234", "status": "enabled"},
@@ -328,8 +348,85 @@ class TestConnect:
         msg = ReceiveMessage("zigbee2mqtt/my_lock", "invalid json", 0, False)
 
         assert callback_captured is not None
-        callback_captured(msg)
+        with patch("custom_components.keymaster.providers.zigbee2mqtt._LOGGER.error") as mock_log:
+            callback_captured(msg)
         assert len(provider._usercodes_cache) == 0
+        mock_log.assert_not_called()
+
+    async def test_connect_ignores_non_object_json(self, provider, mock_hass):
+        """Test that non-object JSON payloads are ignored gracefully."""
+        setup_successful_connect(provider, mock_hass)
+
+        callback_captured = None
+
+        def mock_subscribe(hass, topic, callback_fn):
+            nonlocal callback_captured
+            callback_captured = callback_fn
+            return lambda: None
+
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_sub:
+            mock_sub.side_effect = mock_subscribe
+            await provider.async_connect()
+
+        assert callback_captured is not None
+        callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", "[1, 2, 3]", 0, False))
+
+        assert provider._usercodes_cache == {}
+        provider.hass.async_create_task.assert_not_called()
+
+    def test_cache_slot_and_resolve_resolves_pending_future_once(self, provider):
+        """Test caching a slot resolves a pending future only while it is not done."""
+        future = MagicMock()
+        future.done.side_effect = [False, True]
+        slot_data = CodeSlot(slot_num=1, code="1234", in_use=True)
+        provider._pending_usercode_futures[1] = future
+
+        provider._cache_slot_and_resolve(slot_data)
+        provider._cache_slot_and_resolve(slot_data)
+
+        assert provider._usercodes_cache[1] == slot_data
+        future.set_result.assert_called_once_with(slot_data)
+
+    def test_cache_slot_and_resolve_skips_done_future(self, provider):
+        """Test caching a slot does not resolve an already-done pending future."""
+        future = MagicMock()
+        future.done.return_value = True
+        slot_data = CodeSlot(slot_num=2, code=None, in_use=False)
+        provider._pending_usercode_futures[2] = future
+
+        provider._cache_slot_and_resolve(slot_data)
+
+        assert provider._usercodes_cache[2] == slot_data
+        future.set_result.assert_not_called()
+
+    def test_handle_bulk_users_payload_skips_invalid_entries(self, provider):
+        """Test invalid bulk users entries skip only those slots."""
+        provider._handle_bulk_users_payload(
+            {
+                "bad": {"pin_code": "0000", "status": "enabled"},
+                "2": "not a dict",
+                "1": {"pin_code": "1234", "status": "enabled"},
+            }
+        )
+
+        assert provider._usercodes_cache == {1: CodeSlot(slot_num=1, code="1234", in_use=True)}
+
+    def test_code_slot_payload_pin_absent_and_present_branches(self, provider):
+        """Test pin_code-absent branches differ from present-without-value branches."""
+        assert provider._code_slot_from_bulk_user(1, {"status": "enabled"}) == CodeSlot(
+            slot_num=1, code=None, in_use=True
+        )
+        assert provider._code_slot_from_bulk_user(
+            2, {"pin_code": "", "status": "enabled"}
+        ) == CodeSlot(slot_num=2, code=None, in_use=False)
+        assert provider._code_slot_from_pin_data(3, {"user": 3, "user_enabled": True}) == CodeSlot(
+            slot_num=3, code=None, in_use=True
+        )
+        assert provider._code_slot_from_pin_data(
+            4, {"user": 4, "pin_code": "", "user_enabled": True}
+        ) == CodeSlot(slot_num=4, code=None, in_use=False)
 
 
 class TestIsConnected:

--- a/tests/providers/test_zigbee2mqtt.py
+++ b/tests/providers/test_zigbee2mqtt.py
@@ -351,6 +351,8 @@ class TestConnect:
         with patch("custom_components.keymaster.providers.zigbee2mqtt._LOGGER.error") as mock_log:
             callback_captured(msg)
         assert len(provider._usercodes_cache) == 0
+        assert provider._initial_state_received is not None
+        assert not provider._initial_state_received.is_set()
         mock_log.assert_not_called()
 
     async def test_connect_ignores_non_object_json(self, provider, mock_hass):
@@ -374,7 +376,58 @@ class TestConnect:
         callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", "[1, 2, 3]", 0, False))
 
         assert provider._usercodes_cache == {}
+        assert provider._initial_state_received is not None
+        assert not provider._initial_state_received.is_set()
         provider.hass.async_create_task.assert_not_called()
+
+    async def test_connect_valid_dict_json_sets_initial_state(self, provider, mock_hass):
+        """Test that a valid JSON object payload marks the initial state received."""
+        setup_successful_connect(provider, mock_hass)
+
+        callback_captured = None
+
+        def mock_subscribe(hass, topic, callback_fn):
+            nonlocal callback_captured
+            callback_captured = callback_fn
+            return lambda: None
+
+        with patch(
+            "homeassistant.components.mqtt.async_subscribe", new_callable=AsyncMock
+        ) as mock_sub:
+            mock_sub.side_effect = mock_subscribe
+            await provider.async_connect()
+
+        assert callback_captured is not None
+        assert provider._initial_state_received is not None
+        assert not provider._initial_state_received.is_set()
+
+        payload = {"users": {"1": {"pin_code": "1234", "status": "enabled"}}}
+        callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", json.dumps(payload), 0, False))
+
+        assert provider._usercodes_cache[1] == CodeSlot(slot_num=1, code="1234", in_use=True)
+        assert provider._initial_state_received.is_set()
+
+    async def test_get_usercodes_waits_after_only_malformed_payloads(self, provider, mock_hass):
+        """Test malformed payloads do not skip the retained-state wait."""
+        mock_subscribe = await connect_provider(provider, mock_hass)
+        callback_captured = mock_subscribe.call_args[0][2]
+        provider.state_wait_timeout = 0.05
+
+        callback_captured(ReceiveMessage("zigbee2mqtt/my_lock", "invalid json", 0, False))
+
+        async def mock_query_slot(slot_num):
+            return CodeSlot(slot_num=slot_num, code=f"{slot_num}" * 4, in_use=True)
+
+        with patch.object(provider, "_async_query_slot", side_effect=mock_query_slot) as mock_query:
+            task = asyncio.create_task(provider.async_get_usercodes())
+            await asyncio.sleep(0.01)
+            assert not task.done()
+
+            result = await task
+
+        assert mock_query.call_count == 6
+        assert len(result) == 6
+        assert result[0] == CodeSlot(slot_num=1, code="1111", in_use=True)
 
     def test_cache_slot_and_resolve_resolves_pending_future_once(self, provider):
         """Test caching a slot resolves a pending future only while it is not done."""


### PR DESCRIPTION
# Summary

Refactor Zigbee2MQTT connection setup to address one long, deeply nested
function while preserving MQTT lock behavior, then fix the pre-existing initial
state signal ordering defect surfaced during review.

## Proposed change

Extract `async_connect` validation and state payload parsing into private helper
methods on `Zigbee2MQTTLockProvider`:

- `_validate_zigbee2mqtt_device`
- `_handle_state_payload`
- `_handle_bulk_users_payload`
- `_code_slot_from_bulk_user`
- `_handle_pin_code_payload`
- `_code_slot_from_pin_data`
- `_cache_slot_and_resolve`

The MQTT `handle_state_message` callback remains decorated with `@callback`,
continues to ignore malformed JSON silently, and preserves the ordering of
action handling, bulk `users` parsing, and single `pin_code` parsing. Pending
slot futures are still resolved only when not already done.

A second commit fixes the reviewed initial-state defect by setting
`_initial_state_received` only after a payload successfully parses as a JSON
object and `_handle_state_payload` finishes. `_handle_state_payload` is fully
synchronous today; setting the event after it returns means waiters observe a
fully populated `_usercodes_cache`, and keeps the ordering safe if the helper
ever gains awaitable work later.

Provider file-size work is intentionally untouched because the maintainer has
deferred provider `file-too-large` cleanup separately.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: n/a
- This PR is related to issue: Refs #651, Refs #770

Validation:

- `tox -e py314`
- `tox -e lint`
- `aislop scan --json` on a pristine clone with this patch applied
