### PR TITLE
refactor: extract switch setup descriptors

### DIFF
--- a/custom_components/keymaster/switch.py
+++ b/custom_components/keymaster/switch.py
@@ -32,23 +32,8 @@ from .lock import KeymasterCodeSlot, KeymasterCodeSlotDayOfWeek, KeymasterLock
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Create keymaster Switches."""
-    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
-    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
-        config_entry.entry_id
-    )
-    kmlock: KeymasterLock | None = await manager.get_lock_by_config_entry_id(config_entry.entry_id)
-    entities: list = []
-
-    if not kmlock:
-        _LOGGER.error("Lock not found for config entry %s", config_entry.entry_id)
-        raise PlatformNotReady
-
+def _base_switch_specs(config_entry: ConfigEntry) -> list[MutableMapping[str, str]]:
+    """Return lock-level switch entity specs for a config entry."""
     switch_entities: list[MutableMapping[str, str]] = [
         {
             "prop": "switch.autolock_enabled",
@@ -77,73 +62,118 @@ async def async_setup_entry(
             ]
         )
 
+    return switch_entities
+
+
+def _day_of_week_switch_specs(slot_num: int) -> list[MutableMapping[str, str]]:
+    """Return day-of-week switch entity specs for a code slot."""
+    switch_entities: list[MutableMapping[str, str]] = []
+    for i, dow in enumerate(DAY_NAMES):
+        switch_entities.extend(
+            [
+                {
+                    "prop": f"switch.code_slots:{slot_num}.accesslimit_day_of_week:{i}.dow_enabled",
+                    "name": f"Code Slot {slot_num}: {dow}",
+                    "icon": "mdi:calendar-today",
+                },
+                {
+                    "prop": (
+                        f"switch.code_slots:{slot_num}.accesslimit_day_of_week:{i}.include_exclude"
+                    ),
+                    "name": f"Code Slot {slot_num}: {dow} - Include (On)/Exclude (Off) Time",
+                    "icon": "mdi:plus-minus",
+                },
+                {
+                    "prop": (
+                        f"switch.code_slots:{slot_num}.accesslimit_day_of_week:{i}.limit_by_time"
+                    ),
+                    "name": f"Code Slot {slot_num}: {dow} - Limit by Time of Day",
+                    "icon": "mdi:timer-lock",
+                },
+            ]
+        )
+
+    return switch_entities
+
+
+def _code_slot_switch_specs(
+    slot_num: int,
+    kmlock: KeymasterLock,
+    config_entry: ConfigEntry,
+) -> list[MutableMapping[str, str]]:
+    """Return switch entity specs for a code slot."""
+    switch_entities: list[MutableMapping[str, str]] = []
+    if kmlock.parent_name:
+        switch_entities.append(
+            {
+                "prop": f"switch.code_slots:{slot_num}.override_parent",
+                "name": f"Code Slot {slot_num}: Override Parent",
+                "icon": "mdi:call-split",
+            }
+        )
+    switch_entities.extend(
+        [
+            {
+                "prop": f"switch.code_slots:{slot_num}.enabled",
+                "name": f"Code Slot {slot_num}: Enabled",
+                "icon": "mdi:folder-pound",
+            },
+            {
+                "prop": f"switch.code_slots:{slot_num}.notifications",
+                "name": f"Code Slot {slot_num}: Notifications",
+                "icon": "mdi:message-lock",
+            },
+            {
+                "prop": f"switch.code_slots:{slot_num}.accesslimit_count_enabled",
+                "name": f"Code Slot {slot_num}: Limit by Number of Uses",
+                "icon": "mdi:numeric",
+            },
+        ]
+    )
+    if config_entry.data.get(CONF_ADVANCED_DATE_RANGE, True):
+        switch_entities.append(
+            {
+                "prop": f"switch.code_slots:{slot_num}.accesslimit_date_range_enabled",
+                "name": f"Code Slot {slot_num}: Use Date Range Limits",
+                "icon": "mdi:calendar-lock",
+            },
+        )
+    if config_entry.data.get(CONF_ADVANCED_DAY_OF_WEEK, True):
+        switch_entities.append(
+            {
+                "prop": f"switch.code_slots:{slot_num}.accesslimit_day_of_week_enabled",
+                "name": f"Code Slot {slot_num}: Use Day of Week Limits",
+                "icon": "mdi:calendar-week",
+            },
+        )
+        switch_entities.extend(_day_of_week_switch_specs(slot_num))
+
+    return switch_entities
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Create keymaster Switches."""
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator: KeymasterLockCoordinator = manager.async_get_lock_coordinator(
+        config_entry.entry_id
+    )
+    kmlock: KeymasterLock | None = await manager.get_lock_by_config_entry_id(config_entry.entry_id)
+    entities: list = []
+
+    if not kmlock:
+        _LOGGER.error("Lock not found for config entry %s", config_entry.entry_id)
+        raise PlatformNotReady
+
+    switch_entities = _base_switch_specs(config_entry)
     for x in range(
         config_entry.data[CONF_START],
         config_entry.data[CONF_START] + config_entry.data[CONF_SLOTS],
     ):
-        if kmlock.parent_name:
-            switch_entities.append(
-                {
-                    "prop": f"switch.code_slots:{x}.override_parent",
-                    "name": f"Code Slot {x}: Override Parent",
-                    "icon": "mdi:call-split",
-                }
-            )
-        switch_entities.extend(
-            [
-                {
-                    "prop": f"switch.code_slots:{x}.enabled",
-                    "name": f"Code Slot {x}: Enabled",
-                    "icon": "mdi:folder-pound",
-                },
-                {
-                    "prop": f"switch.code_slots:{x}.notifications",
-                    "name": f"Code Slot {x}: Notifications",
-                    "icon": "mdi:message-lock",
-                },
-                {
-                    "prop": f"switch.code_slots:{x}.accesslimit_count_enabled",
-                    "name": f"Code Slot {x}: Limit by Number of Uses",
-                    "icon": "mdi:numeric",
-                },
-            ]
-        )
-        if config_entry.data.get(CONF_ADVANCED_DATE_RANGE, True):
-            switch_entities.append(
-                {
-                    "prop": f"switch.code_slots:{x}.accesslimit_date_range_enabled",
-                    "name": f"Code Slot {x}: Use Date Range Limits",
-                    "icon": "mdi:calendar-lock",
-                },
-            )
-        if config_entry.data.get(CONF_ADVANCED_DAY_OF_WEEK, True):
-            switch_entities.append(
-                {
-                    "prop": f"switch.code_slots:{x}.accesslimit_day_of_week_enabled",
-                    "name": f"Code Slot {x}: Use Day of Week Limits",
-                    "icon": "mdi:calendar-week",
-                },
-            )
-            for i, dow in enumerate(DAY_NAMES):
-                switch_entities.extend(
-                    [
-                        {
-                            "prop": f"switch.code_slots:{x}.accesslimit_day_of_week:{i}.dow_enabled",
-                            "name": f"Code Slot {x}: {dow}",
-                            "icon": "mdi:calendar-today",
-                        },
-                        {
-                            "prop": f"switch.code_slots:{x}.accesslimit_day_of_week:{i}.include_exclude",
-                            "name": f"Code Slot {x}: {dow} - Include (On)/Exclude (Off) Time",
-                            "icon": "mdi:plus-minus",
-                        },
-                        {
-                            "prop": f"switch.code_slots:{x}.accesslimit_day_of_week:{i}.limit_by_time",
-                            "name": f"Code Slot {x}: {dow} - Limit by Time of Day",
-                            "icon": "mdi:timer-lock",
-                        },
-                    ]
-                )
+        switch_entities.extend(_code_slot_switch_specs(x, kmlock, config_entry))
     entities.extend(
         [
             KeymasterSwitch(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -75,6 +75,161 @@ async def coordinator(hass: HomeAssistant, switch_config_entry):
     return manager.async_get_lock_coordinator(switch_config_entry.entry_id)
 
 
+async def _created_switch_props(hass: HomeAssistant, data, parent_name="parent_lock"):
+    """Return switch entity props created for config data."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="frontdoor",
+        data=data,
+        version=3,
+    )
+    config_entry.add_to_hass(hass)
+
+    manager = KeymasterCoordinator(hass)
+    manager._initial_setup_done_event.set()
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][COORDINATOR] = manager
+
+    kmlock = KeymasterLock(
+        lock_name="frontdoor",
+        lock_entity_id="lock.test",
+        keymaster_config_entry_id=config_entry.entry_id,
+        parent_name=parent_name,
+    )
+    manager.kmlocks[config_entry.entry_id] = kmlock
+    entities = []
+
+    def mock_add_entities(new_entities, update_before_add=False):
+        del update_before_add
+        entities.extend(new_entities)
+
+    await async_setup_entry(hass, config_entry, mock_add_entities)
+
+    return [entity.entity_description.key for entity in entities]
+
+
+async def test_switch_descriptor_props_preserve_order(hass: HomeAssistant):
+    """Test switch setup preserves descriptor prop values and ordering."""
+    props = await _created_switch_props(hass, CONFIG_DATA_SWITCH)
+
+    assert props == [
+        "switch.autolock_enabled",
+        "switch.lock_notifications",
+        "switch.door_notifications",
+        "switch.retry_lock",
+        "switch.code_slots:1.override_parent",
+        "switch.code_slots:1.enabled",
+        "switch.code_slots:1.notifications",
+        "switch.code_slots:1.accesslimit_count_enabled",
+        "switch.code_slots:1.accesslimit_date_range_enabled",
+        "switch.code_slots:1.accesslimit_day_of_week_enabled",
+        "switch.code_slots:1.accesslimit_day_of_week:0.dow_enabled",
+        "switch.code_slots:1.accesslimit_day_of_week:0.include_exclude",
+        "switch.code_slots:1.accesslimit_day_of_week:0.limit_by_time",
+        "switch.code_slots:1.accesslimit_day_of_week:1.dow_enabled",
+        "switch.code_slots:1.accesslimit_day_of_week:1.include_exclude",
+        "switch.code_slots:1.accesslimit_day_of_week:1.limit_by_time",
+        "switch.code_slots:1.accesslimit_day_of_week:2.dow_enabled",
+        "switch.code_slots:1.accesslimit_day_of_week:2.include_exclude",
+        "switch.code_slots:1.accesslimit_day_of_week:2.limit_by_time",
+        "switch.code_slots:1.accesslimit_day_of_week:3.dow_enabled",
+        "switch.code_slots:1.accesslimit_day_of_week:3.include_exclude",
+        "switch.code_slots:1.accesslimit_day_of_week:3.limit_by_time",
+        "switch.code_slots:1.accesslimit_day_of_week:4.dow_enabled",
+        "switch.code_slots:1.accesslimit_day_of_week:4.include_exclude",
+        "switch.code_slots:1.accesslimit_day_of_week:4.limit_by_time",
+        "switch.code_slots:1.accesslimit_day_of_week:5.dow_enabled",
+        "switch.code_slots:1.accesslimit_day_of_week:5.include_exclude",
+        "switch.code_slots:1.accesslimit_day_of_week:5.limit_by_time",
+        "switch.code_slots:1.accesslimit_day_of_week:6.dow_enabled",
+        "switch.code_slots:1.accesslimit_day_of_week:6.include_exclude",
+        "switch.code_slots:1.accesslimit_day_of_week:6.limit_by_time",
+        "switch.code_slots:2.override_parent",
+        "switch.code_slots:2.enabled",
+        "switch.code_slots:2.notifications",
+        "switch.code_slots:2.accesslimit_count_enabled",
+        "switch.code_slots:2.accesslimit_date_range_enabled",
+        "switch.code_slots:2.accesslimit_day_of_week_enabled",
+        "switch.code_slots:2.accesslimit_day_of_week:0.dow_enabled",
+        "switch.code_slots:2.accesslimit_day_of_week:0.include_exclude",
+        "switch.code_slots:2.accesslimit_day_of_week:0.limit_by_time",
+        "switch.code_slots:2.accesslimit_day_of_week:1.dow_enabled",
+        "switch.code_slots:2.accesslimit_day_of_week:1.include_exclude",
+        "switch.code_slots:2.accesslimit_day_of_week:1.limit_by_time",
+        "switch.code_slots:2.accesslimit_day_of_week:2.dow_enabled",
+        "switch.code_slots:2.accesslimit_day_of_week:2.include_exclude",
+        "switch.code_slots:2.accesslimit_day_of_week:2.limit_by_time",
+        "switch.code_slots:2.accesslimit_day_of_week:3.dow_enabled",
+        "switch.code_slots:2.accesslimit_day_of_week:3.include_exclude",
+        "switch.code_slots:2.accesslimit_day_of_week:3.limit_by_time",
+        "switch.code_slots:2.accesslimit_day_of_week:4.dow_enabled",
+        "switch.code_slots:2.accesslimit_day_of_week:4.include_exclude",
+        "switch.code_slots:2.accesslimit_day_of_week:4.limit_by_time",
+        "switch.code_slots:2.accesslimit_day_of_week:5.dow_enabled",
+        "switch.code_slots:2.accesslimit_day_of_week:5.include_exclude",
+        "switch.code_slots:2.accesslimit_day_of_week:5.limit_by_time",
+        "switch.code_slots:2.accesslimit_day_of_week:6.dow_enabled",
+        "switch.code_slots:2.accesslimit_day_of_week:6.include_exclude",
+        "switch.code_slots:2.accesslimit_day_of_week:6.limit_by_time",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("data_updates", "parent_name", "present_props", "absent_props"),
+    [
+        (
+            {CONF_DOOR_SENSOR_ENTITY_ID: None},
+            "parent_lock",
+            ["switch.code_slots:1.override_parent"],
+            ["switch.door_notifications", "switch.retry_lock"],
+        ),
+        (
+            {CONF_DOOR_SENSOR_ENTITY_ID: ""},
+            "parent_lock",
+            ["switch.door_notifications", "switch.retry_lock"],
+            [],
+        ),
+        (
+            {},
+            None,
+            ["switch.door_notifications", "switch.retry_lock"],
+            ["switch.code_slots:1.override_parent"],
+        ),
+        (
+            {CONF_ADVANCED_DATE_RANGE: False},
+            "parent_lock",
+            ["switch.code_slots:1.accesslimit_day_of_week_enabled"],
+            ["switch.code_slots:1.accesslimit_date_range_enabled"],
+        ),
+        (
+            {CONF_ADVANCED_DAY_OF_WEEK: False},
+            "parent_lock",
+            ["switch.code_slots:1.accesslimit_date_range_enabled"],
+            [
+                "switch.code_slots:1.accesslimit_day_of_week_enabled",
+                "switch.code_slots:1.accesslimit_day_of_week:0.dow_enabled",
+            ],
+        ),
+    ],
+)
+async def test_switch_descriptor_gates_preserve_contract(
+    hass: HomeAssistant, data_updates, parent_name, present_props, absent_props
+):
+    """Test switch descriptor gates preserve their existing behavior."""
+    props = await _created_switch_props(
+        hass,
+        CONFIG_DATA_SWITCH | {CONF_SLOTS: 1} | data_updates,
+        parent_name,
+    )
+
+    assert "switch.autolock_enabled" in props
+    assert "switch.lock_notifications" in props
+    for prop in present_props:
+        assert prop in props
+    for prop in absent_props:
+        assert prop not in props
+
+
 async def test_switch_entities_created_with_lock_coordinator(
     hass: HomeAssistant, switch_config_entry
 ):

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,6 +1,7 @@
 """Tests for keymaster Switch platform."""
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -34,6 +35,7 @@ from custom_components.keymaster.switch import (
 )
 from homeassistant.components.lock.const import LockState
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import EntityCategory
 
 CONFIG_DATA_SWITCH = {
@@ -254,6 +256,20 @@ async def test_switch_entities_created_with_lock_coordinator(
     assert entities
     assert all(entity.coordinator is lock_coordinator for entity in entities)
     assert entities[0].unique_id == f"{switch_config_entry.entry_id}_switch_autolock_enabled"
+
+
+async def test_switch_setup_raises_when_lock_not_found(
+    hass: HomeAssistant, switch_config_entry, caplog: pytest.LogCaptureFixture
+):
+    """Test switch setup raises and logs when the lock is missing."""
+    manager: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    manager._initial_setup_done_event.set()
+    caplog.set_level(logging.ERROR, logger="custom_components.keymaster.switch")
+
+    with pytest.raises(PlatformNotReady):
+        await async_setup_entry(hass, switch_config_entry, Mock())
+
+    assert f"Lock not found for config entry {switch_config_entry.entry_id}" in caplog.messages
 
 
 async def test_switch_entity_initialization(hass: HomeAssistant, switch_config_entry, coordinator):


### PR DESCRIPTION
# Summary

Refactor switch platform setup helpers for issue #772.

## Proposed change

This extracts private helper functions from async_setup_entry in
custom_components/keymaster/switch.py for:

- lock-level switch descriptor specs
- per-code-slot switch descriptor specs
- day-of-week switch descriptor specs

The extraction is behavior-preserving. Descriptor prop, name, and icon
strings are unchanged, and descriptor ordering is unchanged. A new test pins
the full ordered prop list for a representative configuration with a parent
lock, door sensor, advanced date range, and advanced day-of-week switches.
Additional gate coverage verifies no parent lock, no door sensor, and disabled
advanced flags.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #772
