### PR TITLE
refactor: split config flow schema helpers

### DIFF
--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -106,7 +106,7 @@ class KeymasterConfigFlow(ConfigFlow, domain=DOMAIN):
         if self._data[CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID] is None:
             self._data[CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID] = NONE_TEXT
 
-        notify_scripts = config_flow_schema._get_entities(  # noqa: SLF001
+        notify_scripts = config_flow_schema.get_entities(
             hass=self.hass,
             domain=SCRIPT_DOMAIN,
             extra_entities=[NONE_TEXT],
@@ -224,7 +224,7 @@ async def _start_config_flow(
                     )
                 return cls.async_abort(reason="reconfigure_successful")
 
-    data_schema = config_flow_schema._get_schema(  # noqa: SLF001
+    data_schema = config_flow_schema.get_schema(
         hass=cls.hass,
         user_input=user_input,
         default_dict=defaults,

--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -2,20 +2,18 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, MutableMapping
+from collections.abc import MutableMapping
 import logging
 from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import DOMAIN as BINARY_DOMAIN
-from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.util import slugify
 
+from . import config_flow_schema
 from .const import (
     CONF_ADVANCED_DATE_RANGE,
     CONF_ADVANCED_DAY_OF_WEEK,
@@ -23,7 +21,6 @@ from .const import (
     CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
     CONF_DOOR_SENSOR_ENTITY_ID,
     CONF_HIDE_PINS,
-    CONF_LOCK_ENTITY_ID,
     CONF_LOCK_NAME,
     CONF_NOTIFY_SCRIPT_NAME,
     CONF_PARENT,
@@ -31,7 +28,6 @@ from .const import (
     CONF_REDACT_SLOT_NAMES,
     CONF_SLOTS,
     CONF_START,
-    COORDINATOR,
     DEFAULT_ADVANCED_DATE_RANGE,
     DEFAULT_ADVANCED_DAY_OF_WEEK,
     DEFAULT_CODE_SLOTS,
@@ -42,9 +38,7 @@ from .const import (
     DOMAIN,
     NONE_TEXT,
 )
-from .coordinator import KeymasterCoordinator
 from .helpers import async_update_large_lock_repair_issue
-from .providers import is_platform_supported
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -112,7 +106,7 @@ class KeymasterConfigFlow(ConfigFlow, domain=DOMAIN):
         if self._data[CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID] is None:
             self._data[CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID] = NONE_TEXT
 
-        notify_scripts = _get_entities(
+        notify_scripts = config_flow_schema._get_entities(  # noqa: SLF001
             hass=self.hass,
             domain=SCRIPT_DOMAIN,
             extra_entities=[NONE_TEXT],
@@ -176,196 +170,6 @@ class KeymasterOptionsFlowHandler(OptionsFlow):
         )
 
 
-def _available_parent_locks(hass: HomeAssistant, entry_id: str | None = None) -> list:
-    """Return other keymaster locks if they are not already a child lock."""
-
-    data: list[str] = [NONE_TEXT]
-    if DOMAIN not in hass.data:
-        return data
-
-    data.extend(
-        [
-            entry.title
-            for entry in hass.config_entries.async_entries(DOMAIN)
-            if entry.entry_id != entry_id
-            and (CONF_PARENT not in entry.data or entry.data[CONF_PARENT] is None)
-        ]
-    )
-    return data
-
-
-def _get_entities(
-    hass: HomeAssistant,
-    domain: str,
-    *,
-    search: list[str] | None = None,
-    extra_entities: list[str] | None = None,
-    exclude_entities: list[str] | None = None,
-    sort: bool = True,
-    filter_func: Callable[[HomeAssistant, str], bool] | None = None,
-) -> list[str]:
-    """Get entities from a domain with optional filtering.
-
-    Args:
-        hass: Home Assistant instance
-        domain: Entity domain (e.g., "lock", "sensor")
-        search: Only include entities whose ID contains one of these strings
-        extra_entities: Additional entity IDs to append to results
-        exclude_entities: Entity IDs to remove from results
-        sort: Whether to sort the results alphabetically
-        filter_func: Optional callback(hass, entity_id) -> bool to filter entities.
-            Entity is included only if filter_func returns True.
-
-    """
-    data: list[str] = []
-    if domain not in hass.data:
-        return extra_entities or []
-
-    for entity in hass.data[domain].entities:
-        # Skip if search terms provided and entity ID doesn't contain any of them
-        if search is not None and not any(map(entity.entity_id.__contains__, search)):
-            continue
-        # Skip if filter function provided and it returns False for this entity
-        if filter_func is not None and not filter_func(hass, entity.entity_id):
-            continue
-        data.append(entity.entity_id)
-
-    if extra_entities:
-        data.extend(extra_entities)
-
-    if exclude_entities:
-        for ent in exclude_entities:
-            if ent in data:
-                data.remove(ent)
-    if sort:
-        data.sort()
-
-    return data
-
-
-def _get_locks_in_use(hass: HomeAssistant, exclude: str | None = None) -> list[str]:
-    if DOMAIN not in hass.data or COORDINATOR not in hass.data[DOMAIN]:
-        return []
-    data: list[str] = []
-    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
-    data.extend([kmlock.lock_entity_id for kmlock in coordinator.data.values()])
-    if exclude and exclude in data:
-        data.remove(exclude)
-
-    return data
-
-
-def _get_schema(
-    hass: HomeAssistant,
-    user_input: MutableMapping[str, Any] | None,
-    default_dict: MutableMapping[str, Any],
-    entry_id: str | None = None,
-    flow: KeymasterConfigFlow | None = None,
-) -> vol.Schema | ConfigFlowResult:
-    """Get a schema using the default_dict as a backup."""
-    if user_input is None:
-        user_input = {}
-
-    if CONF_PARENT in default_dict and default_dict[CONF_PARENT] is None:
-        check_dict: MutableMapping[str, Any] = dict(default_dict).copy()
-        check_dict.pop(CONF_PARENT, None)
-        default_dict = check_dict
-
-    def _get_default(key: str, fallback_default: Any = None) -> Any:
-        """Get default value for key."""
-        return user_input.get(key, default_dict.get(key, fallback_default))
-
-    script_default: str | None = _get_default(CONF_NOTIFY_SCRIPT_NAME, NONE_TEXT)
-    if script_default is None:
-        script_default = NONE_TEXT
-    elif script_default != NONE_TEXT and not script_default.startswith("script."):
-        script_default = f"script.{script_default}"
-    _LOGGER.debug("[get_schema] script_default: %s (%s)", script_default, type(script_default))
-    lock_entities = _get_entities(
-        hass=hass,
-        domain=LOCK_DOMAIN,
-        exclude_entities=_get_locks_in_use(hass=hass, exclude=_get_default(CONF_LOCK_ENTITY_ID)),
-        filter_func=is_platform_supported,
-    )
-    if not lock_entities:
-        if flow is not None:
-            return flow.async_abort(reason="no_locks")
-        raise ValueError("No lock entities found")
-    return vol.Schema(
-        {
-            vol.Required(CONF_LOCK_NAME, default=_get_default(CONF_LOCK_NAME)): str,
-            vol.Required(CONF_LOCK_ENTITY_ID, default=_get_default(CONF_LOCK_ENTITY_ID)): vol.In(
-                lock_entities
-            ),
-            vol.Optional(CONF_PARENT, default=_get_default(CONF_PARENT, NONE_TEXT)): vol.In(
-                _available_parent_locks(hass, entry_id)
-            ),
-            vol.Required(CONF_SLOTS, default=_get_default(CONF_SLOTS, DEFAULT_CODE_SLOTS)): vol.All(
-                vol.Coerce(int), vol.Range(min=1)
-            ),
-            vol.Required(CONF_START, default=_get_default(CONF_START, DEFAULT_START)): vol.All(
-                vol.Coerce(int), vol.Range(min=1)
-            ),
-            vol.Optional(
-                CONF_DOOR_SENSOR_ENTITY_ID,
-                default=_get_default(CONF_DOOR_SENSOR_ENTITY_ID, NONE_TEXT),
-            ): vol.In(
-                _get_entities(
-                    hass=hass,
-                    domain=BINARY_DOMAIN,
-                    extra_entities=[NONE_TEXT],
-                )
-            ),
-            vol.Optional(
-                CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
-                default=_get_default(CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID, NONE_TEXT),
-            ): vol.In(
-                _get_entities(
-                    hass=hass,
-                    domain=SENSOR_DOMAIN,
-                    search=["alarm_level", "user_code", "alarmlevel"],
-                    extra_entities=[NONE_TEXT],
-                )
-            ),
-            vol.Optional(
-                CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
-                default=_get_default(
-                    CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
-                    NONE_TEXT,
-                ),
-            ): vol.In(
-                _get_entities(
-                    hass=hass,
-                    domain=SENSOR_DOMAIN,
-                    search=["alarm_type", "access_control", "alarmtype"],
-                    extra_entities=[NONE_TEXT],
-                )
-            ),
-            vol.Optional(
-                CONF_NOTIFY_SCRIPT_NAME,
-                default=script_default,
-            ): vol.In(
-                _get_entities(
-                    hass=hass,
-                    domain=SCRIPT_DOMAIN,
-                    extra_entities=[NONE_TEXT],
-                )
-            ),
-            vol.Required(
-                CONF_ADVANCED_DATE_RANGE,
-                default=_get_default(CONF_ADVANCED_DATE_RANGE, DEFAULT_ADVANCED_DATE_RANGE),
-            ): bool,
-            vol.Required(
-                CONF_ADVANCED_DAY_OF_WEEK,
-                default=_get_default(CONF_ADVANCED_DAY_OF_WEEK, DEFAULT_ADVANCED_DAY_OF_WEEK),
-            ): bool,
-            vol.Required(
-                CONF_HIDE_PINS, default=_get_default(CONF_HIDE_PINS, DEFAULT_HIDE_PINS)
-            ): bool,
-        },
-    )
-
-
 async def _start_config_flow(
     cls: KeymasterConfigFlow,
     step_id: str,
@@ -420,7 +224,7 @@ async def _start_config_flow(
                     )
                 return cls.async_abort(reason="reconfigure_successful")
 
-    data_schema = _get_schema(
+    data_schema = config_flow_schema._get_schema(  # noqa: SLF001
         hass=cls.hass,
         user_input=user_input,
         default_dict=defaults,

--- a/custom_components/keymaster/config_flow_schema.py
+++ b/custom_components/keymaster/config_flow_schema.py
@@ -1,0 +1,266 @@
+"""Schema helpers for keymaster config flow."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, MutableMapping
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_ADVANCED_DATE_RANGE,
+    CONF_ADVANCED_DAY_OF_WEEK,
+    CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
+    CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
+    CONF_DOOR_SENSOR_ENTITY_ID,
+    CONF_HIDE_PINS,
+    CONF_LOCK_ENTITY_ID,
+    CONF_LOCK_NAME,
+    CONF_NOTIFY_SCRIPT_NAME,
+    CONF_PARENT,
+    CONF_SLOTS,
+    CONF_START,
+    COORDINATOR,
+    DEFAULT_ADVANCED_DATE_RANGE,
+    DEFAULT_ADVANCED_DAY_OF_WEEK,
+    DEFAULT_CODE_SLOTS,
+    DEFAULT_HIDE_PINS,
+    DEFAULT_START,
+    DOMAIN,
+    NONE_TEXT,
+)
+from .coordinator import KeymasterCoordinator
+from .providers import is_platform_supported
+
+if TYPE_CHECKING:
+    from .config_flow import KeymasterConfigFlow
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+type DefaultGetter = Callable[..., Any]
+type SchemaFields = dict[Any, Any]
+
+
+def _available_parent_locks(hass: HomeAssistant, entry_id: str | None = None) -> list:
+    """Return other keymaster locks if they are not already a child lock."""
+
+    data: list[str] = [NONE_TEXT]
+    if DOMAIN not in hass.data:
+        return data
+
+    data.extend(
+        [
+            entry.title
+            for entry in hass.config_entries.async_entries(DOMAIN)
+            if entry.entry_id != entry_id
+            and (CONF_PARENT not in entry.data or entry.data[CONF_PARENT] is None)
+        ]
+    )
+    return data
+
+
+def _get_entities(
+    hass: HomeAssistant,
+    domain: str,
+    *,
+    search: list[str] | None = None,
+    extra_entities: list[str] | None = None,
+    exclude_entities: list[str] | None = None,
+    sort: bool = True,
+    filter_func: Callable[[HomeAssistant, str], bool] | None = None,
+) -> list[str]:
+    """Get entities from a domain with optional filtering.
+
+    Args:
+        hass: Home Assistant instance
+        domain: Entity domain (e.g., "lock", "sensor")
+        search: Only include entities whose ID contains one of these strings
+        extra_entities: Additional entity IDs to append to results
+        exclude_entities: Entity IDs to remove from results
+        sort: Whether to sort the results alphabetically
+        filter_func: Optional callback(hass, entity_id) -> bool to filter entities.
+            Entity is included only if filter_func returns True.
+
+    """
+    data: list[str] = []
+    if domain not in hass.data:
+        return extra_entities or []
+
+    for entity in hass.data[domain].entities:
+        # Skip if search terms provided and entity ID doesn't contain any of them
+        if search is not None and not any(map(entity.entity_id.__contains__, search)):
+            continue
+        # Skip if filter function provided and it returns False for this entity
+        if filter_func is not None and not filter_func(hass, entity.entity_id):
+            continue
+        data.append(entity.entity_id)
+
+    if extra_entities:
+        data.extend(extra_entities)
+
+    if exclude_entities:
+        for ent in exclude_entities:
+            if ent in data:
+                data.remove(ent)
+    if sort:
+        data.sort()
+
+    return data
+
+
+def _get_locks_in_use(hass: HomeAssistant, exclude: str | None = None) -> list[str]:
+    """Return lock entity IDs already managed by keymaster."""
+    if DOMAIN not in hass.data or COORDINATOR not in hass.data[DOMAIN]:
+        return []
+    data: list[str] = []
+    coordinator: KeymasterCoordinator = hass.data[DOMAIN][COORDINATOR]
+    data.extend([kmlock.lock_entity_id for kmlock in coordinator.data.values()])
+    if exclude and exclude in data:
+        data.remove(exclude)
+
+    return data
+
+
+def _core_schema_fields(
+    hass: HomeAssistant,
+    entry_id: str | None,
+    get_default: DefaultGetter,
+    lock_entities: list[str],
+) -> SchemaFields:
+    """Return core config flow schema fields."""
+    return {
+        vol.Required(CONF_LOCK_NAME, default=get_default(CONF_LOCK_NAME)): str,
+        vol.Required(CONF_LOCK_ENTITY_ID, default=get_default(CONF_LOCK_ENTITY_ID)): vol.In(
+            lock_entities
+        ),
+        vol.Optional(CONF_PARENT, default=get_default(CONF_PARENT, NONE_TEXT)): vol.In(
+            _available_parent_locks(hass, entry_id)
+        ),
+        vol.Required(CONF_SLOTS, default=get_default(CONF_SLOTS, DEFAULT_CODE_SLOTS)): vol.All(
+            vol.Coerce(int), vol.Range(min=1)
+        ),
+        vol.Required(CONF_START, default=get_default(CONF_START, DEFAULT_START)): vol.All(
+            vol.Coerce(int), vol.Range(min=1)
+        ),
+    }
+
+
+def _entity_schema_fields(
+    hass: HomeAssistant,
+    get_default: DefaultGetter,
+    script_default: str,
+) -> SchemaFields:
+    """Return entity selector config flow schema fields."""
+    return {
+        vol.Optional(
+            CONF_DOOR_SENSOR_ENTITY_ID,
+            default=get_default(CONF_DOOR_SENSOR_ENTITY_ID, NONE_TEXT),
+        ): vol.In(
+            _get_entities(
+                hass=hass,
+                domain=BINARY_DOMAIN,
+                extra_entities=[NONE_TEXT],
+            )
+        ),
+        vol.Optional(
+            CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
+            default=get_default(CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID, NONE_TEXT),
+        ): vol.In(
+            _get_entities(
+                hass=hass,
+                domain=SENSOR_DOMAIN,
+                search=["alarm_level", "user_code", "alarmlevel"],
+                extra_entities=[NONE_TEXT],
+            )
+        ),
+        vol.Optional(
+            CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
+            default=get_default(
+                CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
+                NONE_TEXT,
+            ),
+        ): vol.In(
+            _get_entities(
+                hass=hass,
+                domain=SENSOR_DOMAIN,
+                search=["alarm_type", "access_control", "alarmtype"],
+                extra_entities=[NONE_TEXT],
+            )
+        ),
+        vol.Optional(
+            CONF_NOTIFY_SCRIPT_NAME,
+            default=script_default,
+        ): vol.In(
+            _get_entities(
+                hass=hass,
+                domain=SCRIPT_DOMAIN,
+                extra_entities=[NONE_TEXT],
+            )
+        ),
+    }
+
+
+def _advanced_schema_fields(get_default: DefaultGetter) -> SchemaFields:
+    """Return advanced config flow schema fields."""
+    return {
+        vol.Required(
+            CONF_ADVANCED_DATE_RANGE,
+            default=get_default(CONF_ADVANCED_DATE_RANGE, DEFAULT_ADVANCED_DATE_RANGE),
+        ): bool,
+        vol.Required(
+            CONF_ADVANCED_DAY_OF_WEEK,
+            default=get_default(CONF_ADVANCED_DAY_OF_WEEK, DEFAULT_ADVANCED_DAY_OF_WEEK),
+        ): bool,
+        vol.Required(CONF_HIDE_PINS, default=get_default(CONF_HIDE_PINS, DEFAULT_HIDE_PINS)): bool,
+    }
+
+
+def _get_schema(
+    hass: HomeAssistant,
+    user_input: MutableMapping[str, Any] | None,
+    default_dict: MutableMapping[str, Any],
+    entry_id: str | None = None,
+    flow: KeymasterConfigFlow | None = None,
+) -> vol.Schema | ConfigFlowResult:
+    """Get a schema using the default_dict as a backup."""
+    if user_input is None:
+        user_input = {}
+
+    if CONF_PARENT in default_dict and default_dict[CONF_PARENT] is None:
+        check_dict: MutableMapping[str, Any] = dict(default_dict).copy()
+        check_dict.pop(CONF_PARENT, None)
+        default_dict = check_dict
+
+    def _get_default(key: str, fallback_default: Any = None) -> Any:
+        """Get default value for key."""
+        return user_input.get(key, default_dict.get(key, fallback_default))
+
+    script_default: str | None = _get_default(CONF_NOTIFY_SCRIPT_NAME, NONE_TEXT)
+    if script_default is None:
+        script_default = NONE_TEXT
+    elif script_default != NONE_TEXT and not script_default.startswith("script."):
+        script_default = f"script.{script_default}"
+    _LOGGER.debug("[get_schema] script_default: %s (%s)", script_default, type(script_default))
+    lock_entities = _get_entities(
+        hass=hass,
+        domain=LOCK_DOMAIN,
+        exclude_entities=_get_locks_in_use(hass=hass, exclude=_get_default(CONF_LOCK_ENTITY_ID)),
+        filter_func=is_platform_supported,
+    )
+    if not lock_entities:
+        if flow is not None:
+            return flow.async_abort(reason="no_locks")
+        raise ValueError("No lock entities found")
+
+    schema_fields = _core_schema_fields(hass, entry_id, _get_default, lock_entities)
+    schema_fields.update(_entity_schema_fields(hass, _get_default, script_default))
+    schema_fields.update(_advanced_schema_fields(_get_default))
+    return vol.Schema(schema_fields)

--- a/custom_components/keymaster/config_flow_schema.py
+++ b/custom_components/keymaster/config_flow_schema.py
@@ -45,11 +45,11 @@ if TYPE_CHECKING:
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
-type DefaultGetter = Callable[..., Any]
-type SchemaFields = dict[Any, Any]
+DefaultGetter = Callable[..., Any]
+SchemaFields = dict[Any, Any]
 
 
-def _available_parent_locks(hass: HomeAssistant, entry_id: str | None = None) -> list:
+def _available_parent_locks(hass: HomeAssistant, entry_id: str | None = None) -> list[str]:
     """Return other keymaster locks if they are not already a child lock."""
 
     data: list[str] = [NONE_TEXT]

--- a/custom_components/keymaster/config_flow_schema.py
+++ b/custom_components/keymaster/config_flow_schema.py
@@ -67,7 +67,7 @@ def _available_parent_locks(hass: HomeAssistant, entry_id: str | None = None) ->
     return data
 
 
-def _get_entities(
+def get_entities(
     hass: HomeAssistant,
     domain: str,
     *,
@@ -164,7 +164,7 @@ def _entity_schema_fields(
             CONF_DOOR_SENSOR_ENTITY_ID,
             default=get_default(CONF_DOOR_SENSOR_ENTITY_ID, NONE_TEXT),
         ): vol.In(
-            _get_entities(
+            get_entities(
                 hass=hass,
                 domain=BINARY_DOMAIN,
                 extra_entities=[NONE_TEXT],
@@ -174,7 +174,7 @@ def _entity_schema_fields(
             CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
             default=get_default(CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID, NONE_TEXT),
         ): vol.In(
-            _get_entities(
+            get_entities(
                 hass=hass,
                 domain=SENSOR_DOMAIN,
                 search=["alarm_level", "user_code", "alarmlevel"],
@@ -188,7 +188,7 @@ def _entity_schema_fields(
                 NONE_TEXT,
             ),
         ): vol.In(
-            _get_entities(
+            get_entities(
                 hass=hass,
                 domain=SENSOR_DOMAIN,
                 search=["alarm_type", "access_control", "alarmtype"],
@@ -199,7 +199,7 @@ def _entity_schema_fields(
             CONF_NOTIFY_SCRIPT_NAME,
             default=script_default,
         ): vol.In(
-            _get_entities(
+            get_entities(
                 hass=hass,
                 domain=SCRIPT_DOMAIN,
                 extra_entities=[NONE_TEXT],
@@ -223,7 +223,7 @@ def _advanced_schema_fields(get_default: DefaultGetter) -> SchemaFields:
     }
 
 
-def _get_schema(
+def get_schema(
     hass: HomeAssistant,
     user_input: MutableMapping[str, Any] | None,
     default_dict: MutableMapping[str, Any],
@@ -249,7 +249,7 @@ def _get_schema(
     elif script_default != NONE_TEXT and not script_default.startswith("script."):
         script_default = f"script.{script_default}"
     _LOGGER.debug("[get_schema] script_default: %s (%s)", script_default, type(script_default))
-    lock_entities = _get_entities(
+    lock_entities = get_entities(
         hass=hass,
         domain=LOCK_DOMAIN,
         exclude_entities=_get_locks_in_use(hass=hass, exclude=_get_default(CONF_LOCK_ENTITY_ID)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,7 +167,7 @@ async def auto_unload(hass: HomeAssistant):
 def mock_get_entities():
     """Mock available entities."""
     with patch(
-        "custom_components.keymaster.config_flow_schema._get_entities",
+        "custom_components.keymaster.config_flow_schema.get_entities",
         autospec=True,
     ) as mock_entities:
         mock_entities.side_effect = side_effect_get_entities

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,7 +167,7 @@ async def auto_unload(hass: HomeAssistant):
 def mock_get_entities():
     """Mock available entities."""
     with patch(
-        "custom_components.keymaster.config_flow._get_entities",
+        "custom_components.keymaster.config_flow_schema._get_entities",
         autospec=True,
     ) as mock_entities:
         mock_entities.side_effect = side_effect_get_entities

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,7 +8,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 import voluptuous as vol
 
-from custom_components.keymaster.config_flow_schema import _get_entities, _get_schema
+from custom_components.keymaster.config_flow_schema import get_entities, get_schema
 from custom_components.keymaster.const import (
     CONF_ADVANCED_DATE_RANGE,
     CONF_ADVANCED_DAY_OF_WEEK,
@@ -43,7 +43,7 @@ pytestmark = pytest.mark.asyncio
 
 async def test_no_locks_abort(hass):
     """Test the flow aborts when no locks are available."""
-    with patch("custom_components.keymaster.config_flow_schema._get_entities", return_value=[]):
+    with patch("custom_components.keymaster.config_flow_schema.get_entities", return_value=[]):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -113,7 +113,7 @@ async def test_form(test_user_input, title, final_config_flow_data, hass, mock_g
 
 async def test_get_schema_preserves_field_order_and_markers(hass, mock_get_entities):
     """Test config flow schema fields keep their UI order and marker type."""
-    schema = _get_schema(
+    schema = get_schema(
         hass=hass,
         user_input=None,
         default_dict={
@@ -161,10 +161,10 @@ async def test_get_schema_preserves_field_order_and_markers(hass, mock_get_entit
 async def test_get_schema_raises_without_flow_when_no_locks(hass):
     """Test schema generation raises without a flow when no locks are available."""
     with (
-        patch("custom_components.keymaster.config_flow_schema._get_entities", return_value=[]),
+        patch("custom_components.keymaster.config_flow_schema.get_entities", return_value=[]),
         pytest.raises(ValueError, match="No lock entities found"),
     ):
-        _get_schema(
+        get_schema(
             hass=hass,
             user_input=None,
             default_dict={CONF_NOTIFY_SCRIPT_NAME: None},
@@ -182,7 +182,7 @@ async def test_get_entities_filters_excludes_and_sorts(hass):
         ]
     )
 
-    assert _get_entities(
+    assert get_entities(
         hass,
         "test_domain",
         search=["keep"],
@@ -190,7 +190,7 @@ async def test_get_entities_filters_excludes_and_sorts(hass):
         exclude_entities=["test.keep_z"],
         filter_func=lambda _, entity_id: not entity_id.endswith("blocked"),
     ) == ["test.extra", "test.keep_a"]
-    assert _get_entities(hass, "missing_domain", extra_entities=["test.extra"]) == ["test.extra"]
+    assert get_entities(hass, "missing_domain", extra_entities=["test.extra"]) == ["test.extra"]
 
 
 @pytest.mark.parametrize(
@@ -424,10 +424,10 @@ async def test_get_entities(hass):
 
     assert state.state == LockState.UNLOCKED
 
-    assert KWIKSET_910_LOCK_ENTITY in _get_entities(
+    assert KWIKSET_910_LOCK_ENTITY in get_entities(
         hass, LOCK_DOMAIN, extra_entities=["lock.fake"], exclude_entities=["lock.fake"]
     )
-    assert "(none)" in _get_entities(hass, SCRIPT_DOMAIN, extra_entities=[NONE_TEXT])
+    assert "(none)" in get_entities(hass, SCRIPT_DOMAIN, extra_entities=[NONE_TEXT])
 
 
 async def test_options_flow(hass):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,12 +1,14 @@
 """Test keymaster config flow."""
 
 import logging
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+import voluptuous as vol
 
-from custom_components.keymaster.config_flow import _get_entities
+from custom_components.keymaster.config_flow_schema import _get_entities, _get_schema
 from custom_components.keymaster.const import (
     CONF_ADVANCED_DATE_RANGE,
     CONF_ADVANCED_DAY_OF_WEEK,
@@ -41,7 +43,7 @@ pytestmark = pytest.mark.asyncio
 
 async def test_no_locks_abort(hass):
     """Test the flow aborts when no locks are available."""
-    with patch("custom_components.keymaster.config_flow._get_entities", return_value=[]):
+    with patch("custom_components.keymaster.config_flow_schema._get_entities", return_value=[]):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -82,8 +84,7 @@ async def test_no_locks_abort(hass):
         )
     ],
 )
-@pytest.mark.usefixtures("mock_get_entities")
-async def test_form(test_user_input, title, final_config_flow_data, hass):
+async def test_form(test_user_input, title, final_config_flow_data, hass, mock_get_entities):
     """Test we get the form."""
 
     _LOGGER.warning("[test_form] result Starting")
@@ -94,6 +95,7 @@ async def test_form(test_user_input, title, final_config_flow_data, hass):
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {}
+    mock_get_entities.assert_called()
 
     with patch(
         "custom_components.keymaster.async_setup_entry", return_value=True
@@ -107,6 +109,88 @@ async def test_form(test_user_input, title, final_config_flow_data, hass):
 
         await hass.async_block_till_done()
         assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_get_schema_preserves_field_order_and_markers(hass, mock_get_entities):
+    """Test config flow schema fields keep their UI order and marker type."""
+    schema = _get_schema(
+        hass=hass,
+        user_input=None,
+        default_dict={
+            CONF_LOCK_NAME: "frontdoor",
+            CONF_LOCK_ENTITY_ID: "lock.kwikset_touchpad_electronic_deadbolt_frontdoor",
+            CONF_SLOTS: 6,
+            CONF_START: 1,
+            CONF_NOTIFY_SCRIPT_NAME: "keymaster_frontdoor_manual_notify",
+        },
+    )
+
+    assert isinstance(schema, vol.Schema)
+    fields = list(schema.schema)
+    assert [field.schema for field in fields] == [
+        CONF_LOCK_NAME,
+        CONF_LOCK_ENTITY_ID,
+        CONF_PARENT,
+        CONF_SLOTS,
+        CONF_START,
+        CONF_DOOR_SENSOR_ENTITY_ID,
+        CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
+        CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
+        CONF_NOTIFY_SCRIPT_NAME,
+        CONF_ADVANCED_DATE_RANGE,
+        CONF_ADVANCED_DAY_OF_WEEK,
+        CONF_HIDE_PINS,
+    ]
+    assert [type(field) for field in fields] == [
+        vol.Required,
+        vol.Required,
+        vol.Optional,
+        vol.Required,
+        vol.Required,
+        vol.Optional,
+        vol.Optional,
+        vol.Optional,
+        vol.Optional,
+        vol.Required,
+        vol.Required,
+        vol.Required,
+    ]
+    mock_get_entities.assert_called()
+
+
+async def test_get_schema_raises_without_flow_when_no_locks(hass):
+    """Test schema generation raises without a flow when no locks are available."""
+    with (
+        patch("custom_components.keymaster.config_flow_schema._get_entities", return_value=[]),
+        pytest.raises(ValueError, match="No lock entities found"),
+    ):
+        _get_schema(
+            hass=hass,
+            user_input=None,
+            default_dict={CONF_NOTIFY_SCRIPT_NAME: None},
+        )
+
+
+async def test_get_entities_filters_excludes_and_sorts(hass):
+    """Test entity lookup search, callback filtering, exclusion, extras, and sorting."""
+    hass.data["test_domain"] = SimpleNamespace(
+        entities=[
+            SimpleNamespace(entity_id="test.keep_z"),
+            SimpleNamespace(entity_id="test.drop"),
+            SimpleNamespace(entity_id="test.keep_blocked"),
+            SimpleNamespace(entity_id="test.keep_a"),
+        ]
+    )
+
+    assert _get_entities(
+        hass,
+        "test_domain",
+        search=["keep"],
+        extra_entities=["test.extra"],
+        exclude_entities=["test.keep_z"],
+        filter_func=lambda _, entity_id: not entity_id.endswith("blocked"),
+    ) == ["test.extra", "test.keep_a"]
+    assert _get_entities(hass, "missing_domain", extra_entities=["test.extra"]) == ["test.extra"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary

Refactors the keymaster config flow schema construction for one of the
issue #772 aislop items. The config flow schema and entity lookup helpers
now live in `custom_components/keymaster/config_flow_schema.py`, keeping the
flow classes and step handling in `config_flow.py`.

## Proposed change

In-place extraction was not viable because `config_flow.py` was within five
lines of aislop's `complexity/file-too-large` threshold. Moving the schema
building code to a new module provides room to decompose `_get_schema`
without trading the existing function-length finding for a new file-size
finding.

The new module splits the schema literal into ordered core, entity selector,
and advanced field builders. The builders are merged in the original order so
Home Assistant renders the config-flow UI fields in the same sequence, and a
new test pins both the field order and each `vol.Required`/`vol.Optional`
marker.

The shared `mock_get_entities` fixture and config-flow tests were retargeted
to patch `custom_components.keymaster.config_flow_schema.get_entities`, with
an assertion proving the fixture still intercepts schema generation.

A follow-up commit promotes `get_schema` and `get_entities` as the public
cross-module API for `config_flow_schema.py`, removing the `SLF001`
suppressions from `config_flow.py` while keeping module-internal helpers
private.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #772
