### PR TITLE
test: assert deleted code slot entity removal

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -166,18 +166,18 @@ async def test_delete_code_slot_entities(hass):
     code_slot_num = 1
 
     # Create some entities to delete
-    entity_registry.async_get_or_create(
+    entity = entity_registry.async_get_or_create(
         "binary_sensor",
         DOMAIN,
         f"{config_entry_id}_binary_sensor_code_slots_{code_slot_num}_active",
         suggested_object_id=f"code_slots_{code_slot_num}_active",
     )
+    assert entity_registry.async_get(entity.entity_id) is not None
 
     # Delete entities
     await delete_code_slot_entities(hass, config_entry_id, code_slot_num)
 
-    # Verify it didn't crash
-    assert True
+    assert entity_registry.async_get(entity.entity_id) is None
 
 
 async def test_delete_code_slot_entities_removes_all(hass):


### PR DESCRIPTION
# Summary

Replaces the tautological assertion in the helper test for deleting code slot
entities with registry assertions that verify the created entity exists before
the delete call and is removed afterward.

## Proposed change

The test now captures the entity registry entry created for the code slot binary
sensor, asserts it is registered before deletion, calls
`delete_code_slot_entities`, and asserts the entity no longer resolves in the
registry.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #780
- This PR is related to issue:
