### PR TITLE
test: cover self-referential parent entry guard

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -3,21 +3,20 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import MutableMapping
 from datetime import datetime as dt, timedelta
 import functools
 import logging
 from pathlib import Path
 import sys
+from typing import TYPE_CHECKING
 
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.core_config import Config
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.event import async_call_later
-from homeassistant.util import slugify
 
 from .const import (
     CONF_ADVANCED_DATE_RANGE,
@@ -27,33 +26,22 @@ from .const import (
     CONF_ALARM_TYPE,
     CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
     CONF_CHILD_LOCKS_FILE,
-    CONF_DOOR_SENSOR_ENTITY_ID,
     CONF_ENTITY_ID,
     CONF_HIDE_PINS,
     CONF_LOCK_ENTITY_ID,
     CONF_LOCK_NAME,
-    CONF_NOTIFY_SCRIPT_NAME,
-    CONF_PARENT,
-    CONF_PARENT_ENTRY_ID,
-    CONF_REDACT_PIN_CODES,
-    CONF_REDACT_SLOT_NAMES,
-    CONF_SLOTS,
-    CONF_START,
     COORDINATOR,
-    DAY_NAMES,
     DEFAULT_ADVANCED_DATE_RANGE,
     DEFAULT_ADVANCED_DAY_OF_WEEK,
     DEFAULT_HIDE_PINS,
-    DEFAULT_REDACT_PIN_CODES,
-    DEFAULT_REDACT_SLOT_NAMES,
     DOMAIN,
     LOCK_COORDINATORS,
-    NORMALIZED_TO_NONE_SENTINELS,
     PLATFORMS,
     STRATEGY_FILENAME,
     STRATEGY_PATH,
 )
 from .coordinator import KeymasterCoordinator
+from .entry_setup import async_get_or_create_device, build_kmlock, normalize_config_data
 from .helpers import (
     async_clear_large_lock_ack,
     async_delete_large_lock_repair_issue,
@@ -61,12 +49,14 @@ from .helpers import (
     async_update_all_large_lock_repair_issues,
     async_update_large_lock_repair_issue,
 )
-from .lock import KeymasterCodeSlot, KeymasterCodeSlotDayOfWeek, KeymasterLock
 from .lovelace import KeymasterLovelaceSpec, async_generate_lovelace
 from .migrate import migrate_2to3
 from .resources import async_cleanup_strategy_resource, async_register_strategy_resource
 from .services import async_setup_services
 from .websocket import async_setup as async_websocket_setup
+
+if TYPE_CHECKING:
+    from .lock import KeymasterLock
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -114,96 +104,64 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     return True
 
 
-@callback
-def _async_get_or_create_device(
-    device_registry: dr.DeviceRegistry, config_entry: ConfigEntry
+async def _async_get_or_create_coordinator(hass: HomeAssistant) -> KeymasterCoordinator:
+    """Create or retrieve the shared keymaster coordinator."""
+    if COORDINATOR in hass.data[DOMAIN]:
+        return hass.data[DOMAIN][COORDINATOR]
+
+    coordinator: KeymasterCoordinator = KeymasterCoordinator(hass)
+    hass.data[DOMAIN][COORDINATOR] = coordinator
+    setup_success = True
+    try:
+        await coordinator.initial_setup()
+        await coordinator.async_refresh()
+        setup_success = coordinator.last_update_success
+    except Exception as err:
+        hass.data[DOMAIN].pop(COORDINATOR, None)
+        if isinstance(err, ConfigEntryNotReady | TypeError | AttributeError):
+            raise
+        raise ConfigEntryNotReady(f"Error during initial setup: {err}") from err
+
+    if not setup_success:
+        hass.data[DOMAIN].pop(COORDINATOR, None)
+        raise ConfigEntryNotReady from coordinator.last_exception
+
+    return coordinator
+
+
+async def _async_apply_large_lock_repairs(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    kmlock: KeymasterLock,
 ) -> None:
-    """Register or get the device entry in the device registry."""
-    if hasattr(device_registry, "async_get_device_by_identifier"):
-        # Home Assistant 2026.8+ supports via_device_id
-        if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
-            if parent_device := device_registry.async_get_device_by_identifier(
-                (DOMAIN, parent_entry_id),
-                config_entry_id=parent_entry_id,
-            ):
-                device_registry.async_get_or_create(
-                    config_entry_id=config_entry.entry_id,
-                    identifiers={(DOMAIN, config_entry.entry_id)},
-                    name=config_entry.data.get(CONF_LOCK_NAME),
-                    configuration_url="https://github.com/FutureTense/keymaster",
-                    via_device_id=parent_device.id,
-                )
-            else:
-                # Parent device not registered yet; leave any existing link intact
-                _LOGGER.debug(
-                    "[init] Parent device for entry %s not registered yet; skipping via_device_id",
-                    parent_entry_id,
-                )
-                device_registry.async_get_or_create(
-                    config_entry_id=config_entry.entry_id,
-                    identifiers={(DOMAIN, config_entry.entry_id)},
-                    name=config_entry.data.get(CONF_LOCK_NAME),
-                    configuration_url="https://github.com/FutureTense/keymaster",
-                )
-        else:
-            # Genuinely parentless; explicitly clear any stale via link
-            device_registry.async_get_or_create(
-                config_entry_id=config_entry.entry_id,
-                identifiers={(DOMAIN, config_entry.entry_id)},
-                name=config_entry.data.get(CONF_LOCK_NAME),
-                configuration_url="https://github.com/FutureTense/keymaster",
-                via_device_id=None,
-            )
-    else:
-        # Fallback for earlier Home Assistant versions
-        via_device: tuple[str, str] | None = None
-        if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
-            via_device = (DOMAIN, parent_entry_id)
-        device_registry.async_get_or_create(
-            config_entry_id=config_entry.entry_id,
-            identifiers={(DOMAIN, config_entry.entry_id)},
-            name=config_entry.data.get(CONF_LOCK_NAME),
-            configuration_url="https://github.com/FutureTense/keymaster",
-            via_device=via_device,
+    """Update large-lock repair issues for a keymaster lock setup."""
+    try:
+        await async_load_large_lock_ack_store(hass)
+        supports_connection_status = True
+        if kmlock.provider:
+            supports_connection_status = kmlock.provider.supports_connection_status
+        await async_update_large_lock_repair_issue(
+            hass,
+            config_entry,
+            supports_connection_status=supports_connection_status,
         )
+    except Exception:
+        _LOGGER.exception(
+            "Failed to update large-lock repair issue for %s",
+            config_entry.entry_id,
+        )
+
+    if not hass.data[DOMAIN].get(_LARGE_LOCK_REPAIR_SWEEP_DONE):
+        hass.data[DOMAIN][_LARGE_LOCK_REPAIR_SWEEP_DONE] = True
+        try:
+            await async_update_all_large_lock_repair_issues(hass)
+        except Exception:
+            _LOGGER.exception("Failed to update large-lock repair issues during setup sweep")
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up is called when Home Assistant is loading our component."""
-    updated_config = config_entry.data.copy()
-
-    for prop in (
-        CONF_PARENT,
-        CONF_NOTIFY_SCRIPT_NAME,
-        CONF_DOOR_SENSOR_ENTITY_ID,
-        CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
-        CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
-    ):
-        if config_entry.data.get(prop) in NORMALIZED_TO_NONE_SENTINELS:
-            updated_config[prop] = None
-
-    if config_entry.data.get(CONF_PARENT_ENTRY_ID) == config_entry.entry_id:
-        updated_config[CONF_PARENT_ENTRY_ID] = None
-
-    if updated_config.get(CONF_PARENT) is None:
-        updated_config[CONF_PARENT_ENTRY_ID] = None
-    elif updated_config.get(CONF_PARENT_ENTRY_ID) is None:
-        for entry in hass.config_entries.async_entries(DOMAIN):
-            if updated_config.get(CONF_PARENT) in (entry.title, entry.data.get(CONF_LOCK_NAME)):
-                updated_config[CONF_PARENT_ENTRY_ID] = entry.entry_id
-                break
-
-    if not updated_config.get(CONF_NOTIFY_SCRIPT_NAME):
-        updated_config[CONF_NOTIFY_SCRIPT_NAME] = (
-            f"keymaster_{slugify(updated_config.get(CONF_LOCK_NAME, ''))}_manual_notify"
-        )
-    elif isinstance(updated_config.get(CONF_NOTIFY_SCRIPT_NAME), str) and updated_config[
-        CONF_NOTIFY_SCRIPT_NAME
-    ].startswith("script."):
-        updated_config[CONF_NOTIFY_SCRIPT_NAME] = updated_config[CONF_NOTIFY_SCRIPT_NAME].split(
-            ".", maxsplit=1
-        )[1]
-
+    updated_config = normalize_config_data(hass, config_entry)
     if updated_config != config_entry.data:
         hass.config_entries.async_update_entry(config_entry, data=updated_config)
 
@@ -212,67 +170,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     await async_setup_services(hass)
     await async_register_strategy_resource(hass)
 
-    if COORDINATOR not in hass.data[DOMAIN]:
-        coordinator: KeymasterCoordinator = KeymasterCoordinator(hass)
-        hass.data[DOMAIN][COORDINATOR] = coordinator
-        setup_success = True
-        try:
-            await coordinator.initial_setup()
-            await coordinator.async_refresh()
-            setup_success = coordinator.last_update_success
-        except Exception as err:
-            hass.data[DOMAIN].pop(COORDINATOR, None)
-            if isinstance(err, ConfigEntryNotReady | TypeError | AttributeError):
-                raise
-            raise ConfigEntryNotReady(f"Error during initial setup: {err}") from err
-
-        if not setup_success:
-            hass.data[DOMAIN].pop(COORDINATOR, None)
-            raise ConfigEntryNotReady from coordinator.last_exception
-    else:
-        coordinator = hass.data[DOMAIN][COORDINATOR]
+    coordinator = await _async_get_or_create_coordinator(hass)
 
     device_registry = dr.async_get(hass)
-    _async_get_or_create_device(device_registry, config_entry)
+    async_get_or_create_device(device_registry, config_entry)
 
     # _LOGGER.debug(f"[init async_setup_entry] device: {device}")
 
-    code_slots: MutableMapping[int, KeymasterCodeSlot] = {}
-    for x in range(
-        config_entry.data[CONF_START],
-        config_entry.data[CONF_START] + config_entry.data[CONF_SLOTS],
-    ):
-        dow_slots: MutableMapping[int, KeymasterCodeSlotDayOfWeek] = {}
-        for i, dow in enumerate(DAY_NAMES):
-            dow_slots[i] = KeymasterCodeSlotDayOfWeek(day_of_week_num=i, day_of_week_name=dow)
-        code_slots[x] = KeymasterCodeSlot(number=x, accesslimit_day_of_week=dow_slots)
-
-    kmlock = KeymasterLock(
-        lock_name=config_entry.data[CONF_LOCK_NAME],
-        lock_entity_id=config_entry.data[CONF_LOCK_ENTITY_ID],
-        keymaster_config_entry_id=config_entry.entry_id,
-        alarm_level_or_user_code_entity_id=config_entry.data.get(
-            CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID
-        ),
-        alarm_type_or_access_control_entity_id=config_entry.data.get(
-            CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID
-        ),
-        door_sensor_entity_id=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
-        number_of_code_slots=config_entry.data[CONF_SLOTS],
-        starting_code_slot=config_entry.data[CONF_START],
-        code_slots=code_slots,
-        parent_name=config_entry.data.get(CONF_PARENT),
-        parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
-        notify_script_name=config_entry.data.get(CONF_NOTIFY_SCRIPT_NAME),
-        redact_slot_names=config_entry.options.get(
-            CONF_REDACT_SLOT_NAMES,
-            config_entry.data.get(CONF_REDACT_SLOT_NAMES, DEFAULT_REDACT_SLOT_NAMES),
-        ),
-        redact_pin_codes=config_entry.options.get(
-            CONF_REDACT_PIN_CODES,
-            config_entry.data.get(CONF_REDACT_PIN_CODES, DEFAULT_REDACT_PIN_CODES),
-        ),
-    )
+    kmlock = build_kmlock(config_entry)
 
     needs_update = config_entry.entry_id in coordinator.kmlocks
     try:
@@ -286,29 +191,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         hass.data[DOMAIN].setdefault(LOCK_COORDINATORS, {})[config_entry.entry_id] = (
             lock_coordinator
         )
-
-        try:
-            await async_load_large_lock_ack_store(hass)
-            supports_connection_status = True
-            if kmlock.provider:
-                supports_connection_status = kmlock.provider.supports_connection_status
-            await async_update_large_lock_repair_issue(
-                hass,
-                config_entry,
-                supports_connection_status=supports_connection_status,
-            )
-        except Exception:
-            _LOGGER.exception(
-                "Failed to update large-lock repair issue for %s",
-                config_entry.entry_id,
-            )
-
-        if not hass.data[DOMAIN].get(_LARGE_LOCK_REPAIR_SWEEP_DONE):
-            hass.data[DOMAIN][_LARGE_LOCK_REPAIR_SWEEP_DONE] = True
-            try:
-                await async_update_all_large_lock_repair_issues(hass)
-            except Exception:
-                _LOGGER.exception("Failed to update large-lock repair issues during setup sweep")
+        await _async_apply_large_lock_repairs(hass, config_entry, kmlock)
 
         await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
         await async_generate_lovelace(

--- a/custom_components/keymaster/entry_setup.py
+++ b/custom_components/keymaster/entry_setup.py
@@ -56,6 +56,8 @@ def normalize_config_data(hass: HomeAssistant, config_entry: ConfigEntry) -> dic
         updated_config[CONF_PARENT_ENTRY_ID] = None
     elif updated_config.get(CONF_PARENT_ENTRY_ID) is None:
         for entry in hass.config_entries.async_entries(DOMAIN):
+            if entry.entry_id == config_entry.entry_id:
+                continue
             if updated_config.get(CONF_PARENT) in (entry.title, entry.data.get(CONF_LOCK_NAME)):
                 updated_config[CONF_PARENT_ENTRY_ID] = entry.entry_id
                 break

--- a/custom_components/keymaster/entry_setup.py
+++ b/custom_components/keymaster/entry_setup.py
@@ -1,0 +1,168 @@
+"""Helpers for setting up keymaster config entries."""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.util import slugify
+
+from .const import (
+    CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
+    CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
+    CONF_DOOR_SENSOR_ENTITY_ID,
+    CONF_LOCK_ENTITY_ID,
+    CONF_LOCK_NAME,
+    CONF_NOTIFY_SCRIPT_NAME,
+    CONF_PARENT,
+    CONF_PARENT_ENTRY_ID,
+    CONF_REDACT_PIN_CODES,
+    CONF_REDACT_SLOT_NAMES,
+    CONF_SLOTS,
+    CONF_START,
+    DAY_NAMES,
+    DEFAULT_REDACT_PIN_CODES,
+    DEFAULT_REDACT_SLOT_NAMES,
+    DOMAIN,
+    NORMALIZED_TO_NONE_SENTINELS,
+)
+from .lock import KeymasterCodeSlot, KeymasterCodeSlotDayOfWeek, KeymasterLock
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def normalize_config_data(hass: HomeAssistant, config_entry: ConfigEntry) -> dict[str, Any]:
+    """Normalize config entry data before setting up a keymaster lock."""
+    updated_config = config_entry.data.copy()
+
+    for prop in (
+        CONF_PARENT,
+        CONF_NOTIFY_SCRIPT_NAME,
+        CONF_DOOR_SENSOR_ENTITY_ID,
+        CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID,
+        CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID,
+    ):
+        if config_entry.data.get(prop) in NORMALIZED_TO_NONE_SENTINELS:
+            updated_config[prop] = None
+
+    if config_entry.data.get(CONF_PARENT_ENTRY_ID) == config_entry.entry_id:
+        updated_config[CONF_PARENT_ENTRY_ID] = None
+
+    if updated_config.get(CONF_PARENT) is None:
+        updated_config[CONF_PARENT_ENTRY_ID] = None
+    elif updated_config.get(CONF_PARENT_ENTRY_ID) is None:
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if updated_config.get(CONF_PARENT) in (entry.title, entry.data.get(CONF_LOCK_NAME)):
+                updated_config[CONF_PARENT_ENTRY_ID] = entry.entry_id
+                break
+
+    if not updated_config.get(CONF_NOTIFY_SCRIPT_NAME):
+        updated_config[CONF_NOTIFY_SCRIPT_NAME] = (
+            f"keymaster_{slugify(updated_config.get(CONF_LOCK_NAME, ''))}_manual_notify"
+        )
+    elif isinstance(updated_config.get(CONF_NOTIFY_SCRIPT_NAME), str) and updated_config[
+        CONF_NOTIFY_SCRIPT_NAME
+    ].startswith("script."):
+        updated_config[CONF_NOTIFY_SCRIPT_NAME] = updated_config[CONF_NOTIFY_SCRIPT_NAME].split(
+            ".", maxsplit=1
+        )[1]
+
+    return updated_config
+
+
+@callback
+def async_get_or_create_device(
+    device_registry: dr.DeviceRegistry, config_entry: ConfigEntry
+) -> None:
+    """Register or get the device entry in the device registry."""
+    if hasattr(device_registry, "async_get_device_by_identifier"):
+        # Home Assistant 2026.8+ supports via_device_id
+        if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
+            if parent_device := device_registry.async_get_device_by_identifier(
+                (DOMAIN, parent_entry_id),
+                config_entry_id=parent_entry_id,
+            ):
+                device_registry.async_get_or_create(
+                    config_entry_id=config_entry.entry_id,
+                    identifiers={(DOMAIN, config_entry.entry_id)},
+                    name=config_entry.data.get(CONF_LOCK_NAME),
+                    configuration_url="https://github.com/FutureTense/keymaster",
+                    via_device_id=parent_device.id,
+                )
+            else:
+                # Parent device not registered yet; leave any existing link intact
+                _LOGGER.debug(
+                    "[init] Parent device for entry %s not registered yet; skipping via_device_id",
+                    parent_entry_id,
+                )
+                device_registry.async_get_or_create(
+                    config_entry_id=config_entry.entry_id,
+                    identifiers={(DOMAIN, config_entry.entry_id)},
+                    name=config_entry.data.get(CONF_LOCK_NAME),
+                    configuration_url="https://github.com/FutureTense/keymaster",
+                )
+        else:
+            # Genuinely parentless; explicitly clear any stale via link
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry.entry_id,
+                identifiers={(DOMAIN, config_entry.entry_id)},
+                name=config_entry.data.get(CONF_LOCK_NAME),
+                configuration_url="https://github.com/FutureTense/keymaster",
+                via_device_id=None,
+            )
+    else:
+        # Fallback for earlier Home Assistant versions
+        via_device: tuple[str, str] | None = None
+        if parent_entry_id := config_entry.data.get(CONF_PARENT_ENTRY_ID):
+            via_device = (DOMAIN, parent_entry_id)
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={(DOMAIN, config_entry.entry_id)},
+            name=config_entry.data.get(CONF_LOCK_NAME),
+            configuration_url="https://github.com/FutureTense/keymaster",
+            via_device=via_device,
+        )
+
+
+def build_kmlock(config_entry: ConfigEntry) -> KeymasterLock:
+    """Build a keymaster lock model from config entry data."""
+    code_slots: MutableMapping[int, KeymasterCodeSlot] = {}
+    for x in range(
+        config_entry.data[CONF_START],
+        config_entry.data[CONF_START] + config_entry.data[CONF_SLOTS],
+    ):
+        dow_slots: MutableMapping[int, KeymasterCodeSlotDayOfWeek] = {}
+        for i, dow in enumerate(DAY_NAMES):
+            dow_slots[i] = KeymasterCodeSlotDayOfWeek(day_of_week_num=i, day_of_week_name=dow)
+        code_slots[x] = KeymasterCodeSlot(number=x, accesslimit_day_of_week=dow_slots)
+
+    return KeymasterLock(
+        lock_name=config_entry.data[CONF_LOCK_NAME],
+        lock_entity_id=config_entry.data[CONF_LOCK_ENTITY_ID],
+        keymaster_config_entry_id=config_entry.entry_id,
+        alarm_level_or_user_code_entity_id=config_entry.data.get(
+            CONF_ALARM_LEVEL_OR_USER_CODE_ENTITY_ID
+        ),
+        alarm_type_or_access_control_entity_id=config_entry.data.get(
+            CONF_ALARM_TYPE_OR_ACCESS_CONTROL_ENTITY_ID
+        ),
+        door_sensor_entity_id=config_entry.data.get(CONF_DOOR_SENSOR_ENTITY_ID),
+        number_of_code_slots=config_entry.data[CONF_SLOTS],
+        starting_code_slot=config_entry.data[CONF_START],
+        code_slots=code_slots,
+        parent_name=config_entry.data.get(CONF_PARENT),
+        parent_config_entry_id=config_entry.data.get(CONF_PARENT_ENTRY_ID),
+        notify_script_name=config_entry.data.get(CONF_NOTIFY_SCRIPT_NAME),
+        redact_slot_names=config_entry.options.get(
+            CONF_REDACT_SLOT_NAMES,
+            config_entry.data.get(CONF_REDACT_SLOT_NAMES, DEFAULT_REDACT_SLOT_NAMES),
+        ),
+        redact_pin_codes=config_entry.options.get(
+            CONF_REDACT_PIN_CODES,
+            config_entry.data.get(CONF_REDACT_PIN_CODES, DEFAULT_REDACT_PIN_CODES),
+        ),
+    )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -319,6 +319,67 @@ async def test_parent_title_resolves_to_parent_entry_id_during_setup(hass):
     assert lovelace_call["spec"].parent_config_entry_id == parent_entry.entry_id
 
 
+async def test_self_referential_parent_entry_id_clears_during_setup(hass):
+    """Test setup clears a parent entry ID that points to its own entry."""
+    entry_id = "self-referential-entry"
+    entry_data = _build_entry_data("front_door", "lock.front_door")
+    entry_data[CONF_PARENT] = "Ghost Parent"
+    entry_data[CONF_PARENT_ENTRY_ID] = entry_id
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Front Door",
+        data=entry_data,
+        entry_id=entry_id,
+        version=4,
+    )
+    entry.add_to_hass(hass)
+
+    hass.data.setdefault(DOMAIN, {})
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch("custom_components.keymaster.KeymasterCoordinator") as mock_coordinator_class,
+        patch("custom_components.keymaster.dr.async_get") as mock_device_registry_get,
+        patch(
+            "custom_components.keymaster.async_generate_lovelace",
+            new_callable=AsyncMock,
+        ) as mock_generate_lovelace,
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+        ),
+    ):
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.initial_setup = AsyncMock()
+        mock_coordinator.async_refresh = AsyncMock()
+        mock_coordinator.last_update_success = True
+        mock_coordinator.kmlocks = {}
+        mock_coordinator.add_lock = AsyncMock()
+        mock_coordinator.async_flush_pending_save_data_if_setup_complete = AsyncMock()
+
+        mock_device_registry = Mock()
+        mock_device_registry.async_get_or_create = Mock()
+        mock_device_registry_get.return_value = mock_device_registry
+
+        assert await async_setup_entry(hass, entry)
+
+    assert entry.data[CONF_PARENT_ENTRY_ID] is None
+
+    add_lock_await_args = mock_coordinator.add_lock.await_args
+    assert add_lock_await_args is not None
+    add_lock_call = add_lock_await_args.kwargs
+    assert add_lock_call["kmlock"].parent_config_entry_id is None
+
+    device_registry_call = mock_device_registry.async_get_or_create.call_args.kwargs
+    assert device_registry_call["via_device_id"] is None
+
+    lovelace_await_args = mock_generate_lovelace.await_args
+    assert lovelace_await_args is not None
+    lovelace_call = lovelace_await_args.kwargs
+    assert lovelace_call["spec"].parent_config_entry_id is None
+
+
 async def test_parent_via_device_fallback_for_older_ha_versions(hass):
     """Test legacy via_device fallback when async_get_device_by_identifier is not present."""
     parent_data = _build_entry_data("front_door", "lock.front_door")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -358,7 +358,7 @@ async def test_self_referential_parent_entry_id_clears_during_setup(hass):
         mock_coordinator.add_lock = AsyncMock()
         mock_coordinator.async_flush_pending_save_data_if_setup_complete = AsyncMock()
 
-        mock_device_registry = Mock()
+        mock_device_registry = Mock(spec=["async_get_or_create", "async_get_device_by_identifier"])
         mock_device_registry.async_get_or_create = Mock()
         mock_device_registry_get.return_value = mock_device_registry
 
@@ -378,6 +378,127 @@ async def test_self_referential_parent_entry_id_clears_during_setup(hass):
     assert lovelace_await_args is not None
     lovelace_call = lovelace_await_args.kwargs
     assert lovelace_call["spec"].parent_config_entry_id is None
+
+
+async def test_parent_title_resolution_does_not_match_current_entry(hass):
+    """Test parent title resolution does not set an entry as its own parent."""
+    entry_id = "self-title-match-entry"
+    entry_data = _build_entry_data("Front Door", "lock.front_door")
+    entry_data[CONF_PARENT] = "Front Door"
+    entry_data[CONF_PARENT_ENTRY_ID] = None
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Front Door",
+        data=entry_data,
+        entry_id=entry_id,
+        version=4,
+    )
+    entry.add_to_hass(hass)
+
+    hass.data.setdefault(DOMAIN, {})
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch("custom_components.keymaster.KeymasterCoordinator") as mock_coordinator_class,
+        patch("custom_components.keymaster.dr.async_get") as mock_device_registry_get,
+        patch("custom_components.keymaster.async_generate_lovelace", new_callable=AsyncMock),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+        ),
+    ):
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.initial_setup = AsyncMock()
+        mock_coordinator.async_refresh = AsyncMock()
+        mock_coordinator.last_update_success = True
+        mock_coordinator.kmlocks = {}
+        mock_coordinator.add_lock = AsyncMock()
+        mock_coordinator.async_flush_pending_save_data_if_setup_complete = AsyncMock()
+
+        mock_device_registry = Mock(spec=["async_get_or_create", "async_get_device_by_identifier"])
+        mock_device_registry.async_get_or_create = Mock()
+        mock_device_registry_get.return_value = mock_device_registry
+
+        assert await async_setup_entry(hass, entry)
+
+    assert entry.data[CONF_PARENT_ENTRY_ID] is None
+    add_lock_await_args = mock_coordinator.add_lock.await_args
+    assert add_lock_await_args is not None
+    assert add_lock_await_args.kwargs["kmlock"].parent_config_entry_id is None
+
+
+async def test_parent_title_resolution_prefers_matching_sibling_entry(hass):
+    """Test parent title resolution skips self and continues to a matching sibling."""
+    current_entry_id = "current-shared-name-entry"
+    parent_entry_id = "genuine-parent-entry"
+    current_data = _build_entry_data("Shared Door", "lock.shared_door_current")
+    current_data[CONF_PARENT] = "Shared Door"
+    current_data[CONF_PARENT_ENTRY_ID] = None
+    current_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Shared Door",
+        data=current_data,
+        entry_id=current_entry_id,
+        version=4,
+    )
+    parent_data = _build_entry_data("Shared Door", "lock.shared_door_parent")
+    parent_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Shared Door",
+        data=parent_data,
+        entry_id=parent_entry_id,
+        version=4,
+    )
+    current_entry.add_to_hass(hass)
+    parent_entry.add_to_hass(hass)
+    async_entries = hass.config_entries.async_entries
+
+    hass.data.setdefault(DOMAIN, {})
+
+    with (
+        patch("custom_components.keymaster.async_setup_services", new_callable=AsyncMock),
+        patch("custom_components.keymaster.KeymasterCoordinator") as mock_coordinator_class,
+        patch("custom_components.keymaster.dr.async_get") as mock_device_registry_get,
+        patch("custom_components.keymaster.async_generate_lovelace", new_callable=AsyncMock),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new_callable=AsyncMock,
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_entries",
+            side_effect=lambda domain=None, *args, **kwargs: (
+                [current_entry, parent_entry]
+                if domain == DOMAIN
+                else async_entries(domain, *args, **kwargs)
+            ),
+        ),
+    ):
+        mock_coordinator = mock_coordinator_class.return_value
+        mock_coordinator.initial_setup = AsyncMock()
+        mock_coordinator.async_refresh = AsyncMock()
+        mock_coordinator.last_update_success = True
+        mock_coordinator.kmlocks = {}
+        mock_coordinator.add_lock = AsyncMock()
+        mock_coordinator.async_flush_pending_save_data_if_setup_complete = AsyncMock()
+
+        mock_device_registry = Mock(spec=["async_get_or_create", "async_get_device_by_identifier"])
+        mock_device_registry.async_get_or_create = Mock()
+        mock_parent_device = Mock(id="parent_device_123")
+        mock_device_registry.async_get_device_by_identifier = Mock(return_value=mock_parent_device)
+        mock_device_registry_get.return_value = mock_device_registry
+
+        assert await async_setup_entry(hass, current_entry)
+
+    assert current_entry.data[CONF_PARENT_ENTRY_ID] == parent_entry_id
+    add_lock_await_args = mock_coordinator.add_lock.await_args
+    assert add_lock_await_args is not None
+    assert add_lock_await_args.kwargs["kmlock"].parent_config_entry_id == parent_entry_id
+    mock_device_registry.async_get_device_by_identifier.assert_called_once_with(
+        (DOMAIN, parent_entry_id), config_entry_id=parent_entry_id
+    )
 
 
 async def test_parent_via_device_fallback_for_older_ha_versions(hass):


### PR DESCRIPTION
# Summary
Refs #772

Reduce `custom_components/keymaster/__init__.py` below the aislop raw-line limit, shorten `async_setup_entry`, and cover/fix self-parent resolution edge cases.

## Proposed change
This PR is intentionally split into three commits:

1. `test: cover self-referential parent entry guard`
   - Adds coverage for clearing `CONF_PARENT_ENTRY_ID` when an entry points directly at itself.
2. `refactor: split config entry setup helpers`
   - Moves patch-safe setup code into `custom_components/keymaster/entry_setup.py`:
     - config data normalization
     - keymaster lock model construction
     - device registry get-or-create helper
   - Keeps mock-patched call sites in `custom_components.keymaster` by extracting coordinator bootstrap and large-lock repair handling only into private helpers in `__init__.py`.
3. `fix: avoid resolving a config entry as its own parent`
   - Skips the current config entry during parent title/name resolution so setup cannot reintroduce a self-parent link.
   - Keeps looking after the current entry so a genuine sibling parent with the same name can be selected.

The refactor/fix split is necessary because tests patch production names through the `custom_components.keymaster` namespace; moving those call sites would bypass the patches. Aside from the explicit self-parent resolution fix in commit 3, setup behavior, ordering, and side effects are unchanged.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: Refs #772

Validation:

- `tox -e py314`
- `tox -e lint`
- pristine clone `aislop scan --json`
