### PR TITLE
refactor: split large lock repair helpers

### DIFF
--- a/custom_components/keymaster/__init__.py
+++ b/custom_components/keymaster/__init__.py
@@ -42,7 +42,7 @@ from .const import (
 )
 from .coordinator import KeymasterCoordinator
 from .entry_setup import async_get_or_create_device, build_kmlock, normalize_config_data
-from .helpers import (
+from .large_lock_repairs import (
     async_clear_large_lock_ack,
     async_delete_large_lock_repair_issue,
     async_load_large_lock_ack_store,

--- a/custom_components/keymaster/config_flow.py
+++ b/custom_components/keymaster/config_flow.py
@@ -38,7 +38,7 @@ from .const import (
     DOMAIN,
     NONE_TEXT,
 )
-from .helpers import async_update_large_lock_repair_issue
+from .large_lock_repairs import async_update_large_lock_repair_issue
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -2,51 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, MutableMapping
+from collections.abc import MutableMapping
 import logging
 import time
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import persistent_notification
 from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
-from homeassistant.config_entries import SOURCE_IGNORE, ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceNotFound
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
-from homeassistant.helpers.storage import Store
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 
-from .const import (
-    CONF_ADVANCED_DATE_RANGE,
-    CONF_ADVANCED_DAY_OF_WEEK,
-    CONF_DOOR_SENSOR_ENTITY_ID,
-    CONF_LOCK_NAME,
-    CONF_PARENT,
-    CONF_PARENT_ENTRY_ID,
-    CONF_SLOTS,
-    COORDINATOR,
-    DAY_NAMES,
-    DOMAIN,
-    LARGE_LOCK_ACK_STORE_KEY,
-    LARGE_LOCK_ACK_STORE_VERSION,
-    LARGE_LOCK_CRITICAL_THRESHOLD,
-    LARGE_LOCK_EVENT_GUARD_LIMIT,
-    LARGE_LOCK_WARNING_THRESHOLD,
-    NONE_TEXT,
-    NORMALIZED_TO_NONE_SENTINELS,
-)
+from .const import DOMAIN
 from .providers import is_platform_supported
 
 if TYPE_CHECKING:
     from .lock import KeymasterLock
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-
-LARGE_LOCK_ENTITY_WARNING_THRESHOLD = LARGE_LOCK_WARNING_THRESHOLD
-LARGE_LOCK_REPAIR_TRANSLATION_KEY = "large_lock_configuration"
-LARGE_LOCK_ACK_STORE = "large_lock_ack_store"
-LARGE_LOCK_ACK_DATA = "large_lock_ack_data"
-_LARGE_LOCK_REPAIR_ISSUE_ID_PREFIX = "large_lock_configuration"
 
 
 class Throttle:
@@ -72,224 +46,6 @@ class Throttle:
         """Clear the cooldown for a function/key so the next call is allowed."""
         if func_name in self._cooldowns:
             self._cooldowns[func_name].pop(key, None)
-
-
-def large_lock_repair_issue_id(config_entry_id: str) -> str:
-    """Return the repair issue ID for a config entry."""
-    return f"{_LARGE_LOCK_REPAIR_ISSUE_ID_PREFIX}_{config_entry_id}"
-
-
-def projected_lock_entity_count(
-    config: Mapping[str, Any],
-    *,
-    is_child: bool | None = None,
-    has_door_sensor: bool | None = None,
-    supports_connection_status: bool = True,
-) -> int:
-    """Return the projected number of entities generated for one Keymaster lock."""
-    slots = int(config.get(CONF_SLOTS, 0))
-    if slots < 1:
-        return 0
-
-    if is_child is None:
-        is_child = _has_value(config.get(CONF_PARENT)) or _has_value(
-            config.get(CONF_PARENT_ENTRY_ID)
-        )
-    if has_door_sensor is None:
-        # async_setup_entry normalizes these door-sensor sentinel values to
-        # None before platforms load, so switch.py does not create door switches
-        # for them. Mirror that post-normalization behavior here.
-        has_door_sensor = config.get(CONF_DOOR_SENSOR_ENTITY_ID) not in (
-            None,
-            *NORMALIZED_TO_NONE_SENTINELS,
-        )
-
-    advanced_date_range = bool(config.get(CONF_ADVANCED_DATE_RANGE, True))
-    advanced_day_of_week = bool(config.get(CONF_ADVANCED_DAY_OF_WEEK, True))
-    days = len(DAY_NAMES)
-
-    binary_sensor_count = slots + (1 if supports_connection_status else 0)
-    button_count = slots + 1
-    datetime_count = 2 * slots if advanced_date_range else 0
-    event_count = slots
-    number_count = slots + 2
-    sensor_count = slots + 2 + (1 if is_child else 0)
-    switch_count = 2 + (2 if has_door_sensor else 0)
-    switch_count += slots * (3 + (1 if is_child else 0))
-    if advanced_date_range:
-        switch_count += slots
-    if advanced_day_of_week:
-        switch_count += slots * (1 + (3 * days))
-    text_count = 2 * slots
-    time_count = 2 * slots * days if advanced_day_of_week else 0
-
-    return (
-        binary_sensor_count
-        + button_count
-        + datetime_count
-        + event_count
-        + number_count
-        + sensor_count
-        + switch_count
-        + text_count
-        + time_count
-    )
-
-
-async def async_update_large_lock_repair_issue(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    config: Mapping[str, Any] | None = None,
-    *,
-    supports_connection_status: bool | None = None,
-) -> int:
-    """Create or clear the large-lock repair issue for one config entry."""
-    entry_config = config_entry.data if config is None else config
-    if supports_connection_status is None:
-        supports_connection_status = _supports_connection_status(hass, config_entry.entry_id)
-    entity_count = projected_lock_entity_count(
-        entry_config,
-        supports_connection_status=supports_connection_status,
-    )
-    issue_id = large_lock_repair_issue_id(config_entry.entry_id)
-
-    if entity_count < LARGE_LOCK_WARNING_THRESHOLD:
-        async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
-        await async_clear_large_lock_ack(hass, config_entry.entry_id)
-        return entity_count
-
-    ack_count = await async_get_large_lock_ack(hass, config_entry.entry_id)
-    if entity_count < LARGE_LOCK_CRITICAL_THRESHOLD and ack_count is not None:
-        # Acknowledged warning-band locks stay dismissed; ensure no active issue remains.
-        async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
-        return entity_count
-
-    if entity_count >= LARGE_LOCK_CRITICAL_THRESHOLD and ack_count is not None:
-        await async_clear_large_lock_ack(hass, config_entry.entry_id)
-
-    ir.async_create_issue(
-        hass,
-        DOMAIN,
-        issue_id,
-        is_fixable=True,
-        severity=ir.IssueSeverity.WARNING,
-        translation_key=LARGE_LOCK_REPAIR_TRANSLATION_KEY,
-        translation_placeholders={
-            "lock_name": str(entry_config.get(CONF_LOCK_NAME, config_entry.title)),
-            "entity_count": str(entity_count),
-            "threshold": str(LARGE_LOCK_WARNING_THRESHOLD),
-            "guard_limit": str(LARGE_LOCK_EVENT_GUARD_LIMIT),
-        },
-        data={
-            "entry_id": config_entry.entry_id,
-            "projected": entity_count,
-        },
-    )
-    return entity_count
-
-
-async def async_update_all_large_lock_repair_issues(hass: HomeAssistant) -> None:
-    """Create or clear large-lock repair issues for all Keymaster config entries."""
-    for config_entry in hass.config_entries.async_entries(DOMAIN):
-        try:
-            if not _entry_is_generating_entities(config_entry):
-                async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
-                continue
-            await async_update_large_lock_repair_issue(
-                hass,
-                config_entry,
-                supports_connection_status=_supports_connection_status(hass, config_entry.entry_id),
-            )
-        except Exception:
-            _LOGGER.exception(
-                "Failed to update large-lock repair issue for %s",
-                config_entry.entry_id,
-            )
-
-
-@callback
-def async_delete_large_lock_repair_issue(hass: HomeAssistant, config_entry_id: str) -> None:
-    """Delete the large-lock repair issue for a removed config entry."""
-    issue_id = large_lock_repair_issue_id(config_entry_id)
-    issue_registry = ir.async_get(hass)
-    if issue_registry.async_get_issue(DOMAIN, issue_id):
-        ir.async_delete_issue(hass, DOMAIN, issue_id)
-
-
-async def async_load_large_lock_ack_store(hass: HomeAssistant) -> dict[str, int]:
-    """Load the large-lock acknowledgement store."""
-    hass_data = hass.data.setdefault(DOMAIN, {})
-    if LARGE_LOCK_ACK_DATA in hass_data:
-        return hass_data[LARGE_LOCK_ACK_DATA]
-
-    store: Store[dict[str, int]] = Store(
-        hass,
-        LARGE_LOCK_ACK_STORE_VERSION,
-        LARGE_LOCK_ACK_STORE_KEY,
-    )
-    stored_data = await store.async_load()
-    ack_data = {
-        str(entry_id): int(projected) for entry_id, projected in (stored_data or {}).items()
-    }
-    hass_data[LARGE_LOCK_ACK_STORE] = store
-    hass_data[LARGE_LOCK_ACK_DATA] = ack_data
-    return ack_data
-
-
-async def async_get_large_lock_ack(hass: HomeAssistant, entry_id: str) -> int | None:
-    """Return the acknowledged projected count for an entry."""
-    ack_data = await async_load_large_lock_ack_store(hass)
-    return ack_data.get(entry_id)
-
-
-async def async_set_large_lock_ack(hass: HomeAssistant, entry_id: str, count: int) -> None:
-    """Store a large-lock acknowledgement for an entry."""
-    ack_data = await async_load_large_lock_ack_store(hass)
-    ack_data[entry_id] = count
-    store: Store[dict[str, int]] = hass.data[DOMAIN][LARGE_LOCK_ACK_STORE]
-    await store.async_save(ack_data)
-
-
-async def async_clear_large_lock_ack(hass: HomeAssistant, entry_id: str) -> None:
-    """Clear the large-lock acknowledgement for an entry."""
-    ack_data = await async_load_large_lock_ack_store(hass)
-    if entry_id not in ack_data:
-        return
-    ack_data.pop(entry_id)
-    store: Store[dict[str, int]] = hass.data[DOMAIN][LARGE_LOCK_ACK_STORE]
-    await store.async_save(ack_data)
-
-
-def _has_value(value: Any) -> bool:
-    """Return whether a config value represents a selected entity or parent."""
-    return value not in (None, "", NONE_TEXT)
-
-
-def _get_kmlock_for_entry(hass: HomeAssistant, entry_id: str) -> KeymasterLock | None:
-    """Return the loaded lock for a config entry if the coordinator exists."""
-    coordinator = None
-    if DOMAIN in hass.data:
-        coordinator = hass.data[DOMAIN].get(COORDINATOR)
-    if coordinator is None:
-        return None
-    return coordinator.sync_get_lock_by_config_entry_id(entry_id)
-
-
-def _entry_is_generating_entities(config_entry: ConfigEntry) -> bool:
-    """Return whether an entry is active and expected to generate Keymaster entities."""
-    return (
-        config_entry.disabled_by is None
-        and config_entry.source != SOURCE_IGNORE
-        and config_entry.state in {ConfigEntryState.LOADED, ConfigEntryState.SETUP_IN_PROGRESS}
-    )
-
-
-def _supports_connection_status(hass: HomeAssistant, entry_id: str) -> bool:
-    """Return whether the loaded provider will create a connection-status binary sensor."""
-    kmlock = _get_kmlock_for_entry(hass, entry_id)
-    if kmlock and kmlock.provider:
-        return kmlock.provider.supports_connection_status
-    return True
 
 
 @callback

--- a/custom_components/keymaster/large_lock_repairs.py
+++ b/custom_components/keymaster/large_lock_repairs.py
@@ -1,0 +1,265 @@
+"""Large-lock repair issue and acknowledgement helpers for keymaster."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.config_entries import SOURCE_IGNORE, ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.storage import Store
+
+from .const import (
+    CONF_ADVANCED_DATE_RANGE,
+    CONF_ADVANCED_DAY_OF_WEEK,
+    CONF_DOOR_SENSOR_ENTITY_ID,
+    CONF_LOCK_NAME,
+    CONF_PARENT,
+    CONF_PARENT_ENTRY_ID,
+    CONF_SLOTS,
+    COORDINATOR,
+    DAY_NAMES,
+    DOMAIN,
+    LARGE_LOCK_ACK_STORE_KEY,
+    LARGE_LOCK_ACK_STORE_VERSION,
+    LARGE_LOCK_CRITICAL_THRESHOLD,
+    LARGE_LOCK_EVENT_GUARD_LIMIT,
+    LARGE_LOCK_WARNING_THRESHOLD,
+    NONE_TEXT,
+    NORMALIZED_TO_NONE_SENTINELS,
+)
+
+if TYPE_CHECKING:
+    from .lock import KeymasterLock
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+LARGE_LOCK_ENTITY_WARNING_THRESHOLD = LARGE_LOCK_WARNING_THRESHOLD
+LARGE_LOCK_REPAIR_TRANSLATION_KEY = "large_lock_configuration"
+LARGE_LOCK_ACK_STORE = "large_lock_ack_store"
+LARGE_LOCK_ACK_DATA = "large_lock_ack_data"
+_LARGE_LOCK_REPAIR_ISSUE_ID_PREFIX = "large_lock_configuration"
+
+
+def large_lock_repair_issue_id(config_entry_id: str) -> str:
+    """Return the repair issue ID for a config entry."""
+    return f"{_LARGE_LOCK_REPAIR_ISSUE_ID_PREFIX}_{config_entry_id}"
+
+
+def projected_lock_entity_count(
+    config: Mapping[str, Any],
+    *,
+    is_child: bool | None = None,
+    has_door_sensor: bool | None = None,
+    supports_connection_status: bool = True,
+) -> int:
+    """Return the projected number of entities generated for one Keymaster lock."""
+    slots = int(config.get(CONF_SLOTS, 0))
+    if slots < 1:
+        return 0
+
+    if is_child is None:
+        is_child = _has_value(config.get(CONF_PARENT)) or _has_value(
+            config.get(CONF_PARENT_ENTRY_ID)
+        )
+    if has_door_sensor is None:
+        # async_setup_entry normalizes these door-sensor sentinel values to
+        # None before platforms load, so switch.py does not create door switches
+        # for them. Mirror that post-normalization behavior here.
+        has_door_sensor = config.get(CONF_DOOR_SENSOR_ENTITY_ID) not in (
+            None,
+            *NORMALIZED_TO_NONE_SENTINELS,
+        )
+
+    advanced_date_range = bool(config.get(CONF_ADVANCED_DATE_RANGE, True))
+    advanced_day_of_week = bool(config.get(CONF_ADVANCED_DAY_OF_WEEK, True))
+    days = len(DAY_NAMES)
+
+    binary_sensor_count = slots + (1 if supports_connection_status else 0)
+    button_count = slots + 1
+    datetime_count = 2 * slots if advanced_date_range else 0
+    event_count = slots
+    number_count = slots + 2
+    sensor_count = slots + 2 + (1 if is_child else 0)
+    switch_count = 2 + (2 if has_door_sensor else 0)
+    switch_count += slots * (3 + (1 if is_child else 0))
+    if advanced_date_range:
+        switch_count += slots
+    if advanced_day_of_week:
+        switch_count += slots * (1 + (3 * days))
+    text_count = 2 * slots
+    time_count = 2 * slots * days if advanced_day_of_week else 0
+
+    return (
+        binary_sensor_count
+        + button_count
+        + datetime_count
+        + event_count
+        + number_count
+        + sensor_count
+        + switch_count
+        + text_count
+        + time_count
+    )
+
+
+async def async_update_large_lock_repair_issue(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    config: Mapping[str, Any] | None = None,
+    *,
+    supports_connection_status: bool | None = None,
+) -> int:
+    """Create or clear the large-lock repair issue for one config entry."""
+    entry_config = config_entry.data if config is None else config
+    if supports_connection_status is None:
+        supports_connection_status = provider_supports_connection_status(
+            hass, config_entry.entry_id
+        )
+    entity_count = projected_lock_entity_count(
+        entry_config,
+        supports_connection_status=supports_connection_status,
+    )
+    issue_id = large_lock_repair_issue_id(config_entry.entry_id)
+
+    if entity_count < LARGE_LOCK_WARNING_THRESHOLD:
+        async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
+        await async_clear_large_lock_ack(hass, config_entry.entry_id)
+        return entity_count
+
+    ack_count = await async_get_large_lock_ack(hass, config_entry.entry_id)
+    if entity_count < LARGE_LOCK_CRITICAL_THRESHOLD and ack_count is not None:
+        # Acknowledged warning-band locks stay dismissed; ensure no active issue remains.
+        async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
+        return entity_count
+
+    if entity_count >= LARGE_LOCK_CRITICAL_THRESHOLD and ack_count is not None:
+        await async_clear_large_lock_ack(hass, config_entry.entry_id)
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=LARGE_LOCK_REPAIR_TRANSLATION_KEY,
+        translation_placeholders={
+            "lock_name": str(entry_config.get(CONF_LOCK_NAME, config_entry.title)),
+            "entity_count": str(entity_count),
+            "threshold": str(LARGE_LOCK_WARNING_THRESHOLD),
+            "guard_limit": str(LARGE_LOCK_EVENT_GUARD_LIMIT),
+        },
+        data={
+            "entry_id": config_entry.entry_id,
+            "projected": entity_count,
+        },
+    )
+    return entity_count
+
+
+async def async_update_all_large_lock_repair_issues(hass: HomeAssistant) -> None:
+    """Create or clear large-lock repair issues for all Keymaster config entries."""
+    for config_entry in hass.config_entries.async_entries(DOMAIN):
+        try:
+            if not _entry_is_generating_entities(config_entry):
+                async_delete_large_lock_repair_issue(hass, config_entry.entry_id)
+                continue
+            await async_update_large_lock_repair_issue(
+                hass,
+                config_entry,
+                supports_connection_status=provider_supports_connection_status(
+                    hass, config_entry.entry_id
+                ),
+            )
+        except Exception:
+            _LOGGER.exception(
+                "Failed to update large-lock repair issue for %s",
+                config_entry.entry_id,
+            )
+
+
+@callback
+def async_delete_large_lock_repair_issue(hass: HomeAssistant, config_entry_id: str) -> None:
+    """Delete the large-lock repair issue for a removed config entry."""
+    issue_id = large_lock_repair_issue_id(config_entry_id)
+    issue_registry = ir.async_get(hass)
+    if issue_registry.async_get_issue(DOMAIN, issue_id):
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+
+async def async_load_large_lock_ack_store(hass: HomeAssistant) -> dict[str, int]:
+    """Load the large-lock acknowledgement store."""
+    hass_data = hass.data.setdefault(DOMAIN, {})
+    if LARGE_LOCK_ACK_DATA in hass_data:
+        return hass_data[LARGE_LOCK_ACK_DATA]
+
+    store: Store[dict[str, int]] = Store(
+        hass,
+        LARGE_LOCK_ACK_STORE_VERSION,
+        LARGE_LOCK_ACK_STORE_KEY,
+    )
+    stored_data = await store.async_load()
+    ack_data = {
+        str(entry_id): int(projected) for entry_id, projected in (stored_data or {}).items()
+    }
+    hass_data[LARGE_LOCK_ACK_STORE] = store
+    hass_data[LARGE_LOCK_ACK_DATA] = ack_data
+    return ack_data
+
+
+async def async_get_large_lock_ack(hass: HomeAssistant, entry_id: str) -> int | None:
+    """Return the acknowledged projected count for an entry."""
+    ack_data = await async_load_large_lock_ack_store(hass)
+    return ack_data.get(entry_id)
+
+
+async def async_set_large_lock_ack(hass: HomeAssistant, entry_id: str, count: int) -> None:
+    """Store a large-lock acknowledgement for an entry."""
+    ack_data = await async_load_large_lock_ack_store(hass)
+    ack_data[entry_id] = count
+    store: Store[dict[str, int]] = hass.data[DOMAIN][LARGE_LOCK_ACK_STORE]
+    await store.async_save(ack_data)
+
+
+async def async_clear_large_lock_ack(hass: HomeAssistant, entry_id: str) -> None:
+    """Clear the large-lock acknowledgement for an entry."""
+    ack_data = await async_load_large_lock_ack_store(hass)
+    if entry_id not in ack_data:
+        return
+    ack_data.pop(entry_id)
+    store: Store[dict[str, int]] = hass.data[DOMAIN][LARGE_LOCK_ACK_STORE]
+    await store.async_save(ack_data)
+
+
+def _has_value(value: Any) -> bool:
+    """Return whether a config value represents a selected entity or parent."""
+    return value not in (None, "", NONE_TEXT)
+
+
+def _get_kmlock_for_entry(hass: HomeAssistant, entry_id: str) -> KeymasterLock | None:
+    """Return the loaded lock for a config entry if the coordinator exists."""
+    coordinator = None
+    if DOMAIN in hass.data:
+        coordinator = hass.data[DOMAIN].get(COORDINATOR)
+    if coordinator is None:
+        return None
+    return coordinator.sync_get_lock_by_config_entry_id(entry_id)
+
+
+def _entry_is_generating_entities(config_entry: ConfigEntry) -> bool:
+    """Return whether an entry is active and expected to generate Keymaster entities."""
+    return (
+        config_entry.disabled_by is None
+        and config_entry.source != SOURCE_IGNORE
+        and config_entry.state in {ConfigEntryState.LOADED, ConfigEntryState.SETUP_IN_PROGRESS}
+    )
+
+
+def provider_supports_connection_status(hass: HomeAssistant, entry_id: str) -> bool:
+    """Return whether the loaded provider will create a connection-status binary sensor."""
+    kmlock = _get_kmlock_for_entry(hass, entry_id)
+    if kmlock and kmlock.provider:
+        return kmlock.provider.supports_connection_status
+    return True

--- a/custom_components/keymaster/repairs.py
+++ b/custom_components/keymaster/repairs.py
@@ -12,10 +12,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN, LARGE_LOCK_WARNING_THRESHOLD
-from .helpers import (
-    _supports_connection_status,
+from .large_lock_repairs import (
     async_set_large_lock_ack,
     projected_lock_entity_count,
+    provider_supports_connection_status,
 )
 
 
@@ -51,7 +51,7 @@ class LargeLockConfigurationRepairFlow(RepairsFlow):
 
             projected = projected_lock_entity_count(
                 config_entry.data,
-                supports_connection_status=_supports_connection_status(self.hass, entry_id),
+                supports_connection_status=provider_supports_connection_status(self.hass, entry_id),
             )
             if projected >= LARGE_LOCK_WARNING_THRESHOLD:
                 await async_set_large_lock_ack(self.hass, entry_id, projected)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 from custom_components.keymaster.const import COORDINATOR, DOMAIN
 from custom_components.keymaster.helpers import (
     Throttle,
-    _get_kmlock_for_entry,
     async_has_supported_provider,
     call_hass_service,
     delete_code_slot_entities,
@@ -13,6 +12,7 @@ from custom_components.keymaster.helpers import (
     send_manual_notification,
     send_persistent_notification,
 )
+from custom_components.keymaster.large_lock_repairs import _get_kmlock_for_entry
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 

--- a/tests/test_large_lock_repairs.py
+++ b/tests/test_large_lock_repairs.py
@@ -28,9 +28,8 @@ from custom_components.keymaster.const import (
     LARGE_LOCK_WARNING_THRESHOLD,
     NONE_TEXT,
 )
-from custom_components.keymaster.helpers import (
+from custom_components.keymaster.large_lock_repairs import (
     LARGE_LOCK_ENTITY_WARNING_THRESHOLD,
-    _supports_connection_status,
     async_clear_large_lock_ack,
     async_get_large_lock_ack,
     async_set_large_lock_ack,
@@ -38,6 +37,7 @@ from custom_components.keymaster.helpers import (
     async_update_large_lock_repair_issue,
     large_lock_repair_issue_id,
     projected_lock_entity_count,
+    provider_supports_connection_status,
 )
 from custom_components.keymaster.lock import KeymasterLock
 from custom_components.keymaster.repairs import (
@@ -795,7 +795,7 @@ async def test_setup_sweep_entry_failure_logs_and_continues(
     caplog.set_level(logging.ERROR)
 
     with patch(
-        "custom_components.keymaster.helpers.async_update_large_lock_repair_issue",
+        "custom_components.keymaster.large_lock_repairs.async_update_large_lock_repair_issue",
         new_callable=AsyncMock,
         side_effect=Exception("per-entry repair update failed"),
     ):
@@ -805,10 +805,10 @@ async def test_setup_sweep_entry_failure_logs_and_continues(
     assert _issue(hass, disabled_entry.entry_id) is None
 
 
-@pytest.mark.parametrize("supports_connection_status", [True, False])
+@pytest.mark.parametrize("expected_supports", [True, False])
 async def test_supports_connection_status_uses_loaded_provider(
     hass: Any,
-    supports_connection_status: bool,
+    expected_supports: bool,
 ) -> None:
     """Test helper returns the loaded provider's connection-status support."""
     entry_id = "entry-with-provider"
@@ -818,7 +818,7 @@ async def test_supports_connection_status_uses_loaded_provider(
         keymaster_config_entry_id=entry_id,
         provider=cast(
             Any,
-            SimpleNamespace(supports_connection_status=supports_connection_status),
+            SimpleNamespace(supports_connection_status=expected_supports),
         ),
     )
     hass.data.setdefault(DOMAIN, {})[COORDINATOR] = SimpleNamespace(
@@ -827,7 +827,7 @@ async def test_supports_connection_status_uses_loaded_provider(
         )
     )
 
-    assert _supports_connection_status(hass, entry_id) is supports_connection_status
+    assert provider_supports_connection_status(hass, entry_id) is expected_supports
 
 
 async def test_supports_connection_status_defaults_true_without_loaded_provider(hass: Any) -> None:
@@ -836,7 +836,7 @@ async def test_supports_connection_status_defaults_true_without_loaded_provider(
         sync_get_lock_by_config_entry_id=lambda requested_entry_id: None
     )
 
-    assert _supports_connection_status(hass, "missing-entry") is True
+    assert provider_supports_connection_status(hass, "missing-entry") is True
 
 
 async def test_setup_checks_all_existing_entries(hass: Any) -> None:


### PR DESCRIPTION
# Summary
Split the large-lock repair issue and acknowledgement-store helpers out of `helpers.py` into a dedicated `large_lock_repairs.py` module. Closes #772 as the final remaining finding for that issue.

## Proposed change
Move the large-lock projection, repair issue management, acknowledgement store, and related internal helper logic into `custom_components/keymaster/large_lock_repairs.py`. Update production and test imports to use the new module, and expose `supports_connection_status` publicly because `repairs.py` uses it across modules. Behavior is otherwise unchanged.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #772
- This PR is related to issue:
