### PR TITLE
refactor: split long provider functions

### DIFF
--- a/custom_components/keymaster/providers/schlage.py
+++ b/custom_components/keymaster/providers/schlage.py
@@ -33,6 +33,9 @@ SCHLAGE_DOMAIN = "schlage"
 # Format: [KM:XX] Friendly Name
 _SLOT_TAG_RE = re.compile(r"^\[KM:(\d+)\]\s*(.*)")
 
+_TaggedCode = tuple[str, str, int, str]
+_UntaggedCode = tuple[str, str, str]
+
 
 def _make_tagged_name(slot_num: int, name: str | None = None) -> str:
     """Create a tagged code name with keymaster slot number."""
@@ -77,6 +80,29 @@ def _get_schlage_locks(coordinator: Any) -> Mapping[str, Any] | None:
     return None
 
 
+def _partition_codes(
+    codes: dict[str, dict[str, str]],
+) -> tuple[list[_TaggedCode], list[_UntaggedCode], set[int]]:
+    """Partition Schlage codes into tagged and untagged collections."""
+    assigned_slots: set[int] = set()
+    # (code_id, pin, slot, friendly_name)
+    tagged: list[_TaggedCode] = []
+    # (code_id, pin, original_name)
+    untagged: list[_UntaggedCode] = []
+
+    for code_id, code_data in codes.items():
+        name = code_data.get("name", "")
+        pin = code_data.get("code", "")
+        slot_num, friendly_name = _parse_tag(name)
+        if slot_num is not None:
+            tagged.append((code_id, pin, slot_num, friendly_name))
+            assigned_slots.add(slot_num)
+        else:
+            untagged.append((code_id, pin, name))
+
+    return tagged, untagged, assigned_slots
+
+
 @dataclass
 class SchlageLockProvider(BaseLockProvider):
     """Schlage WiFi lock provider implementation.
@@ -98,25 +124,15 @@ class SchlageLockProvider(BaseLockProvider):
         """Whether provider can report lock connection status."""
         return True
 
-    async def async_connect(self) -> bool:
-        """Connect to the Schlage lock."""
-        self._connected = False
-
-        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
-        if not lock_entry:
-            _LOGGER.error(
-                "[SchlageProvider] Can't find lock in Entity Registry: %s",
-                self.lock_entity_id,
-            )
-            return False
-
+    def _get_schlage_coordinator(self, lock_entry: Any) -> Any | None:
+        """Return the loaded Schlage coordinator for the lock entry."""
         self.lock_config_entry_id = lock_entry.config_entry_id
         if not self.lock_config_entry_id:
             _LOGGER.error(
                 "[SchlageProvider] Lock has no config entry: %s",
                 self.lock_entity_id,
             )
-            return False
+            return None
 
         schlage_entry = self.hass.config_entries.async_get_entry(self.lock_config_entry_id)
         if not schlage_entry:
@@ -124,7 +140,7 @@ class SchlageLockProvider(BaseLockProvider):
                 "[SchlageProvider] Can't find Schlage config entry: %s",
                 self.lock_config_entry_id,
             )
-            return False
+            return None
 
         if getattr(schlage_entry, "state", None) != ConfigEntryState.LOADED:
             _LOGGER.debug(
@@ -132,7 +148,7 @@ class SchlageLockProvider(BaseLockProvider):
                 self.lock_config_entry_id,
                 getattr(schlage_entry, "state", None),
             )
-            return False
+            return None
 
         coordinator = getattr(schlage_entry, "runtime_data", None)
         if coordinator is None:
@@ -140,8 +156,12 @@ class SchlageLockProvider(BaseLockProvider):
                 "[SchlageProvider] Schlage coordinator runtime_data not yet available: %s",
                 self.lock_config_entry_id,
             )
-            return False
+            return None
 
+        return coordinator
+
+    def _get_schlage_device_id(self, lock_entry: Any) -> str | None:
+        """Return the Schlage device identifier for the lock entry."""
         device_entry = None
         if lock_entry.device_id:
             device_entry = self.device_registry.async_get(lock_entry.device_id)
@@ -150,7 +170,7 @@ class SchlageLockProvider(BaseLockProvider):
                 "[SchlageProvider] Can't find lock in Device Registry: %s",
                 self.lock_entity_id,
             )
-            return False
+            return None
 
         schlage_device_id: str | None = None
         for identifier in device_entry.identifiers:
@@ -163,8 +183,12 @@ class SchlageLockProvider(BaseLockProvider):
                 "[SchlageProvider] Unable to get Schlage device ID for lock: %s",
                 self.lock_entity_id,
             )
-            return False
+            return None
 
+        return schlage_device_id
+
+    def _schlage_lock_exists(self, coordinator: Any, schlage_device_id: str) -> bool:
+        """Return whether the Schlage lock is present in coordinator data."""
         locks = _get_schlage_locks(coordinator)
         if locks is None:
             _LOGGER.error(
@@ -176,6 +200,31 @@ class SchlageLockProvider(BaseLockProvider):
                 "[SchlageProvider] Lock %s not found in Schlage coordinator data",
                 schlage_device_id,
             )
+            return False
+
+        return True
+
+    async def async_connect(self) -> bool:
+        """Connect to the Schlage lock."""
+        self._connected = False
+
+        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
+        if not lock_entry:
+            _LOGGER.error(
+                "[SchlageProvider] Can't find lock in Entity Registry: %s",
+                self.lock_entity_id,
+            )
+            return False
+
+        coordinator = self._get_schlage_coordinator(lock_entry)
+        if coordinator is None:
+            return False
+
+        schlage_device_id = self._get_schlage_device_id(lock_entry)
+        if not schlage_device_id:
+            return False
+
+        if not self._schlage_lock_exists(coordinator, schlage_device_id):
             return False
 
         self._schlage_device_id = schlage_device_id
@@ -262,45 +311,15 @@ class SchlageLockProvider(BaseLockProvider):
             blocking=True,
         )
 
-    async def async_get_usercodes(self) -> list[CodeSlot]:
-        """Get all user codes from the Schlage lock.
-
-        Codes already bearing a ``[KM:<slot>]`` tag are mapped to the
-        embedded slot number.  Untagged codes are assigned to the next
-        available slot and their names are updated on the lock to include
-        the tag (via delete + re-add with the same PIN).
-
-        Only codes whose slot numbers fall within the configured managed
-        range are returned.  Tagged codes outside the range and untagged
-        codes that cannot be assigned to a managed slot are left untouched.
-        """
-        codes = await self._async_get_codes()
-        if not codes:
-            return []
-
-        # Determine the managed slot range from the keymaster config.
-        slot_start: int = self.keymaster_config_entry.data.get(CONF_START, 1)
-        slot_count: int = self.keymaster_config_entry.data.get(CONF_SLOTS, 0)
-        managed_range = set(range(slot_start, slot_start + slot_count))
-
-        result: list[CodeSlot] = []
-        assigned_slots: set[int] = set()
-
-        # (code_id, pin, slot, friendly_name)
-        tagged: list[tuple[str, str, int, str]] = []
-        # (code_id, pin, original_name)
-        untagged: list[tuple[str, str, str]] = []
-
-        for code_id, code_data in codes.items():
-            name = code_data.get("name", "")
-            pin = code_data.get("code", "")
-            slot_num, friendly_name = _parse_tag(name)
-            if slot_num is not None:
-                tagged.append((code_id, pin, slot_num, friendly_name))
-                assigned_slots.add(slot_num)
-            else:
-                untagged.append((code_id, pin, name))
-
+    def _append_tagged_codes(
+        self,
+        tagged: list[_TaggedCode],
+        managed_range: set[int],
+        slot_start: int,
+        slot_count: int,
+        result: list[CodeSlot],
+    ) -> None:
+        """Append already-tagged managed codes to the result list."""
         # Emit already-tagged codes that fall within the managed range.
         # Sort by code_id for deterministic dedup, then keep the first per slot.
         tagged.sort(key=lambda t: t[0])
@@ -333,6 +352,62 @@ class SchlageLockProvider(BaseLockProvider):
                 )
             )
 
+    async def _async_tag_untagged_code(
+        self, original_name: str, pin: str, prospective_slot: int, tagged_name: str
+    ) -> bool:
+        """Tag an untagged Schlage code on the lock."""
+        if _is_masked_pin(pin):
+            _LOGGER.debug(
+                "[SchlageProvider] Skipping untaggable code '%s' (slot %d): "
+                "PIN appears masked or empty",
+                self.redact_name(original_name),
+                prospective_slot,
+            )
+            return False
+
+        try:
+            await self._async_add_code(tagged_name, pin)
+        except HomeAssistantError as e:
+            _LOGGER.error(
+                "[SchlageProvider] Failed to tag code '%s' for slot %d: %s: %s",
+                self.redact_name(original_name),
+                prospective_slot,
+                e.__class__.__qualname__,
+                e,
+            )
+            return False
+
+        try:
+            await self._async_delete_code(original_name)
+        except HomeAssistantError as e:
+            _LOGGER.warning(
+                "[SchlageProvider] Tagged code added but failed to delete "
+                "original '%s' for slot %d: %s. Attempting rollback.",
+                self.redact_name(original_name),
+                prospective_slot,
+                e,
+            )
+            try:
+                await self._async_delete_code(tagged_name)
+            except HomeAssistantError:
+                _LOGGER.error(
+                    "[SchlageProvider] Rollback failed for tagged code '%s'. "
+                    "Lock may have duplicate entries.",
+                    self.redact_name(tagged_name),
+                )
+            return False
+
+        return True
+
+    async def _async_assign_untagged_codes(
+        self,
+        untagged: list[_UntaggedCode],
+        assigned_slots: set[int],
+        managed_range: set[int],
+        slot_start: int,
+        result: list[CodeSlot],
+    ) -> None:
+        """Assign virtual slots to untagged codes and append successful tags."""
         # Assign virtual slots to untagged codes and tag them on the lock.
         # Only codes that are successfully tagged get a managed slot; masked
         # PINs and tagging failures are skipped to avoid slot drift.
@@ -357,45 +432,10 @@ class SchlageLockProvider(BaseLockProvider):
             prospective_slot = next_slot
             tagged_name = _make_tagged_name(prospective_slot, original_name)
 
-            if _is_masked_pin(pin):
-                _LOGGER.debug(
-                    "[SchlageProvider] Skipping untaggable code '%s' (slot %d): "
-                    "PIN appears masked or empty",
-                    self.redact_name(original_name),
-                    prospective_slot,
-                )
-                continue
-
-            try:
-                await self._async_add_code(tagged_name, pin)
-            except HomeAssistantError as e:
-                _LOGGER.error(
-                    "[SchlageProvider] Failed to tag code '%s' for slot %d: %s: %s",
-                    self.redact_name(original_name),
-                    prospective_slot,
-                    e.__class__.__qualname__,
-                    e,
-                )
-                continue
-
-            try:
-                await self._async_delete_code(original_name)
-            except HomeAssistantError as e:
-                _LOGGER.warning(
-                    "[SchlageProvider] Tagged code added but failed to delete "
-                    "original '%s' for slot %d: %s. Attempting rollback.",
-                    self.redact_name(original_name),
-                    prospective_slot,
-                    e,
-                )
-                try:
-                    await self._async_delete_code(tagged_name)
-                except HomeAssistantError:
-                    _LOGGER.error(
-                        "[SchlageProvider] Rollback failed for tagged code '%s'. "
-                        "Lock may have duplicate entries.",
-                        self.redact_name(tagged_name),
-                    )
+            tagged_successfully = await self._async_tag_untagged_code(
+                original_name, pin, prospective_slot, tagged_name
+            )
+            if not tagged_successfully:
                 continue
 
             slot_num = prospective_slot
@@ -416,6 +456,34 @@ class SchlageLockProvider(BaseLockProvider):
                     name=original_name,
                 )
             )
+
+    async def async_get_usercodes(self) -> list[CodeSlot]:
+        """Get all user codes from the Schlage lock.
+
+        Codes already bearing a ``[KM:<slot>]`` tag are mapped to the
+        embedded slot number.  Untagged codes are assigned to the next
+        available slot and their names are updated on the lock to include
+        the tag (via delete + re-add with the same PIN).
+
+        Only codes whose slot numbers fall within the configured managed
+        range are returned.  Tagged codes outside the range and untagged
+        codes that cannot be assigned to a managed slot are left untouched.
+        """
+        codes = await self._async_get_codes()
+        if not codes:
+            return []
+
+        # Determine the managed slot range from the keymaster config.
+        slot_start: int = self.keymaster_config_entry.data.get(CONF_START, 1)
+        slot_count: int = self.keymaster_config_entry.data.get(CONF_SLOTS, 0)
+        managed_range = set(range(slot_start, slot_start + slot_count))
+
+        result: list[CodeSlot] = []
+        tagged, untagged, assigned_slots = _partition_codes(codes)
+        self._append_tagged_codes(tagged, managed_range, slot_start, slot_count, result)
+        await self._async_assign_untagged_codes(
+            untagged, assigned_slots, managed_range, slot_start, result
+        )
 
         return result
 

--- a/custom_components/keymaster/providers/zha.py
+++ b/custom_components/keymaster/providers/zha.py
@@ -27,6 +27,102 @@ _LOGGER = logging.getLogger(__name__)
 ZCL_DUPLICATE_CODE_STATUS = 3
 
 
+def _parse_operation_event_args(args: Any) -> tuple[Any, Any, Any]:
+    """Extract code slot, operation, and source from ZHA operation event args."""
+    code_slot = None
+    operation = None
+    source = None
+
+    if isinstance(args, dict):
+        # Real zha_event uses ZCL field names, not display labels.
+        code_slot = args.get("user_id")
+        operation = args.get("operation_event_code")
+        source = args.get("operation_event_source")
+    elif isinstance(args, list | tuple):
+        if len(args) >= 3:
+            operation = args[0]
+            source = args[1]
+            code_slot = args[2]
+
+    return code_slot, operation, source
+
+
+def _operation_event_value(operation: Any) -> DoorLock.OperationEvent | None:
+    """Convert a raw ZHA operation event to a DoorLock operation enum value."""
+    op_val = None
+    if operation is not None:
+        try:
+            op_val = DoorLock.OperationEvent(int(operation))
+        except TypeError:
+            with contextlib.suppress(KeyError):
+                op_val = DoorLock.OperationEvent[str(operation)]
+        except ValueError:
+            with contextlib.suppress(KeyError):
+                op_val = DoorLock.OperationEvent[str(operation)]
+    return op_val
+
+
+def _operation_event_source_value(source: Any) -> DoorLock.OperationEventSource | None:
+    """Convert a raw ZHA operation event source to a DoorLock source enum value."""
+    src_val = None
+    if source is not None:
+        try:
+            src_val = DoorLock.OperationEventSource(int(source))
+        except TypeError:
+            with contextlib.suppress(KeyError):
+                src_val = DoorLock.OperationEventSource[str(source)]
+        except ValueError:
+            with contextlib.suppress(KeyError):
+                src_val = DoorLock.OperationEventSource[str(source)]
+    return src_val
+
+
+def _operation_event_label_action(
+    op_val: DoorLock.OperationEvent | None,
+    src_val: DoorLock.OperationEventSource | None,
+    operation: Any,
+    source: Any,
+) -> tuple[str, int | None]:
+    """Return a keymaster event label and action code for a ZHA operation event."""
+    is_keypad = src_val == DoorLock.OperationEventSource.Keypad
+    is_unlock = op_val in {
+        DoorLock.OperationEvent.Unlock,
+        DoorLock.OperationEvent.KeyUnlock,
+        DoorLock.OperationEvent.Manual_Unlock,
+        DoorLock.OperationEvent.ScheduleUnlock,
+    }
+    is_lock = op_val in {
+        DoorLock.OperationEvent.Lock,
+        DoorLock.OperationEvent.KeyLock,
+        DoorLock.OperationEvent.Manual_Lock,
+        DoorLock.OperationEvent.ScheduleLock,
+        DoorLock.OperationEvent.AutoLock,
+        DoorLock.OperationEvent.OnTouchLock,
+    }
+
+    if is_keypad:
+        if is_unlock:
+            event_label = "Unlocked via Keypad"
+            action_code = 1
+        elif is_lock:
+            event_label = "Keypad Lock"
+            action_code = 5
+        else:
+            event_label = f"Keypad {operation}"
+            action_code = None
+    elif is_unlock:
+        event_label = "Unlocked via RF"
+        action_code = None
+    elif is_lock:
+        event_label = "Locked via RF"
+        action_code = None
+    else:
+        event_label = f"Lock Event: {operation} via {source}"
+        action_code = None
+
+    return event_label, action_code
+
+
 @dataclass
 class ZHALockProvider(BaseLockProvider):
     """ZHA lock provider implementation."""
@@ -354,49 +450,7 @@ class ZHALockProvider(BaseLockProvider):
             if status is None and isinstance(result, list | tuple) and len(result) > 0:
                 status = result[0]
             if status is not None and status != 0:
-                # Some ZHA locks (e.g. Yale YRD210) return ZCL_DUPLICATE_CODE_STATUS (3)
-                # when set_pin_code is called on a slot that already holds that same code.
-                # If the code is already in use in a different slot, this is a genuine
-                # duplicate PIN error across slots and the write failed (so we return False,
-                # which is a behavior change to enforce duplicate rejection).
-                # Note: This cross-slot duplicate detection is best-effort and cache-dependent;
-                # on a cold start with an empty cache, it may not be detected and will soft-succeed.
-                if int(status) == ZCL_DUPLICATE_CODE_STATUS:
-                    duplicate_elsewhere = any(
-                        slot.in_use and slot.code == code
-                        for s_num, slot in self._usercodes_cache.items()
-                        if s_num != slot_num
-                    )
-                    if duplicate_elsewhere:
-                        _LOGGER.warning(
-                            "Lock %s slot %s set_pin_code returned status %s "
-                            "(Duplicate PIN); code already exists in another slot",
-                            self.lock_entity_id,
-                            slot_num,
-                            status,
-                        )
-                        return False
-
-                    _LOGGER.debug(
-                        "Lock %s slot %s set_pin_code returned status %s "
-                        "(Duplicate PIN); treating as success (likely already set in this slot)",
-                        self.lock_entity_id,
-                        slot_num,
-                        status,
-                    )
-                    self._usercodes_cache[slot_num] = CodeSlot(
-                        slot_num=slot_num,
-                        code=code,
-                        in_use=True,
-                    )
-                    return True
-                _LOGGER.error(
-                    "Lock %s slot %s set_pin_code rejected: status %s",
-                    self.lock_entity_id,
-                    slot_num,
-                    status,
-                )
-                return False
+                return self._handle_set_pin_status(status, slot_num, code)
             self._usercodes_cache[slot_num] = CodeSlot(
                 slot_num=slot_num,
                 code=code,
@@ -411,6 +465,52 @@ class ZHALockProvider(BaseLockProvider):
             return False
         else:
             return True
+
+    def _handle_set_pin_status(self, status: Any, slot_num: int, code: str) -> bool:
+        """Handle a non-success set_pin_code status."""
+        # Some ZHA locks (e.g. Yale YRD210) return ZCL_DUPLICATE_CODE_STATUS (3)
+        # when set_pin_code is called on a slot that already holds that same code.
+        # If the code is already in use in a different slot, this is a genuine
+        # duplicate PIN error across slots and the write failed (so we return False,
+        # which is a behavior change to enforce duplicate rejection).
+        # Note: This cross-slot duplicate detection is best-effort and cache-dependent;
+        # on a cold start with an empty cache, it may not be detected and will soft-succeed.
+        if int(status) == ZCL_DUPLICATE_CODE_STATUS:
+            duplicate_elsewhere = any(
+                slot.in_use and slot.code == code
+                for s_num, slot in self._usercodes_cache.items()
+                if s_num != slot_num
+            )
+            if duplicate_elsewhere:
+                _LOGGER.warning(
+                    "Lock %s slot %s set_pin_code returned status %s "
+                    "(Duplicate PIN); code already exists in another slot",
+                    self.lock_entity_id,
+                    slot_num,
+                    status,
+                )
+                return False
+
+            _LOGGER.debug(
+                "Lock %s slot %s set_pin_code returned status %s "
+                "(Duplicate PIN); treating as success (likely already set in this slot)",
+                self.lock_entity_id,
+                slot_num,
+                status,
+            )
+            self._usercodes_cache[slot_num] = CodeSlot(
+                slot_num=slot_num,
+                code=code,
+                in_use=True,
+            )
+            return True
+        _LOGGER.error(
+            "Lock %s slot %s set_pin_code rejected: status %s",
+            self.lock_entity_id,
+            slot_num,
+            status,
+        )
+        return False
 
     async def async_clear_usercode(self, slot_num: int) -> bool:
         """Clear user code from ZHA lock."""
@@ -478,104 +578,7 @@ class ZHALockProvider(BaseLockProvider):
         @ha_callback
         def handle_zha_event(event: Event) -> None:
             """Handle incoming ZHA events."""
-            device_ieee = event.data.get("device_ieee")
-            if device_ieee != self._device_ieee:
-                return
-
-            command = event.data.get("command")
-            if command == "programming_event_notification":
-                coordinator = None
-                if DOMAIN in self.hass.data:
-                    coordinator = self.hass.data[DOMAIN].get(COORDINATOR)
-                if coordinator:
-                    self.hass.async_create_task(
-                        coordinator.async_refresh(),
-                        f"Refresh {self.lock_entity_id} after ZHA programming event",
-                    )
-                return
-
-            if command != "operation_event_notification":
-                return
-
-            args = event.data.get("args", {})
-            code_slot = None
-            operation = None
-            source = None
-
-            if isinstance(args, dict):
-                # Real zha_event uses ZCL field names, not display labels.
-                code_slot = args.get("user_id")
-                operation = args.get("operation_event_code")
-                source = args.get("operation_event_source")
-            elif isinstance(args, list | tuple):
-                if len(args) >= 3:
-                    operation = args[0]
-                    source = args[1]
-                    code_slot = args[2]
-
-            # user_id == 0 is a master/system event, not a slot operation
-            if code_slot is None or code_slot == 0:
-                return
-
-            op_val = None
-            src_val = None
-            if operation is not None:
-                try:
-                    op_val = DoorLock.OperationEvent(int(operation))
-                except TypeError:
-                    with contextlib.suppress(KeyError):
-                        op_val = DoorLock.OperationEvent[str(operation)]
-                except ValueError:
-                    with contextlib.suppress(KeyError):
-                        op_val = DoorLock.OperationEvent[str(operation)]
-
-            if source is not None:
-                try:
-                    src_val = DoorLock.OperationEventSource(int(source))
-                except TypeError:
-                    with contextlib.suppress(KeyError):
-                        src_val = DoorLock.OperationEventSource[str(source)]
-                except ValueError:
-                    with contextlib.suppress(KeyError):
-                        src_val = DoorLock.OperationEventSource[str(source)]
-
-            is_keypad = src_val == DoorLock.OperationEventSource.Keypad
-            is_unlock = op_val in {
-                DoorLock.OperationEvent.Unlock,
-                DoorLock.OperationEvent.KeyUnlock,
-                DoorLock.OperationEvent.Manual_Unlock,
-                DoorLock.OperationEvent.ScheduleUnlock,
-            }
-            is_lock = op_val in {
-                DoorLock.OperationEvent.Lock,
-                DoorLock.OperationEvent.KeyLock,
-                DoorLock.OperationEvent.Manual_Lock,
-                DoorLock.OperationEvent.ScheduleLock,
-                DoorLock.OperationEvent.AutoLock,
-                DoorLock.OperationEvent.OnTouchLock,
-            }
-
-            if is_keypad:
-                if is_unlock:
-                    event_label = "Unlocked via Keypad"
-                    action_code = 1
-                elif is_lock:
-                    event_label = "Keypad Lock"
-                    action_code = 5
-                else:
-                    event_label = f"Keypad {operation}"
-                    action_code = None
-            elif is_unlock:
-                event_label = "Unlocked via RF"
-                action_code = None
-            elif is_lock:
-                event_label = "Locked via RF"
-                action_code = None
-            else:
-                event_label = f"Lock Event: {operation} via {source}"
-                action_code = None
-
-            self.hass.async_create_task(callback(code_slot, event_label, action_code))
+            self._handle_zha_event(event, callback)
 
         unsub = self.hass.bus.async_listen("zha_event", handle_zha_event)
         self._listeners.append(unsub)
@@ -588,6 +591,48 @@ class ZHALockProvider(BaseLockProvider):
 
         self._event_unsub = unsubscribe
         return unsubscribe
+
+    def _handle_zha_event(self, event: Event, callback: LockEventCallback) -> None:
+        """Handle incoming ZHA events."""
+        device_ieee = event.data.get("device_ieee")
+        if device_ieee != self._device_ieee:
+            return
+
+        command = event.data.get("command")
+        if command == "programming_event_notification":
+            self._handle_zha_programming_event()
+            return
+
+        if command != "operation_event_notification":
+            return
+
+        self._handle_zha_operation_event(event, callback)
+
+    def _handle_zha_programming_event(self) -> None:
+        """Handle incoming ZHA programming events."""
+        coordinator = None
+        if DOMAIN in self.hass.data:
+            coordinator = self.hass.data[DOMAIN].get(COORDINATOR)
+        if coordinator:
+            self.hass.async_create_task(
+                coordinator.async_refresh(),
+                f"Refresh {self.lock_entity_id} after ZHA programming event",
+            )
+
+    def _handle_zha_operation_event(self, event: Event, callback: LockEventCallback) -> None:
+        """Handle incoming ZHA operation events."""
+        args = event.data.get("args", {})
+        code_slot, operation, source = _parse_operation_event_args(args)
+
+        # user_id == 0 is a master/system event, not a slot operation
+        if code_slot is None or code_slot == 0:
+            return
+
+        op_val = _operation_event_value(operation)
+        src_val = _operation_event_source_value(source)
+        event_label, action_code = _operation_event_label_action(op_val, src_val, operation, source)
+
+        self.hass.async_create_task(callback(code_slot, event_label, action_code))
 
     def subscribe_connection_events(self, callback: ConnectionCallback) -> Callable[[], None]:
         """Notify on lock entity availability transitions."""


### PR DESCRIPTION
# Summary
Refactor long Schlage and ZHA provider functions into smaller helpers for issue #770.

## Proposed change
Split Schlage user-code discovery and ZHA lock event subscription handling into named helper functions and methods. The refactor keeps each function in the touched provider files within the 80-line static-analysis limit without changing behavior.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to issue: #770
