### PR TITLE
refactor: split long Z-Wave JS provider functions

### DIFF
--- a/custom_components/keymaster/providers/zwave_js.py
+++ b/custom_components/keymaster/providers/zwave_js.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 import functools
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from zwave_js_server.client import Client as ZwaveJSClient
 from zwave_js_server.const import NodeStatus
@@ -34,7 +34,7 @@ from homeassistant.components.zwave_js import ZWAVE_JS_NOTIFICATION_EVENT
 from homeassistant.components.zwave_js.const import ATTR_PARAMETERS, DOMAIN as ZWAVE_JS_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
-from homeassistant.core import Event, EventStateChangedData
+from homeassistant.core import Event, EventStateChangedData, State
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util import dt as dt_util
@@ -316,6 +316,139 @@ ZWAVE_STATE_MAP: MutableMapping[str, MutableMapping[str, int]] = {
 }
 
 
+def _get_zwave_notification_action(
+    event_data: MutableMapping[str, Any],
+) -> MutableMapping[str, Any] | None:
+    """Return the Z-Wave activity mapped to a notification event."""
+    action: MutableMapping[str, Any] | None = None
+    for activity in ZWAVE_ACTIVITY_MAP:
+        if activity.get("zwavejs_event") == event_data.get("event"):
+            action = activity
+            break
+    return action
+
+
+def _get_zwave_notification_details(event: Event) -> tuple[int, str, Any]:
+    """Return callback details for a Z-Wave JS notification event."""
+    params: MutableMapping[str, Any] = event.data.get(ATTR_PARAMETERS) or {}
+    code_slot_num: int = params.get("userId", 0)
+
+    if (
+        event.data.get("command_class") == 113
+        and event.data.get("type") == 6
+        and event.data.get("event")
+    ):
+        action = _get_zwave_notification_action(event.data)
+        if action:
+            event_label = action.get("name", "Unknown Lock Event")
+            if action.get("method") != LockMethod.KEYPAD:
+                code_slot_num = 0
+        else:
+            event_label = event.data.get("event_label", "Unknown Lock Event")
+    else:
+        event_label = event.data.get("event_label", "Unknown Lock Event")
+
+    action_code = event.data.get("event")
+    return code_slot_num, event_label, action_code
+
+
+def _get_alarm_sensor_state_value(
+    hass: Any,
+    entity_id: str | None,
+) -> tuple[State | None, int | None]:
+    """Return an alarm sensor state and usable integer value."""
+    alarm_state = None
+    if entity_id:
+        alarm_state = hass.states.get(entity_id)
+    alarm_value: int | None = (
+        int(alarm_state.state)
+        if alarm_state and alarm_state.state not in {STATE_UNKNOWN, STATE_UNAVAILABLE}
+        else None
+    )
+    return alarm_state, alarm_value
+
+
+def _alarm_type_sensor_is_stale(
+    alarm_level_state: State | None,
+    alarm_type_state: State | None,
+    new_state: str | None,
+) -> bool:
+    """Return whether the alarm type sensor has not changed recently."""
+    return bool(
+        alarm_level_state is not None
+        and alarm_type_state is not None
+        and alarm_type_state.last_changed is not None
+        and new_state
+        and dt_util.utcnow() - dt_util.as_utc(alarm_type_state.last_changed) > timedelta(seconds=5)
+    )
+
+
+def _get_state_changed_event_states(
+    event: Event[EventStateChangedData],
+) -> tuple[str, str | None, str | None]:
+    """Return entity ID and old/new states from a state-changed event."""
+    changed_entity: str = event.data["entity_id"]
+    old_state: str | None = None
+    if temp_old_state := event.data.get("old_state"):
+        old_state = temp_old_state.state
+    new_state: str | None = None
+    if temp_new_state := event.data.get("new_state"):
+        new_state = temp_new_state.state
+    return changed_entity, old_state, new_state
+
+
+def _get_activity_callback_details(
+    activity: LockActivity | None,
+    alarm_level_value: int,
+) -> tuple[int, str]:
+    """Return code slot and label for a resolved lock activity."""
+    if activity:
+        event_label = activity.name
+        code_slot_num = alarm_level_value if activity.method == LockMethod.KEYPAD else 0
+    else:
+        event_label = "Unknown Lock Event"
+        code_slot_num = 0
+    return code_slot_num, event_label
+
+
+def _credential_delete_result_ok(credential_result: Any, slot_num: int) -> bool:
+    """Return whether the credential deletion result is acceptable."""
+    # LOCATION_EMPTY means the slot was already empty, which is the
+    # desired post-condition for a clear operation.
+    ok_credential_results = (
+        SetCredentialResult.OK,
+        SetCredentialResult.ERROR_MODIFY_REJECTED_LOCATION_EMPTY,
+        SetCredentialResult.ERROR_UNKNOWN,
+    )
+    if credential_result not in ok_credential_results:
+        _LOGGER.error(
+            "[ZWaveJSProvider] Failed to delete credential on slot %s: %s",
+            slot_num,
+            credential_result,
+        )
+        return False
+    return True
+
+
+def _user_delete_result_ok(user_result: Any, slot_num: int) -> bool:
+    """Return whether the user deletion result is acceptable."""
+    # LOCATION_EMPTY means the user was already absent, which is the
+    # desired post-condition for a clear operation.
+    ok_user_results = (
+        SetUserResult.OK,
+        SetUserResult.ERROR_MODIFY_REJECTED_LOCATION_EMPTY,
+        SetUserResult.ERROR_UNKNOWN,
+    )
+    if user_result not in ok_user_results:
+        _LOGGER.error(
+            "[ZWaveJSProvider] Failed to delete user on slot %s: %s",
+            slot_num,
+            user_result,
+        )
+        return False
+    return True
+
+
 @dataclass
 class ZWaveJSLockProvider(BaseLockProvider):
     """Z-Wave JS lock provider implementation."""
@@ -414,12 +547,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
         """Connect to the Z-Wave JS lock."""
         self._connected = False
 
-        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
-        if not lock_entry:
-            _LOGGER.error(
-                "[ZWaveJSProvider] Can't find lock in Entity Registry: %s",
-                self.lock_entity_id,
-            )
+        if not (lock_entry := self._get_lock_registry_entry()):
             return False
 
         self.lock_config_entry_id = lock_entry.config_entry_id
@@ -431,13 +559,63 @@ class ZWaveJSLockProvider(BaseLockProvider):
             )
             return False
 
+        if not (zwave_entry := self._get_loaded_zwave_entry()):
+            return False
+
+        if not self._set_client_from_runtime_data(zwave_entry):
+            return False
+
+        if not self._zwave_client_is_connected():
+            return False
+
+        if not self._set_device_from_lock_entry(lock_entry):
+            return False
+
+        if not (node_id := self._get_node_id_from_device()):
+            return False
+
+        if not self._set_node_from_controller(node_id):
+            return False
+
+        # Warn if node is dead, but connect anyway for cached data access.
+        # The backoff mechanism handles repeated failures at the coordinator level.
+        if not self._is_node_alive():
+            _LOGGER.warning(
+                "[ZWaveJSProvider] Node %s is currently dead, "
+                "connecting anyway (cached data may still be available)",
+                node_id,
+            )
+
+        await self._async_detect_credential_cc(node_id)
+
+        self._connected = True
+        _LOGGER.debug(
+            "[ZWaveJSProvider] Connected to lock %s (node %s)",
+            self.lock_entity_id,
+            node_id,
+        )
+        return True
+
+    def _get_lock_registry_entry(self) -> Any | None:
+        """Return the lock entity registry entry."""
+        lock_entry = self.entity_registry.async_get(self.lock_entity_id)
+        if not lock_entry:
+            _LOGGER.error(
+                "[ZWaveJSProvider] Can't find lock in Entity Registry: %s",
+                self.lock_entity_id,
+            )
+            return None
+        return lock_entry
+
+    def _get_loaded_zwave_entry(self) -> Any | None:
+        """Return the loaded Z-Wave JS config entry."""
         zwave_entry = self.hass.config_entries.async_get_entry(self.lock_config_entry_id)
         if not zwave_entry:
             _LOGGER.error(
                 "[ZWaveJSProvider] Can't find Z-Wave JS config entry: %s",
                 self.lock_config_entry_id,
             )
-            return False
+            return None
 
         if getattr(zwave_entry, "state", None) != ConfigEntryState.LOADED:
             _LOGGER.debug(
@@ -445,8 +623,11 @@ class ZWaveJSLockProvider(BaseLockProvider):
                 self.lock_config_entry_id,
                 getattr(zwave_entry, "state", None),
             )
-            return False
+            return None
+        return zwave_entry
 
+    def _set_client_from_runtime_data(self, zwave_entry: Any) -> bool:
+        """Set the Z-Wave JS client from config entry runtime data."""
         runtime_data = getattr(zwave_entry, "runtime_data", None)
         if runtime_data is None:
             _LOGGER.debug(
@@ -462,7 +643,10 @@ class ZWaveJSLockProvider(BaseLockProvider):
                 self.lock_config_entry_id,
             )
             return False
+        return True
 
+    def _zwave_client_is_connected(self) -> bool:
+        """Return whether the Z-Wave JS client has an active controller."""
         if not (
             self._client
             and self._client.connected
@@ -471,7 +655,10 @@ class ZWaveJSLockProvider(BaseLockProvider):
         ):
             _LOGGER.error("[ZWaveJSProvider] Z-Wave JS not connected")
             return False
+        return True
 
+    def _set_device_from_lock_entry(self, lock_entry: Any) -> bool:
+        """Set the Z-Wave device from the lock registry entry."""
         if lock_entry.device_id:
             self._device = self.device_registry.async_get(lock_entry.device_id)
 
@@ -481,9 +668,13 @@ class ZWaveJSLockProvider(BaseLockProvider):
                 self.lock_entity_id,
             )
             return False
+        return True
 
+    def _get_node_id_from_device(self) -> int | None:
+        """Return the Z-Wave node ID from the device identifiers."""
         node_id = 0
-        for identifier in self._device.identifiers:
+        device = cast(DeviceEntry, self._device)
+        for identifier in device.identifiers:
             if identifier[0] == ZWAVE_JS_DOMAIN:
                 node_id = int(identifier[1].split("-")[1])
                 break
@@ -493,31 +684,30 @@ class ZWaveJSLockProvider(BaseLockProvider):
                 "[ZWaveJSProvider] Unable to get Z-Wave node ID for lock: %s",
                 self.lock_entity_id,
             )
-            return False
+            return None
+        return node_id
 
+    def _set_node_from_controller(self, node_id: int) -> bool:
+        """Set the Z-Wave node from the client controller."""
+        client = cast(ZwaveJSClient, self._client)
         self._node_id = node_id
-        self._node = self._client.driver.controller.nodes.get(node_id)
+        self._node = client.driver.controller.nodes.get(node_id)
         if not self._node:
             _LOGGER.error(
                 "[ZWaveJSProvider] Node %s not found in Z-Wave network",
                 node_id,
             )
             return False
+        return True
 
-        # Warn if node is dead, but connect anyway for cached data access.
-        # The backoff mechanism handles repeated failures at the coordinator level.
-        if not self._is_node_alive():
-            _LOGGER.warning(
-                "[ZWaveJSProvider] Node %s is currently dead, "
-                "connecting anyway (cached data may still be available)",
-                node_id,
-            )
-
+    async def _async_detect_credential_cc(self, node_id: int) -> None:
+        """Detect whether the node uses User Credential CC for PINs."""
         self._uses_credential_cc = False
-        if _HAS_CREDENTIAL_CC and hasattr(self._node, "access_control"):
+        node = cast(ZwaveJSNode, self._node)
+        if _HAS_CREDENTIAL_CC and hasattr(node, "access_control"):
             try:
-                self._uses_credential_cc = await self._node.access_control.is_supported() and any(
-                    cc.id == 18 for cc in self._node.command_classes
+                self._uses_credential_cc = await node.access_control.is_supported() and any(
+                    cc.id == 18 for cc in node.command_classes
                 )
             except Exception:  # noqa: BLE001
                 self._uses_credential_cc = False
@@ -526,14 +716,6 @@ class ZWaveJSLockProvider(BaseLockProvider):
                 node_id,
                 "User Credential" if self._uses_credential_cc else "User Code",
             )
-
-        self._connected = True
-        _LOGGER.debug(
-            "[ZWaveJSProvider] Connected to lock %s (node %s)",
-            self.lock_entity_id,
-            node_id,
-        )
-        return True
 
     async def async_is_connected(self) -> bool:
         """Check if Z-Wave JS connection is active."""
@@ -752,66 +934,94 @@ class ZWaveJSLockProvider(BaseLockProvider):
             return False
 
         if self._uses_credential_cc:
-            try:
-                credential_result = await node.access_control.set_credential(
-                    slot_num,
-                    UserCredentialType.PIN_CODE,
-                    slot_num,
-                    code,
-                )
-            except BaseZwaveJSServerError as e:
-                _LOGGER.error(
-                    "[ZWaveJSProvider] Failed to set credential on slot %s: %s: %s",
-                    slot_num,
-                    e.__class__.__qualname__,
-                    e,
-                )
-                return False
+            return await self._async_set_credential_usercode(node, slot_num, code, name)
 
-            if credential_result == SetCredentialResult.ERROR_UNKNOWN:
-                if not await self._verify_credential_state(slot_num, expect_present=True):
-                    _LOGGER.error(
-                        "[ZWaveJSProvider] Failed to verify credential set on slot %s",
-                        slot_num,
-                    )
-                    return False
-                _LOGGER.debug(
-                    "[ZWaveJSProvider] Credential set verified post-op despite ERROR_UNKNOWN",
-                )
-            elif credential_result != SetCredentialResult.OK:
-                _LOGGER.error(
-                    "[ZWaveJSProvider] Failed to set credential on slot %s: %s",
-                    slot_num,
-                    credential_result,
-                )
-                return False
+        return await self._async_set_legacy_usercode(node, slot_num, code)
 
-            if name:
-                try:
-                    user_result = await node.access_control.set_user(
-                        slot_num,
-                        SetUserOptions(user_name=name),
-                    )
-                except BaseZwaveJSServerError as e:
-                    _LOGGER.debug(
-                        "[ZWaveJSProvider] Could not set user_name on slot %s: %s",
-                        slot_num,
-                        e,
-                    )
-                else:
-                    if user_result != SetUserResult.OK:
-                        _LOGGER.debug(
-                            "[ZWaveJSProvider] Could not set user_name on slot %s: %s",
-                            slot_num,
-                            user_result,
-                        )
-
-            _LOGGER.debug(
-                "[ZWaveJSProvider] Set credential on slot %s",
+    async def _async_set_credential_usercode(
+        self,
+        node: ZwaveJSNode,
+        slot_num: int,
+        code: str,
+        name: str | None,
+    ) -> bool:
+        """Set a user code via User Credential CC."""
+        try:
+            credential_result = await node.access_control.set_credential(
                 slot_num,
+                UserCredentialType.PIN_CODE,
+                slot_num,
+                code,
             )
-            return True
+        except BaseZwaveJSServerError as e:
+            _LOGGER.error(
+                "[ZWaveJSProvider] Failed to set credential on slot %s: %s: %s",
+                slot_num,
+                e.__class__.__qualname__,
+                e,
+            )
+            return False
 
+        if credential_result == SetCredentialResult.ERROR_UNKNOWN:
+            if not await self._verify_credential_state(slot_num, expect_present=True):
+                _LOGGER.error(
+                    "[ZWaveJSProvider] Failed to verify credential set on slot %s",
+                    slot_num,
+                )
+                return False
+            _LOGGER.debug(
+                "[ZWaveJSProvider] Credential set verified post-op despite ERROR_UNKNOWN",
+            )
+        elif credential_result != SetCredentialResult.OK:
+            _LOGGER.error(
+                "[ZWaveJSProvider] Failed to set credential on slot %s: %s",
+                slot_num,
+                credential_result,
+            )
+            return False
+
+        if name:
+            await self._async_set_credential_user_name(node, slot_num, name)
+
+        _LOGGER.debug(
+            "[ZWaveJSProvider] Set credential on slot %s",
+            slot_num,
+        )
+        return True
+
+    async def _async_set_credential_user_name(
+        self,
+        node: ZwaveJSNode,
+        slot_num: int,
+        name: str,
+    ) -> None:
+        """Set User Credential CC user metadata."""
+        try:
+            user_result = await node.access_control.set_user(
+                slot_num,
+                SetUserOptions(user_name=name),
+            )
+        except BaseZwaveJSServerError as e:
+            _LOGGER.debug(
+                "[ZWaveJSProvider] Could not set user_name on slot %s: %s",
+                slot_num,
+                e,
+            )
+        else:
+            if user_result != SetUserResult.OK:
+                _LOGGER.debug(
+                    "[ZWaveJSProvider] Could not set user_name on slot %s: %s",
+                    slot_num,
+                    user_result,
+                )
+
+    async def _async_set_legacy_usercode(
+        self,
+        node: ZwaveJSNode,
+        slot_num: int,
+        code: str,
+    ) -> bool:
+        """Set a user code via legacy User Code CC."""
         try:
             await set_usercode(node, slot_num, code)
         except BaseZwaveJSServerError as e:
@@ -845,67 +1055,51 @@ class ZWaveJSLockProvider(BaseLockProvider):
             return False
 
         if self._uses_credential_cc:
-            try:
-                credential_result = await node.access_control.delete_credential(
-                    slot_num,
-                    UserCredentialType.PIN_CODE,
-                    slot_num,
-                )
-                # LOCATION_EMPTY means the slot was already empty, which is the
-                # desired post-condition for a clear operation.
-                ok_credential_results = (
-                    SetCredentialResult.OK,
-                    SetCredentialResult.ERROR_MODIFY_REJECTED_LOCATION_EMPTY,
-                    SetCredentialResult.ERROR_UNKNOWN,
-                )
-                if credential_result not in ok_credential_results:
-                    _LOGGER.error(
-                        "[ZWaveJSProvider] Failed to delete credential on slot %s: %s",
-                        slot_num,
-                        credential_result,
-                    )
-                    return False
+            return await self._async_clear_credential_usercode(node, slot_num)
 
-                user_result = await node.access_control.delete_user(slot_num)
-                # LOCATION_EMPTY means the user was already absent, which is the
-                # desired post-condition for a clear operation.
-                ok_user_results = (
-                    SetUserResult.OK,
-                    SetUserResult.ERROR_MODIFY_REJECTED_LOCATION_EMPTY,
-                    SetUserResult.ERROR_UNKNOWN,
-                )
-                if user_result not in ok_user_results:
-                    _LOGGER.error(
-                        "[ZWaveJSProvider] Failed to delete user on slot %s: %s",
-                        slot_num,
-                        user_result,
-                    )
-                    return False
-            except BaseZwaveJSServerError as e:
-                _LOGGER.error(
-                    "[ZWaveJSProvider] Failed to clear credential on slot %s: %s: %s",
-                    slot_num,
-                    e.__class__.__qualname__,
-                    e,
-                )
+        return await self._async_clear_legacy_usercode(node, slot_num)
+
+    async def _async_clear_credential_usercode(self, node: ZwaveJSNode, slot_num: int) -> bool:
+        """Clear a user code via User Credential CC."""
+        try:
+            credential_result = await node.access_control.delete_credential(
+                slot_num,
+                UserCredentialType.PIN_CODE,
+                slot_num,
+            )
+            if not _credential_delete_result_ok(credential_result, slot_num):
                 return False
 
-            if await self._verify_credential_state(slot_num, expect_present=False):
-                if (
-                    credential_result == SetCredentialResult.ERROR_UNKNOWN
-                    or user_result == SetUserResult.ERROR_UNKNOWN
-                ):
-                    _LOGGER.debug(
-                        "[ZWaveJSProvider] Credential clear verified post-op despite ERROR_UNKNOWN",
-                    )
-                return True
-
-            _LOGGER.warning(
-                "[ZWaveJSProvider] Failed to verify credential clear on slot %s",
+            user_result = await node.access_control.delete_user(slot_num)
+            if not _user_delete_result_ok(user_result, slot_num):
+                return False
+        except BaseZwaveJSServerError as e:
+            _LOGGER.error(
+                "[ZWaveJSProvider] Failed to clear credential on slot %s: %s: %s",
                 slot_num,
+                e.__class__.__qualname__,
+                e,
             )
             return False
 
+        if await self._verify_credential_state(slot_num, expect_present=False):
+            if (
+                credential_result == SetCredentialResult.ERROR_UNKNOWN
+                or user_result == SetUserResult.ERROR_UNKNOWN
+            ):
+                _LOGGER.debug(
+                    "[ZWaveJSProvider] Credential clear verified post-op despite ERROR_UNKNOWN",
+                )
+            return True
+
+        _LOGGER.warning(
+            "[ZWaveJSProvider] Failed to verify credential clear on slot %s",
+            slot_num,
+        )
+        return False
+
+    async def _async_clear_legacy_usercode(self, node: ZwaveJSNode, slot_num: int) -> bool:
+        """Clear a user code via legacy User Code CC."""
         try:
             await clear_usercode(node, slot_num)
         except BaseZwaveJSServerError as e:
@@ -922,6 +1116,10 @@ class ZWaveJSLockProvider(BaseLockProvider):
                 slot_num,
             )
 
+        return self._verify_legacy_usercode_clear(node, slot_num)
+
+    def _verify_legacy_usercode_clear(self, node: ZwaveJSNode, slot_num: int) -> bool:
+        """Verify that a legacy User Code CC slot was cleared."""
         # Verify the code was cleared
         try:
             usercode = get_usercode(node, slot_num)
@@ -1015,124 +1213,10 @@ class ZWaveJSLockProvider(BaseLockProvider):
         """
         unsub_list: list[Callable[[], None]] = []
 
-        async def handle_zwave_notification_event(event: Event) -> None:
-            """Handle Z-Wave JS notification event."""
-            node = self._get_node()
-            if not node or not self._device:
-                return
-
-            # Verify this event is for our lock
-            if (
-                event.data.get(ATTR_NODE_ID) != node.node_id
-                or event.data.get(ATTR_DEVICE_ID) != self._device.id
-            ):
-                return
-
-            params: MutableMapping[str, Any] = event.data.get(ATTR_PARAMETERS) or {}
-            code_slot_num: int = params.get("userId", 0)
-
-            if (
-                event.data.get("command_class") == 113
-                and event.data.get("type") == 6
-                and event.data.get("event")
-            ):
-                action: MutableMapping[str, Any] | None = None
-                for activity in ZWAVE_ACTIVITY_MAP:
-                    if activity.get("zwavejs_event") == event.data.get("event"):
-                        action = activity
-                        break
-                if action:
-                    event_label = action.get("name", "Unknown Lock Event")
-                    if action.get("method") != LockMethod.KEYPAD:
-                        code_slot_num = 0
-                else:
-                    event_label = event.data.get("event_label", "Unknown Lock Event")
-            else:
-                event_label = event.data.get("event_label", "Unknown Lock Event")
-
-            action_code = event.data.get("event")
-            self.hass.async_create_task(callback(code_slot_num, event_label, action_code))
-
-        async def handle_lock_state_change(event: Event[EventStateChangedData]) -> None:
-            """Handle lock entity state change with alarm sensor correlation.
-
-            This is a fallback mechanism for Z-Wave locks that have alarm_type or
-            access_control sensors but don't reliably fire notification events.
-            """
-            if not event:
-                return
-
-            changed_entity: str = event.data["entity_id"]
-            if changed_entity != kmlock.lock_entity_id:
-                return
-
-            old_state: str | None = None
-            if temp_old_state := event.data.get("old_state"):
-                old_state = temp_old_state.state
-            new_state: str | None = None
-            if temp_new_state := event.data.get("new_state"):
-                new_state = temp_new_state.state
-
-            # Only process transitions from locked/unlocked states
-            if old_state not in {LockState.LOCKED, LockState.UNLOCKED}:
-                return
-
-            alarm_level_state = None
-            if kmlock.alarm_level_or_user_code_entity_id:
-                alarm_level_state = self.hass.states.get(kmlock.alarm_level_or_user_code_entity_id)
-            alarm_level_value: int | None = (
-                int(alarm_level_state.state)
-                if alarm_level_state
-                and alarm_level_state.state not in {STATE_UNKNOWN, STATE_UNAVAILABLE}
-                else None
-            )
-
-            alarm_type_state = None
-            if kmlock.alarm_type_or_access_control_entity_id:
-                alarm_type_state = self.hass.states.get(
-                    kmlock.alarm_type_or_access_control_entity_id,
-                )
-            alarm_type_value: int | None = (
-                int(alarm_type_state.state)
-                if alarm_type_state
-                and alarm_type_state.state not in {STATE_UNKNOWN, STATE_UNAVAILABLE}
-                else None
-            )
-
-            # Bail out if we can't use the sensors
-            if alarm_level_value is None or alarm_type_value is None:
-                return
-
-            # Check if sensor is stale (hasn't changed in >5 seconds)
-            sensor_is_stale = (
-                alarm_level_state is not None
-                and alarm_type_state is not None
-                and alarm_type_state.last_changed is not None
-                and new_state
-                and dt_util.utcnow() - dt_util.as_utc(alarm_type_state.last_changed)
-                > timedelta(seconds=5)
-            )
-
-            # Translate sensor event to activity
-            activity = self.get_activity_for_sensor_event(
-                sensor_entity_id=kmlock.alarm_type_or_access_control_entity_id,
-                sensor_value=alarm_type_value,
-                lock_state=new_state if sensor_is_stale else None,
-            )
-
-            if activity:
-                event_label = activity.name
-                code_slot_num = alarm_level_value if activity.method == LockMethod.KEYPAD else 0
-            else:
-                event_label = "Unknown Lock Event"
-                code_slot_num = 0
-
-            self.hass.async_create_task(callback(code_slot_num, event_label, alarm_type_value))
-
         # Subscribe to Z-Wave JS notification events
         unsub_notification = self.hass.bus.async_listen(
             ZWAVE_JS_NOTIFICATION_EVENT,
-            functools.partial(handle_zwave_notification_event),
+            functools.partial(self._handle_zwave_notification_event, callback),
         )
         unsub_list.append(unsub_notification)
         self._listeners.append(unsub_notification)
@@ -1145,7 +1229,7 @@ class ZWaveJSLockProvider(BaseLockProvider):
             unsub_state = async_track_state_change_event(
                 hass=self.hass,
                 entity_ids=kmlock.lock_entity_id,
-                action=functools.partial(handle_lock_state_change),
+                action=functools.partial(self._handle_lock_state_change, kmlock, callback),
             )
             unsub_list.append(unsub_state)
             self._listeners.append(unsub_state)
@@ -1155,6 +1239,78 @@ class ZWaveJSLockProvider(BaseLockProvider):
             self._unsubscribe_all_zwave_listeners(unsub_list)
 
         return unsubscribe_all
+
+    async def _handle_zwave_notification_event(
+        self,
+        callback: LockEventCallback,
+        event: Event,
+    ) -> None:
+        """Handle Z-Wave JS notification event."""
+        node = self._get_node()
+        if not node or not self._device:
+            return
+
+        # Verify this event is for our lock
+        if (
+            event.data.get(ATTR_NODE_ID) != node.node_id
+            or event.data.get(ATTR_DEVICE_ID) != self._device.id
+        ):
+            return
+
+        code_slot_num, event_label, action_code = _get_zwave_notification_details(event)
+        self.hass.async_create_task(callback(code_slot_num, event_label, action_code))
+
+    async def _handle_lock_state_change(
+        self,
+        kmlock: KeymasterLock,
+        callback: LockEventCallback,
+        event: Event[EventStateChangedData],
+    ) -> None:
+        """Handle lock entity state change with alarm sensor correlation.
+
+        This is a fallback mechanism for Z-Wave locks that have alarm_type or
+        access_control sensors but don't reliably fire notification events.
+        """
+        if not event:
+            return
+
+        changed_entity, old_state, new_state = _get_state_changed_event_states(event)
+        if changed_entity != kmlock.lock_entity_id:
+            return
+
+        # Only process transitions from locked/unlocked states
+        if old_state not in {LockState.LOCKED, LockState.UNLOCKED}:
+            return
+
+        alarm_level_state, alarm_level_value = _get_alarm_sensor_state_value(
+            self.hass,
+            kmlock.alarm_level_or_user_code_entity_id,
+        )
+        alarm_type_state, alarm_type_value = _get_alarm_sensor_state_value(
+            self.hass,
+            kmlock.alarm_type_or_access_control_entity_id,
+        )
+
+        # Bail out if we can't use the sensors
+        if alarm_level_value is None or alarm_type_value is None:
+            return
+
+        # Check if sensor is stale (hasn't changed in >5 seconds)
+        sensor_is_stale = _alarm_type_sensor_is_stale(
+            alarm_level_state,
+            alarm_type_state,
+            new_state,
+        )
+
+        # Translate sensor event to activity
+        activity = self.get_activity_for_sensor_event(
+            sensor_entity_id=kmlock.alarm_type_or_access_control_entity_id,
+            sensor_value=alarm_type_value,
+            lock_state=new_state if sensor_is_stale else None,
+        )
+
+        code_slot_num, event_label = _get_activity_callback_details(activity, alarm_level_value)
+        self.hass.async_create_task(callback(code_slot_num, event_label, alarm_type_value))
 
     def _unsubscribe_all_zwave_listeners(self, unsub_list: list[Callable[[], None]]) -> None:
         """Unsubscribe from all Z-Wave JS event sources."""

--- a/tests/providers/test_zwave_js.py
+++ b/tests/providers/test_zwave_js.py
@@ -2,11 +2,13 @@
 
 import builtins
 from dataclasses import dataclass
+from datetime import timedelta
 from enum import Enum
 import importlib
 import sys
 from types import ModuleType, SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -24,7 +26,12 @@ from custom_components.keymaster.providers.zwave_js import ZWaveJSLockProvider
 from homeassistant.components.lock.const import LockState
 from homeassistant.components.zwave_js.const import ATTR_PARAMETERS
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import ATTR_DEVICE_ID, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import (
+    ATTR_DEVICE_ID,
+    EVENT_HOMEASSISTANT_STARTED,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import Event as HAEvent, HomeAssistant
 from tests.common import async_capture_events
 from tests.const import CONFIG_DATA_910
@@ -351,6 +358,16 @@ class TestZWaveJSLockProviderConnect:
 
         assert result is False
 
+    async def test_connect_node_missing_from_controller(self, zwave_provider, mock_zwave_client):
+        """Test connect fails when the Z-Wave controller has no matching node."""
+        setup_successful_connect(zwave_provider, mock_zwave_client)
+        mock_zwave_client.driver.controller.nodes = {}
+
+        result = await zwave_provider.async_connect()
+
+        assert result is False
+        assert zwave_provider.node is None
+
     async def test_connect_success(self, zwave_provider, mock_zwave_client, mock_zwave_node):
         """Test successful connection."""
         mock_device = setup_successful_connect(zwave_provider, mock_zwave_client)
@@ -620,6 +637,24 @@ class TestZWaveJSLockProviderUsercodes:
             "custom_components.keymaster.providers.zwave_js.clear_usercode",
             new_callable=AsyncMock,
             side_effect=BaseZwaveJSServerError("error"),
+        ):
+            result = await zwave_provider.async_clear_usercode(1)
+
+        assert result is False
+
+    async def test_clear_usercode_verify_error(self, zwave_provider, mock_zwave_node):
+        """Test clear_usercode returns False when verification raises."""
+        zwave_provider._node = mock_zwave_node
+
+        with (
+            patch(
+                "custom_components.keymaster.providers.zwave_js.clear_usercode",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "custom_components.keymaster.providers.zwave_js.get_usercode",
+                side_effect=BaseZwaveJSServerError("verify failed"),
+            ),
         ):
             result = await zwave_provider.async_clear_usercode(1)
 
@@ -1065,6 +1100,47 @@ class TestZWaveJSLockProviderCredentialCC:
 class TestZWaveJSLockProviderEventSubscription:
     """Test ZWaveJSLockProvider event subscription."""
 
+    def _provider_with_real_hass(self, hass: HomeAssistant) -> ZWaveJSLockProvider:
+        """Create a Z-Wave JS provider backed by the real Home Assistant fixture."""
+        config_entry = MagicMock()
+        config_entry.entry_id = "keymaster_test_entry"
+        return ZWaveJSLockProvider(
+            hass=hass,
+            lock_entity_id="lock.test_lock",
+            keymaster_config_entry=config_entry,
+            device_registry=MagicMock(),
+            entity_registry=MagicMock(),
+        )
+
+    def _alarm_kmlock(
+        self,
+        *,
+        lock_entity_id: str = "lock.test_lock",
+        alarm_level_entity_id: str | None = "sensor.test_alarm_level",
+        alarm_type_entity_id: str | None = "sensor.test_access_control",
+    ) -> Any:
+        """Create a mock Keymaster lock with alarm sensor entity IDs."""
+        return SimpleNamespace(
+            lock_entity_id=lock_entity_id,
+            alarm_level_or_user_code_entity_id=alarm_level_entity_id,
+            alarm_type_or_access_control_entity_id=alarm_type_entity_id,
+        )
+
+    async def _fire_lock_state_change(
+        self,
+        hass: HomeAssistant,
+        *,
+        old_state: str = LockState.UNLOCKED,
+        new_state: str = LockState.LOCKED,
+        entity_id: str = "lock.test_lock",
+    ) -> None:
+        """Fire a lock state transition and drain pending tasks."""
+        hass.states.async_set(entity_id, old_state)
+        await hass.async_block_till_done()
+        hass.states.async_set(entity_id, new_state)
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
     def test_subscribe_lock_events(self, zwave_provider, mock_zwave_node):
         """Test subscribe_lock_events registers listener for notification events."""
         zwave_provider._node = mock_zwave_node
@@ -1083,6 +1159,35 @@ class TestZWaveJSLockProviderEventSubscription:
         assert unsub is not None
         zwave_provider.hass.bus.async_listen.assert_called_once()
         # Only notification event listener when no alarm sensors configured
+        assert len(zwave_provider._listeners) == 1
+
+    @pytest.mark.parametrize(
+        ("alarm_level_entity_id", "alarm_type_entity_id"),
+        [
+            ("sensor.test_alarm_level", None),
+            (None, "sensor.test_access_control"),
+            (None, None),
+        ],
+    )
+    def test_subscribe_lock_events_requires_both_alarm_sensors(
+        self,
+        zwave_provider,
+        alarm_level_entity_id,
+        alarm_type_entity_id,
+    ):
+        """Test state listener registration requires both alarm sensor IDs."""
+        mock_kmlock = self._alarm_kmlock(
+            alarm_level_entity_id=alarm_level_entity_id,
+            alarm_type_entity_id=alarm_type_entity_id,
+        )
+
+        with patch(
+            "custom_components.keymaster.providers.zwave_js.async_track_state_change_event",
+        ) as mock_track:
+            zwave_provider.subscribe_lock_events(mock_kmlock, AsyncMock())
+
+        mock_track.assert_not_called()
+        zwave_provider.hass.bus.async_listen.assert_called_once()
         assert len(zwave_provider._listeners) == 1
 
     async def test_handle_zwave_notification_event_dispatches_correctly(
@@ -1149,6 +1254,86 @@ class TestZWaveJSLockProviderEventSubscription:
         await handler(matching_event)
         zwave_provider.hass.async_create_task.assert_not_called()
 
+    async def test_zwave_notification_event_uses_non_keypad_activity(
+        self,
+        hass,
+        mock_zwave_node,
+    ):
+        """Test Z-Wave notification event label fallbacks and non-keypad activity."""
+        provider = self._provider_with_real_hass(hass)
+        provider._node = mock_zwave_node
+        mock_zwave_node.node_id = 14
+        provider._device = SimpleNamespace(id="device_123")
+        callback = AsyncMock()
+
+        provider.subscribe_lock_events(self._alarm_kmlock(alarm_level_entity_id=None), callback)
+        hass.bus.async_fire(
+            "zwave_js_notification",
+            {
+                ATTR_NODE_ID: 14,
+                ATTR_DEVICE_ID: "device_123",
+                "command_class": 113,
+                "type": 6,
+                "event": 3,
+                ATTR_PARAMETERS: {"userId": 9},
+            },
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+        hass.bus.async_fire(
+            "zwave_js_notification",
+            {
+                ATTR_NODE_ID: 14,
+                ATTR_DEVICE_ID: "device_123",
+                "command_class": 113,
+                "type": 6,
+                "event": 999,
+                "event_label": "Controller Label",
+                ATTR_PARAMETERS: {"userId": 9},
+            },
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+        hass.bus.async_fire(
+            "zwave_js_notification",
+            {
+                ATTR_NODE_ID: 14,
+                ATTR_DEVICE_ID: "device_123",
+                "command_class": 98,
+                "type": 6,
+                "event": 0,
+                "event_label": "Plain Label",
+                ATTR_PARAMETERS: {"userId": 4},
+            },
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+        callback.assert_has_awaits(
+            [
+                call(0, "RF Lock", 3),
+                call(9, "Controller Label", 999),
+                call(4, "Plain Label", 0),
+            ]
+        )
+
+    def test_get_activity_for_sensor_event_ignores_unknown_sensor_type(self, zwave_provider):
+        """Test sensor activity lookup ignores unrecognized sensor entities."""
+        assert (
+            zwave_provider.get_activity_for_sensor_event(
+                "sensor.front_door_battery",
+                6,
+                LockState.UNLOCKED,
+            )
+            is None
+        )
+
+    def test_get_activity_for_sensor_event_returns_none_for_unmapped_value(self, zwave_provider):
+        """Test sensor activity lookup returns None for unmapped sensor values."""
+        assert zwave_provider.get_activity_for_sensor_event("sensor.test_alarm_type", 999) is None
+
     def test_subscribe_lock_events_with_alarm_sensors(self, zwave_provider, mock_zwave_node):
         """Test subscribe_lock_events also subscribes to state changes when alarm sensors are configured."""
         zwave_provider._node = mock_zwave_node
@@ -1210,6 +1395,178 @@ class TestZWaveJSLockProviderEventSubscription:
 
         # Stale successfully unsubscribed listeners should be cleaned up from self._listeners
         assert mock_unsub_success not in zwave_provider._listeners
+
+    async def test_lock_state_change_event_ignores_empty_event(self, zwave_provider):
+        """Test lock state handler ignores a falsy event."""
+        handler = None
+
+        def fake_track_state_change_event(*, hass, entity_ids, action):
+            nonlocal handler
+            handler = action
+            return MagicMock()
+
+        with patch(
+            "custom_components.keymaster.providers.zwave_js.async_track_state_change_event",
+            side_effect=fake_track_state_change_event,
+        ):
+            zwave_provider.subscribe_lock_events(self._alarm_kmlock(), AsyncMock())
+
+        assert handler is not None
+        await handler(None)
+        zwave_provider.hass.async_create_task.assert_not_called()
+
+    async def test_lock_state_change_event_ignores_different_entity(self, zwave_provider):
+        """Test lock state handler ignores changes for other entities."""
+        handler = None
+
+        def fake_track_state_change_event(*, hass, entity_ids, action):
+            nonlocal handler
+            handler = action
+            return MagicMock()
+
+        with patch(
+            "custom_components.keymaster.providers.zwave_js.async_track_state_change_event",
+            side_effect=fake_track_state_change_event,
+        ):
+            zwave_provider.subscribe_lock_events(self._alarm_kmlock(), AsyncMock())
+
+        assert handler is not None
+        event = HAEvent(
+            "state_changed",
+            {
+                "entity_id": "lock.other_lock",
+                "old_state": SimpleNamespace(state=LockState.UNLOCKED),
+                "new_state": SimpleNamespace(state=LockState.LOCKED),
+            },
+        )
+        await handler(event)
+        zwave_provider.hass.async_create_task.assert_not_called()
+
+    async def test_lock_state_change_event_ignores_non_lock_old_state(self, hass):
+        """Test alarm fallback ignores transitions from non-locked states."""
+        provider = self._provider_with_real_hass(hass)
+        callback = AsyncMock()
+        provider.subscribe_lock_events(self._alarm_kmlock(), callback)
+        hass.states.async_set("sensor.test_alarm_level", "7")
+        hass.states.async_set("sensor.test_access_control", "6")
+        await hass.async_block_till_done()
+
+        await self._fire_lock_state_change(
+            hass,
+            old_state=LockState.JAMMED,
+            new_state=LockState.LOCKED,
+        )
+
+        callback.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        ("alarm_level_value", "alarm_type_value"),
+        [
+            (STATE_UNKNOWN, "6"),
+            (STATE_UNAVAILABLE, "6"),
+            (None, "6"),
+            ("7", STATE_UNKNOWN),
+            ("7", STATE_UNAVAILABLE),
+            ("7", None),
+        ],
+    )
+    async def test_lock_state_change_event_requires_usable_alarm_sensors(
+        self,
+        hass,
+        alarm_level_value,
+        alarm_type_value,
+    ):
+        """Test alarm fallback does not dispatch when either alarm sensor is unusable."""
+        provider = self._provider_with_real_hass(hass)
+        callback = AsyncMock()
+        provider.subscribe_lock_events(self._alarm_kmlock(), callback)
+        if alarm_level_value is not None:
+            hass.states.async_set("sensor.test_alarm_level", alarm_level_value)
+        if alarm_type_value is not None:
+            hass.states.async_set("sensor.test_access_control", alarm_type_value)
+        await hass.async_block_till_done()
+
+        await self._fire_lock_state_change(hass)
+
+        callback.assert_not_awaited()
+
+    async def test_lock_state_change_event_dispatches_keypad_activity(self, hass):
+        """Test alarm fallback uses the alarm level as keypad code slot."""
+        provider = self._provider_with_real_hass(hass)
+        callback = AsyncMock()
+        provider.subscribe_lock_events(self._alarm_kmlock(), callback)
+        hass.states.async_set("sensor.test_alarm_level", "7")
+        hass.states.async_set("sensor.test_access_control", "6")
+        await hass.async_block_till_done()
+
+        await self._fire_lock_state_change(hass)
+
+        callback.assert_awaited_once_with(7, "Keypad Unlock", 6)
+
+    async def test_lock_state_change_event_dispatches_non_keypad_activity(self, hass):
+        """Test alarm fallback uses code slot zero for non-keypad activities."""
+        provider = self._provider_with_real_hass(hass)
+        callback = AsyncMock()
+        provider.subscribe_lock_events(self._alarm_kmlock(), callback)
+        hass.states.async_set("sensor.test_alarm_level", "8")
+        hass.states.async_set("sensor.test_access_control", "4")
+        await hass.async_block_till_done()
+
+        await self._fire_lock_state_change(hass)
+
+        callback.assert_awaited_once_with(0, "RF Unlock", 4)
+
+    async def test_lock_state_change_event_dispatches_unknown_activity(self, hass):
+        """Test alarm fallback emits the unknown label when no activity resolves."""
+        provider = self._provider_with_real_hass(hass)
+        callback = AsyncMock()
+        provider.subscribe_lock_events(self._alarm_kmlock(), callback)
+        hass.states.async_set("sensor.test_alarm_level", "9")
+        hass.states.async_set("sensor.test_access_control", "999")
+        await hass.async_block_till_done()
+
+        await self._fire_lock_state_change(hass)
+
+        callback.assert_awaited_once_with(0, "Unknown Lock Event", 999)
+
+    async def test_lock_state_change_event_passes_state_for_stale_sensor(self, hass):
+        """Test alarm fallback passes lock state when the alarm type sensor is stale."""
+        provider = self._provider_with_real_hass(hass)
+        callback = AsyncMock()
+        provider.subscribe_lock_events(self._alarm_kmlock(), callback)
+        hass.states.async_set("sensor.test_alarm_level", "10")
+        hass.states.async_set("sensor.test_access_control", "6")
+        await hass.async_block_till_done()
+        alarm_type_state = hass.states.get("sensor.test_access_control")
+        assert alarm_type_state is not None
+        stale_now = zwave_js_provider.dt_util.as_utc(alarm_type_state.last_changed) + timedelta(
+            seconds=6,
+        )
+
+        with patch("custom_components.keymaster.providers.zwave_js.dt_util.utcnow") as mock_utcnow:
+            mock_utcnow.return_value = stale_now
+            await self._fire_lock_state_change(hass, new_state=LockState.LOCKED)
+
+        callback.assert_awaited_once_with(0, "RF Lock", 6)
+
+    async def test_lock_state_change_event_omits_state_for_fresh_sensor(self, hass):
+        """Test alarm fallback omits lock state when the alarm type sensor is fresh."""
+        provider = self._provider_with_real_hass(hass)
+        callback = AsyncMock()
+        provider.get_activity_for_sensor_event = MagicMock(return_value=None)
+        provider.subscribe_lock_events(self._alarm_kmlock(), callback)
+        hass.states.async_set("sensor.test_alarm_level", "10")
+        hass.states.async_set("sensor.test_access_control", "6")
+        await hass.async_block_till_done()
+
+        await self._fire_lock_state_change(hass, new_state=LockState.LOCKED)
+
+        provider.get_activity_for_sensor_event.assert_called_once_with(
+            sensor_entity_id="sensor.test_access_control",
+            sensor_value=6,
+            lock_state=None,
+        )
+        callback.assert_awaited_once_with(0, "Unknown Lock Event", 6)
 
 
 class TestZWaveJSLockProviderDiagnostics:


### PR DESCRIPTION
# Summary

Add characterization coverage for the Z-Wave JS lock event subscription fallback, then split the oversized Z-Wave JS provider methods into focused helpers without changing behavior.

## Proposed change

The first commit pins the existing alarm-sensor fallback behavior and notification event handling in tests. The second commit extracts helper functions and methods from the long Z-Wave JS connect, set, clear, and event subscription paths so every function in `zwave_js.py` is within the static-analysis limit.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

This PR is related to issue: #769
