### PR TITLE
test: cover parent lock cycle guard

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,7 +8,11 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 import voluptuous as vol
 
-from custom_components.keymaster.config_flow_schema import get_entities, get_schema
+from custom_components.keymaster.config_flow_schema import (
+    _available_parent_locks,
+    get_entities,
+    get_schema,
+)
 from custom_components.keymaster.const import (
     CONF_ADVANCED_DATE_RANGE,
     CONF_ADVANCED_DAY_OF_WEEK,
@@ -169,6 +173,77 @@ async def test_get_schema_raises_without_flow_when_no_locks(hass):
             user_input=None,
             default_dict={CONF_NOTIFY_SCRIPT_NAME: None},
         )
+
+
+async def test_available_parent_locks_returns_none_when_domain_not_loaded(hass):
+    """Test parent lock lookup returns only none before keymaster data exists."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Front Door", data={}, entry_id="front_door")
+    entry.add_to_hass(hass)
+
+    assert _available_parent_locks(hass) == [NONE_TEXT]
+
+
+async def test_available_parent_locks_filters_self_and_child_entries(hass):
+    """Test parent lock lookup excludes the current entry and child locks."""
+    hass.data[DOMAIN] = {}
+    current_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Front Door",
+        data={CONF_PARENT: None},
+        entry_id="front_door",
+    )
+    eligible_without_parent_key = MockConfigEntry(
+        domain=DOMAIN,
+        title="Back Door",
+        data={},
+        entry_id="back_door",
+    )
+    eligible_with_no_parent = MockConfigEntry(
+        domain=DOMAIN,
+        title="Garage Door",
+        data={CONF_PARENT: None},
+        entry_id="garage_door",
+    )
+    child_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Guest Door",
+        data={CONF_PARENT: "Front Door"},
+        entry_id="guest_door",
+    )
+    for entry in (
+        current_entry,
+        eligible_without_parent_key,
+        eligible_with_no_parent,
+        child_entry,
+    ):
+        entry.add_to_hass(hass)
+
+    assert _available_parent_locks(hass, entry_id="front_door") == [
+        NONE_TEXT,
+        "Back Door",
+        "Garage Door",
+    ]
+
+
+async def test_available_parent_locks_includes_current_entry_when_entry_id_is_none(hass):
+    """Test parent lock lookup does not exclude entries when no entry ID is given."""
+    hass.data[DOMAIN] = {}
+    current_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Front Door",
+        data={CONF_PARENT: None},
+        entry_id="front_door",
+    )
+    child_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Guest Door",
+        data={CONF_PARENT: "Front Door"},
+        entry_id="guest_door",
+    )
+    for entry in (current_entry, child_entry):
+        entry.add_to_hass(hass)
+
+    assert _available_parent_locks(hass, entry_id=None) == [NONE_TEXT, "Front Door"]
 
 
 async def test_get_entities_filters_excludes_and_sorts(hass):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -692,31 +692,41 @@ class TestRebuildLockRelationships:
         # Assert
         assert len(parent_lock.child_config_entry_ids) == 0
 
-    async def test_rebuild_with_circular_reference_prevention(self, mock_coordinator):
-        """Test that circular parent-child references are handled without crash."""
-        # Arrange: Lock A claims B as child, B claims A as child
+    async def test_rebuild_defensively_handles_existing_circular_references(self, mock_coordinator):
+        """Test defensive handling of circular references from pre-existing data."""
+        # Arrange: Lock A claims B as child, B claims A as child. The config flow
+        # guard in _available_parent_locks prevents this state through the UI.
         lock_a = Mock(spec=KeymasterLock)
         lock_a.keymaster_config_entry_id = "lock_a"
         lock_a.lock_name = "Lock A"
         lock_a.child_config_entry_ids = ["lock_b"]
-        lock_a.parent_config_entry_id = "lock_b"  # Circular!
+        lock_a.parent_config_entry_id = "lock_b"
         lock_a.parent_name = "Lock B"
 
         lock_b = Mock(spec=KeymasterLock)
         lock_b.keymaster_config_entry_id = "lock_b"
         lock_b.lock_name = "Lock B"
         lock_b.child_config_entry_ids = ["lock_a"]
-        lock_b.parent_config_entry_id = "lock_a"  # Circular!
+        lock_b.parent_config_entry_id = "lock_a"
         lock_b.parent_name = "Lock A"
 
         mock_coordinator.kmlocks = {"lock_a": lock_a, "lock_b": lock_b}
+        original_lock_a_parent = lock_a.parent_config_entry_id
+        original_lock_b_parent = lock_b.parent_config_entry_id
+        original_lock_a_children = lock_a.child_config_entry_ids.copy()
+        original_lock_b_children = lock_b.child_config_entry_ids.copy()
 
-        # Act - should handle gracefully without infinite loop or crash
+        # Act
         await mock_coordinator._rebuild_lock_relationships()
 
-        # Assert: Function completed without errors
-        # Note: Circular refs may persist but shouldn't crash
-        assert True  # If we got here, no crash occurred
+        # Assert: The single-pass rebuild leaves the existing cycle unchanged
+        # without duplicating child relationships.
+        assert lock_a.parent_config_entry_id == original_lock_a_parent
+        assert lock_b.parent_config_entry_id == original_lock_b_parent
+        assert lock_a.child_config_entry_ids == original_lock_a_children
+        assert lock_b.child_config_entry_ids == original_lock_b_children
+        assert len(lock_a.child_config_entry_ids) == len(set(lock_a.child_config_entry_ids))
+        assert len(lock_b.child_config_entry_ids) == len(set(lock_b.child_config_entry_ids))
 
     async def test_rebuild_preserves_parent_name_relationships(self, mock_coordinator):
         """Test that parent-child relationships via parent_name are established."""


### PR DESCRIPTION
# Summary
Adds test-only coverage for the parent-lock selector guard that prevents self-parent and child-as-parent choices. Rewrites the coordinator circular-reference test to assert observable defensive behavior instead of a tautological success assertion.

## Proposed change
- Cover `_available_parent_locks` early-return and parent eligibility filtering.
- Verify existing circular coordinator state remains unchanged without duplicate child relationships.
- No production files are modified.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #781
- This PR is related to issue: