### PR TITLE
refactor: extract coordinator helper modules

### DIFF
--- a/custom_components/keymaster/bus_events.py
+++ b/custom_components/keymaster/bus_events.py
@@ -1,0 +1,98 @@
+"""Home Assistant bus event helpers for keymaster locks."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from homeassistant.components.lock.const import LockState
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_STATE
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    ATTR_ACTION_CODE,
+    ATTR_ACTION_TEXT,
+    ATTR_CODE_SLOT,
+    ATTR_CODE_SLOT_NAME,
+    ATTR_NAME,
+    ATTR_NOTIFICATION_SOURCE,
+    EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+)
+from .lock import KeymasterLock
+
+
+class LockStateChangedEvent(NamedTuple):
+    """Details for a keymaster_lock_state_changed bus event."""
+
+    code_slot_num: int
+    source: str | None
+    event_label: str | None
+    action_code: int | None
+
+
+def fire_lock_state_changed_event(
+    hass: HomeAssistant,
+    kmlock: KeymasterLock,
+    state: str,
+    event: LockStateChangedEvent,
+) -> None:
+    """Fire the keymaster_lock_state_changed bus event."""
+    slot = kmlock.code_slots.get(event.code_slot_num) if kmlock.code_slots else None
+    hass.bus.fire(
+        EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+        event_data={
+            ATTR_NOTIFICATION_SOURCE: event.source,
+            ATTR_NAME: kmlock.lock_name,
+            ATTR_ENTITY_ID: kmlock.lock_entity_id,
+            ATTR_STATE: state,
+            ATTR_ACTION_CODE: event.action_code,
+            ATTR_ACTION_TEXT: event.event_label,
+            ATTR_CODE_SLOT: event.code_slot_num,
+            ATTR_CODE_SLOT_NAME: (slot.name or "") if slot and event.code_slot_num != 0 else "",
+        },
+    )
+
+
+def fire_unlock_state_changed(
+    hass: HomeAssistant,
+    kmlock: KeymasterLock,
+    *,
+    code_slot_num: int,
+    source: str | None,
+    event_label: str | None,
+    action_code: int | None,
+) -> None:
+    """Fire the keymaster_lock_state_changed bus event for an unlock."""
+    fire_lock_state_changed_event(
+        hass,
+        kmlock,
+        LockState.UNLOCKED,
+        LockStateChangedEvent(
+            code_slot_num=code_slot_num,
+            source=source,
+            event_label=event_label,
+            action_code=action_code,
+        ),
+    )
+
+
+def fire_lock_state_changed(
+    hass: HomeAssistant,
+    kmlock: KeymasterLock,
+    *,
+    code_slot_num: int,
+    source: str | None,
+    event_label: str | None,
+    action_code: int | None,
+) -> None:
+    """Fire the keymaster_lock_state_changed bus event for a lock."""
+    fire_lock_state_changed_event(
+        hass,
+        kmlock,
+        LockState.LOCKED,
+        LockStateChangedEvent(
+            code_slot_num=code_slot_num,
+            source=source,
+            event_label=event_label,
+            action_code=action_code,
+        ),
+    )

--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -3,23 +3,19 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 from collections.abc import AsyncIterator, Callable, Iterable, MutableMapping
 import contextlib
 from contextlib import asynccontextmanager
-from dataclasses import fields, is_dataclass
 from datetime import datetime as dt, time as dt_time, timedelta
 import functools
-import json
 import logging
 from pathlib import Path
-from typing import Any, Union, cast, get_args, get_origin
+from typing import Any, cast
 
 from homeassistant.components.lock.const import DOMAIN as LOCK_DOMAIN, LockState
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_STATE,
     EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
     SERVICE_LOCK,
@@ -37,13 +33,9 @@ from homeassistant.util import slugify
 from homeassistant.util.dt import utcnow
 
 from .autolock import AutolockTimer, TimerStore
+from .bus_events import fire_lock_state_changed, fire_unlock_state_changed
 from .const import (
-    ATTR_ACTION_CODE,
-    ATTR_ACTION_TEXT,
     ATTR_CODE_SLOT,
-    ATTR_CODE_SLOT_NAME,
-    ATTR_NAME,
-    ATTR_NOTIFICATION_SOURCE,
     BACKOFF_FAILURE_THRESHOLD,
     BACKOFF_INITIAL_SECONDS,
     BACKOFF_MAX_SECONDS,
@@ -53,7 +45,6 @@ from .const import (
     DOMAIN,
     ENTITY_DEBOUNCE_SECONDS,
     EVENT_KEYMASTER_CODE_SLOT_RESET,
-    EVENT_KEYMASTER_LOCK_STATE_CHANGED,
     ISSUE_URL,
     PIN_SET_GRACE_SECONDS,
     QUICK_REFRESH_SECONDS,
@@ -68,17 +59,23 @@ from .helpers import (
     call_hass_service,
     delete_code_slot_entities,
     dismiss_persistent_notification,
+    format_slot_message,
+    global_notification_superseded,
     send_manual_notification,
     send_persistent_notification,
+    should_defer_keypad_lock_notification,
+    should_defer_keypad_unlock_notification,
 )
-from .lock import (
-    KeymasterCodeSlot,
-    KeymasterCodeSlotDayOfWeek,
-    KeymasterLock,
-    keymasterlock_type_lookup,
-)
+from .lock import KeymasterCodeSlot, KeymasterCodeSlotDayOfWeek, KeymasterLock
 from .lovelace import delete_lovelace
 from .providers import CodeSlot, create_provider
+from .serialization import (
+    encode_pin,
+    kmlocks_to_dict,
+    migrate_legacy_json,
+    process_loaded_data,
+    sanitized_lock_dict,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -90,12 +87,6 @@ KEYPAD_NOTIFICATION_DELAY_SECONDS = 1
 
 STORAGE_VERSION = 1
 STORAGE_KEY = f"{DOMAIN}.locks"
-
-
-@functools.cache
-def _serializable_dataclass_fields(cls: type) -> tuple[Any, ...]:
-    """Return dataclass fields that are persisted."""
-    return tuple(field for field in fields(cls) if field.init)
 
 
 def _is_masked_code(code: str | None) -> bool:
@@ -562,7 +553,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if legacy_json_file.exists():
             _LOGGER.info("[load_data] Found legacy JSON file, migrating to Home Assistant storage")
             config = await self.hass.async_add_executor_job(
-                self._migrate_legacy_json,
+                migrate_legacy_json,
                 legacy_json_file,
                 legacy_json_folder,
             )
@@ -575,69 +566,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("[load_data] No stored data found")
             return {}
 
-        return self._process_loaded_data(stored_data)
-
-    def _migrate_legacy_json(
-        self,
-        json_file: Path,
-        json_folder: str,
-    ) -> MutableMapping[str, KeymasterLock]:
-        """Load legacy JSON file, clean it up, and return processed data.
-
-        This is a synchronous method that performs file I/O. Must be called
-        via async_add_executor_job.
-        """
-        config: MutableMapping[str, KeymasterLock] = {}
-        try:
-            with json_file.open(encoding="utf-8") as f:
-                config = self._process_loaded_data(json.load(f))
-        except (OSError, json.JSONDecodeError) as e:
-            _LOGGER.warning(
-                "[migrate_legacy_json] Error reading legacy JSON file: %s: %s",
-                e.__class__.__qualname__,
-                e,
-            )
-
-        # Always clean up the legacy file (regardless of load success)
-        try:
-            json_file.unlink()
-            _LOGGER.info("[migrate_legacy_json] Legacy JSON file deleted")
-        except OSError as e:
-            _LOGGER.warning(
-                "[migrate_legacy_json] Could not delete legacy JSON file: %s: %s",
-                e.__class__.__qualname__,
-                e,
-            )
-            return config
-
-        # Try to remove the folder if empty
-        try:
-            Path(json_folder).rmdir()
-            _LOGGER.debug("[migrate_legacy_json] Legacy JSON folder removed")
-        except OSError:
-            # Folder not empty or other issue - that's fine
-            pass
-
-        return config
-
-    def _process_loaded_data(self, config: dict) -> MutableMapping[str, KeymasterLock]:
-        """Process loaded config data into KeymasterLock objects."""
-        for lock in config.values():
-            lock["autolock_timer"] = None
-            lock["listeners"] = []
-            for kmslot in (lock.get("code_slots") or {}).values():
-                if isinstance(kmslot.get("pin", None), str):
-                    kmslot["pin"] = KeymasterCoordinator._decode_pin(
-                        kmslot["pin"],
-                        lock["keymaster_config_entry_id"],
-                    )
-
-        kmlocks: MutableMapping = {
-            key: self._dict_to_kmlocks(value, KeymasterLock) for key, value in config.items()
-        }
-
-        _LOGGER.debug("[load_data] Loaded kmlocks: %s", kmlocks)
-        return kmlocks
+        return process_loaded_data(stored_data)
 
     async def _async_save_data(
         self,
@@ -669,10 +598,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
 
         for key, kmlock in save_kmlocks:
-            lock = self._sanitized_lock_dict(self._kmlocks_to_dict(kmlock))
+            lock = sanitized_lock_dict(kmlocks_to_dict(kmlock))
             for kmslot in (lock.get("code_slots") or {}).values():
                 if isinstance(kmslot.get("pin", None), str):
-                    kmslot["pin"] = KeymasterCoordinator._encode_pin(
+                    kmslot["pin"] = encode_pin(
                         kmslot["pin"],
                         lock["keymaster_config_entry_id"],
                     )
@@ -730,22 +659,12 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         ):
             await self.async_flush_pending_save_data()
 
-    def _sanitized_lock_dict(self, lock: object) -> dict[str, Any]:
-        """Remove runtime-only lock fields from a serialized lock dictionary."""
-        sanitized = dict(lock) if isinstance(lock, dict) else {}
-        sanitized.pop("zwave_js_lock_device", None)
-        sanitized.pop("zwave_js_lock_node", None)
-        sanitized.pop("autolock_timer", None)
-        sanitized.pop("listeners", None)
-        sanitized.pop("provider", None)
-        return sanitized
-
     def _lock_snapshot(self, entry_id: str) -> dict[str, Any] | None:
         """Return a sanitized comparable snapshot for one lock."""
         kmlock = self.kmlocks.get(entry_id)
         if kmlock is None:
             return None
-        return self._sanitized_lock_dict(self._kmlocks_to_dict(kmlock))
+        return sanitized_lock_dict(kmlocks_to_dict(kmlock))
 
     async def async_remove_data(self) -> None:
         """Remove stored data."""
@@ -769,242 +688,6 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("deleting %s from kmlocks", lock)
                 await self.delete_lock_by_config_entry_id(config_entry_id)
             _LOGGER.debug("================================")
-
-    @staticmethod
-    def _encode_pin(pin: str, unique_id: str) -> str:
-        salted_pin: bytes = unique_id.encode("utf-8") + pin.encode("utf-8")
-        encoded_pin: str = base64.b64encode(salted_pin).decode("utf-8")
-        return encoded_pin
-
-    @staticmethod
-    def _decode_pin(encoded_pin: str, unique_id: str) -> str:
-        decoded_pin_with_salt: bytes = base64.b64decode(encoded_pin)
-        salt_length: int = len(unique_id.encode("utf-8"))
-        original_pin: str = decoded_pin_with_salt[salt_length:].decode("utf-8")
-        return original_pin
-
-    def _dict_to_kmlocks(self, data: dict, cls: type) -> Any:
-        """Recursively convert a dictionary to a dataclass instance."""
-        if hasattr(cls, "__dataclass_fields__"):
-            field_values: MutableMapping = {}
-
-            for field in _serializable_dataclass_fields(cls):
-                field_values[field.name] = self._kmlock_field_from_dict(data, field)
-
-            return cls(**field_values)
-
-        return data
-
-    def _kmlock_field_type_from_dict(self, field_name: str, field_type: Any) -> Any:
-        """Resolve the stored type metadata for a Keymaster lock field."""
-        resolved_type = keymasterlock_type_lookup.get(field_name)
-        if not resolved_type and isinstance(field_type, type):
-            resolved_type = field_type
-        return resolved_type
-
-    def _kmlock_field_from_dict(self, data: dict, field: Any) -> Any:
-        """Convert one serialized dataclass field to its runtime value."""
-        field_name: str = field.name
-        field_type = self._kmlock_field_type_from_dict(field_name, field.type)
-        field_value: Any = data.get(field_name)
-
-        origin_type = get_origin(field_type)
-        type_args = get_args(field_type)
-
-        # _LOGGER.debug(
-        #     f"[dict_to_kmlocks] field_name: {field_name}, field_type: {field_type}, "
-        #     f"origin_type: {origin_type}, type_args: {type_args}, "
-        #     f"field_value_type: {type(field_value)}, field_value: {field_value}"
-        # )
-
-        field_type, origin_type, type_args = self._kmlock_optional_type_from_dict(
-            field_name,
-            field_type,
-            origin_type,
-            type_args,
-        )
-        field_value = self._kmlock_temporal_value_from_dict(field_name, field_value, field_type)
-        return self._kmlock_collection_value_from_dict(
-            field_name,
-            field_value,
-            field_type,
-            origin_type,
-            type_args,
-        )
-
-    def _kmlock_optional_type_from_dict(
-        self,
-        field_name: str,
-        field_type: Any,
-        origin_type: Any,
-        type_args: tuple[Any, ...],
-    ) -> tuple[Any, Any, tuple[Any, ...]]:
-        """Unwrap Optional fields while preserving existing Union handling."""
-        # Handle optional types (Union)
-        if origin_type is not Union:
-            return field_type, origin_type, type_args
-
-        non_optional_types = [t for t in type_args if t is not type(None)]
-        if len(non_optional_types) != 1:
-            return field_type, origin_type, type_args
-
-        field_type = non_optional_types[0]
-        origin_type = get_origin(field_type)
-        type_args = get_args(field_type)
-        # _LOGGER.debug(
-        #     f"[dict_to_kmlocks] Updated for Union: "
-        #     f"field_name: {field_name}, field_type: {field_type}, "
-        #     f"origin_type: {origin_type}, type_args: {type_args}"
-        # )
-        return field_type, origin_type, type_args
-
-    def _kmlock_temporal_value_from_dict(
-        self,
-        field_name: str,
-        field_value: Any,
-        field_type: Any,
-    ) -> Any:
-        """Convert serialized temporal strings while preserving fallback behavior."""
-        # Convert datetime string to datetime object
-        if isinstance(field_value, str) and field_type == dt:
-            # _LOGGER.debug(f"[dict_to_kmlocks] field_name: {field_name}: Converting to datetime")
-            with contextlib.suppress(ValueError):
-                field_value = dt.fromisoformat(field_value)
-
-        # Convert time string to time object
-        elif isinstance(field_value, str) and field_type == dt_time:
-            # _LOGGER.debug(f"[dict_to_kmlocks] field_name: {field_name}: Converting to time")
-            with contextlib.suppress(ValueError):
-                field_value = dt_time.fromisoformat(field_value)
-
-        return field_value
-
-    @staticmethod
-    def _kmlock_key_from_dict(key: Any, key_type: Any) -> Any:
-        """Convert serialized dictionary keys to their runtime type when required."""
-        if key_type is int and isinstance(key, str) and key.isdigit():
-            return int(key)
-        return key
-
-    def _kmlock_collection_value_from_dict(
-        self,
-        field_name: str,
-        field_value: Any,
-        field_type: Any,
-        origin_type: Any,
-        type_args: tuple[Any, ...],
-    ) -> Any:
-        """Convert serialized collection and nested dataclass values."""
-        # _LOGGER.debug(f"[dict_to_kmlocks] isinstance(origin_type, type): {isinstance(origin_type, type)}")
-        # if isinstance(origin_type, type):
-        # _LOGGER.debug(f"[dict_to_kmlocks] issubclass(origin_type, MutableMapping): {issubclass(origin_type, MutableMapping)}, origin_type == dict: {origin_type == dict}")
-
-        # Handle MutableMapping types: when origin_type is MutableMapping
-        if isinstance(origin_type, type) and (
-            issubclass(origin_type, MutableMapping) or origin_type is dict
-        ):
-            return self._kmlock_mapping_value_from_dict(field_name, field_value, type_args)
-
-        if (
-            isinstance(field_value, dict)
-            and is_dataclass(field_type)
-            and isinstance(field_type, type)
-        ):
-            # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting nested dataclass: {field_name}")
-            return self._dict_to_kmlocks(field_value, field_type)
-
-        if isinstance(field_value, list) and type_args:
-            return self._kmlock_list_value_from_dict(field_name, field_value, type_args)
-
-        return field_value
-
-    def _kmlock_mapping_value_from_dict(
-        self,
-        field_name: str,
-        field_value: Any,
-        type_args: tuple[Any, ...],
-    ) -> Any:
-        """Convert serialized mapping values without falling through to other branches."""
-        if len(type_args) != 2:
-            return field_value
-
-        key_type, value_type = type_args
-        # _LOGGER.debug(
-        #     f"[dict_to_kmlocks] field_name: {field_name}: Is MutableMapping or dict. key_type: {key_type}, "
-        #     f"value_type: {value_type}, isinstance(field_value, dict): {isinstance(field_value, dict)}, "
-        #     f"is_dataclass(value_type): {is_dataclass(value_type)}"
-        # )
-        if not isinstance(field_value, dict):
-            return field_value
-
-        # If the value_type is a dataclass, recursively process it
-        if is_dataclass(value_type) and isinstance(value_type, type):
-            # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting dict items for {field_name}")
-            return {
-                self._kmlock_key_from_dict(k, key_type): self._dict_to_kmlocks(v, value_type)
-                for k, v in field_value.items()
-            }
-
-        # If value_type is not a dataclass, just copy the value
-        return {self._kmlock_key_from_dict(k, key_type): v for k, v in field_value.items()}
-
-    def _kmlock_list_value_from_dict(
-        self,
-        field_name: str,
-        field_value: list,
-        type_args: tuple[Any, ...],
-    ) -> Any:
-        """Convert serialized lists containing nested dataclass dictionaries."""
-        list_type = type_args[0]
-        if not (is_dataclass(list_type) and isinstance(list_type, type)):
-            return field_value
-
-        # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting list of dataclasses: {field_name}")
-        return [
-            self._dict_to_kmlocks(item, list_type) if isinstance(item, dict) else item
-            for item in field_value
-        ]
-
-    def _kmlocks_to_dict(self, instance: object) -> object:
-        """Recursively convert a dataclass instance to a dictionary for JSON export."""
-        if is_dataclass(instance):
-            result: MutableMapping = {}
-            for field in _serializable_dataclass_fields(instance.__class__):
-                field_name: str = field.name
-                result[field_name] = self._kmlock_field_to_dict(getattr(instance, field_name))
-            return result
-        return instance
-
-    def _kmlock_field_to_dict(self, field_value: Any) -> object:
-        """Convert a dataclass field value to a JSON-compatible value."""
-        field_value = self._kmlock_temporal_value_to_dict(field_value)
-        return self._kmlock_collection_value_to_dict(field_value)
-
-    def _kmlock_temporal_value_to_dict(self, field_value: Any) -> Any:
-        """Convert temporal field values while preserving existing ordered checks."""
-        if isinstance(field_value, dt):
-            field_value = field_value.isoformat()
-
-        if isinstance(field_value, dt_time):
-            field_value = field_value.isoformat()
-
-        return field_value
-
-    def _kmlock_collection_value_to_dict(self, field_value: Any) -> object:
-        """Convert collection field values while preserving existing recursive behavior."""
-        if isinstance(field_value, list):
-            return [
-                self._kmlocks_to_dict(item) if hasattr(item, "__dataclass_fields__") else item
-                for item in field_value
-            ]
-
-        if isinstance(field_value, dict):
-            return {
-                k: (self._kmlocks_to_dict(v) if hasattr(v, "__dataclass_fields__") else v)
-                for k, v in field_value.items()
-            }
-
-        return field_value
 
     async def _rebuild_lock_relationships(self) -> None:
         for keymaster_config_entry_id, kmlock in self.kmlocks.items():
@@ -1320,82 +1003,6 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
             kmlock.listeners.append(unsub)
 
-    def _fire_lock_state_changed_event(
-        self,
-        kmlock: KeymasterLock,
-        state: str,
-        *,
-        code_slot_num: int,
-        source: str | None,
-        event_label: str | None,
-        action_code: int | None,
-    ) -> None:
-        """Fire the keymaster_lock_state_changed bus event."""
-        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
-        self.hass.bus.fire(
-            EVENT_KEYMASTER_LOCK_STATE_CHANGED,
-            event_data={
-                ATTR_NOTIFICATION_SOURCE: source,
-                ATTR_NAME: kmlock.lock_name,
-                ATTR_ENTITY_ID: kmlock.lock_entity_id,
-                ATTR_STATE: state,
-                ATTR_ACTION_CODE: action_code,
-                ATTR_ACTION_TEXT: event_label,
-                ATTR_CODE_SLOT: code_slot_num,
-                ATTR_CODE_SLOT_NAME: (slot.name or "") if slot and code_slot_num != 0 else "",
-            },
-        )
-
-    def _fire_unlock_state_changed(
-        self,
-        kmlock: KeymasterLock,
-        code_slot_num: int,
-        source: str | None,
-        event_label: str | None,
-        action_code: int | None,
-    ) -> None:
-        """Fire the keymaster_lock_state_changed bus event for an unlock."""
-        self._fire_lock_state_changed_event(
-            kmlock,
-            LockState.UNLOCKED,
-            code_slot_num=code_slot_num,
-            source=source,
-            event_label=event_label,
-            action_code=action_code,
-        )
-
-    def _fire_lock_state_changed(
-        self,
-        kmlock: KeymasterLock,
-        code_slot_num: int,
-        source: str | None,
-        event_label: str | None,
-        action_code: int | None,
-    ) -> None:
-        """Fire the keymaster_lock_state_changed bus event for a lock."""
-        self._fire_lock_state_changed_event(
-            kmlock,
-            LockState.LOCKED,
-            code_slot_num=code_slot_num,
-            source=source,
-            event_label=event_label,
-            action_code=action_code,
-        )
-
-    @staticmethod
-    def _format_slot_message(
-        kmlock: KeymasterLock,
-        code_slot_num: int,
-        event_label: str | None,
-    ) -> str | None:
-        """Append code slot details to a notification message."""
-        if code_slot_num <= 0:
-            return event_label
-        slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
-        if slot and slot.name:
-            return f"{event_label} by {slot.name} [{code_slot_num}]"
-        return f"{event_label} by Code Slot {code_slot_num}"
-
     async def _send_code_slot_unlock_notification(
         self,
         kmlock: KeymasterLock,
@@ -1407,7 +1014,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if not slot or not slot.notifications:
             return False
 
-        message = self._format_slot_message(kmlock, code_slot_num, event_label)
+        message = format_slot_message(kmlock, code_slot_num, event_label)
         await send_manual_notification(
             hass=self.hass,
             script_name=kmlock.notify_script_name,
@@ -1427,7 +1034,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if not slot or not slot.notifications:
             return False
 
-        message = self._format_slot_message(kmlock, code_slot_num, event_label)
+        message = format_slot_message(kmlock, code_slot_num, event_label)
         await send_manual_notification(
             hass=self.hass,
             script_name=kmlock.notify_script_name,
@@ -1443,7 +1050,7 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         event_label: str | None,
     ) -> None:
         """Send a global lock/unlock notification."""
-        message = self._format_slot_message(kmlock, code_slot_num, event_label)
+        message = format_slot_message(kmlock, code_slot_num, event_label)
         await send_manual_notification(
             hass=self.hass,
             script_name=kmlock.notify_script_name,
@@ -1537,45 +1144,6 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             )
         )
 
-    @staticmethod
-    def _global_notification_superseded(
-        kmlock: KeymasterLock,
-        code_slot_num: int,
-    ) -> bool:
-        """Return whether per-slot notification should replace global lock/unlock text."""
-        if not kmlock.code_slots:
-            return False
-
-        if code_slot_num > 0:
-            slot = kmlock.code_slots.get(code_slot_num)
-            return bool(slot and slot.notifications)
-
-        return False
-
-    @staticmethod
-    def _should_defer_keypad_unlock_notification(
-        kmlock: KeymasterLock,
-        code_slot_num: int,
-        event_label: str | None,
-    ) -> bool:
-        """Return whether a slot=0 keypad unlock may be superseded by slot details."""
-        if code_slot_num != 0 or event_label != "Keypad Unlock" or not kmlock.code_slots:
-            return False
-
-        return any(slot.notifications for slot in kmlock.code_slots.values())
-
-    @staticmethod
-    def _should_defer_keypad_lock_notification(
-        kmlock: KeymasterLock,
-        code_slot_num: int,
-        event_label: str | None,
-    ) -> bool:
-        """Return whether a slot=0 keypad lock may be superseded by slot details."""
-        if code_slot_num != 0 or event_label != "Keypad Lock" or not kmlock.code_slots:
-            return False
-
-        return any(slot.notifications for slot in kmlock.code_slots.values())
-
     async def _handle_already_unlocked(
         self,
         kmlock: KeymasterLock,
@@ -1609,7 +1177,14 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 source,
             )
             self._last_unlock_code_slot[kmlock.keymaster_config_entry_id] = code_slot_num
-            self._fire_unlock_state_changed(kmlock, code_slot_num, source, event_label, action_code)
+            fire_unlock_state_changed(
+                self.hass,
+                kmlock,
+                code_slot_num=code_slot_num,
+                source=source,
+                event_label=event_label,
+                action_code=action_code,
+            )
             had_pending_notification = self._cancel_pending_keypad_unlock_notification(kmlock)
             sent_slot_notification = await self._send_code_slot_unlock_notification(
                 kmlock,
@@ -1722,16 +1297,23 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
         if kmlock.lock_notifications:
-            if self._should_defer_keypad_unlock_notification(kmlock, code_slot_num, event_label):
+            if should_defer_keypad_unlock_notification(kmlock, code_slot_num, event_label):
                 self._defer_keypad_unlock_notification(kmlock, event_label)
-            elif not self._global_notification_superseded(kmlock, code_slot_num):
+            elif not global_notification_superseded(kmlock, code_slot_num):
                 await self._send_global_slot_notification(kmlock, code_slot_num, event_label)
 
         if code_slot_num > 0 and kmlock.code_slots and code_slot_num in kmlock.code_slots:
             await self._decrement_unlock_access_limit(kmlock, code_slot_num)
             await self._send_code_slot_unlock_notification(kmlock, code_slot_num, event_label)
 
-        self._fire_unlock_state_changed(kmlock, code_slot_num, source, event_label, action_code)
+        fire_unlock_state_changed(
+            self.hass,
+            kmlock,
+            code_slot_num=code_slot_num,
+            source=source,
+            event_label=event_label,
+            action_code=action_code,
+        )
 
     async def _handle_already_locked(
         self,
@@ -1761,7 +1343,14 @@ class KeymasterCoordinator(DataUpdateCoordinator):
                 source,
             )
             self._last_lock_code_slot[kmlock.keymaster_config_entry_id] = code_slot_num
-            self._fire_lock_state_changed(kmlock, code_slot_num, source, event_label, action_code)
+            fire_lock_state_changed(
+                self.hass,
+                kmlock,
+                code_slot_num=code_slot_num,
+                source=source,
+                event_label=event_label,
+                action_code=action_code,
+            )
             had_pending_notification = self._cancel_pending_keypad_lock_notification(kmlock)
             sent_slot_notification = await self._send_code_slot_lock_notification(
                 kmlock,
@@ -1848,15 +1437,22 @@ class KeymasterCoordinator(DataUpdateCoordinator):
             self.async_schedule_keymaster_notifications([kmlock.keymaster_config_entry_id])
 
         if kmlock.lock_notifications:
-            if self._should_defer_keypad_lock_notification(kmlock, code_slot_num, event_label):
+            if should_defer_keypad_lock_notification(kmlock, code_slot_num, event_label):
                 self._defer_keypad_lock_notification(kmlock, event_label)
-            elif not self._global_notification_superseded(kmlock, code_slot_num):
+            elif not global_notification_superseded(kmlock, code_slot_num):
                 await self._send_global_slot_notification(kmlock, code_slot_num, event_label)
 
         if code_slot_num > 0 and kmlock.code_slots and code_slot_num in kmlock.code_slots:
             await self._send_code_slot_lock_notification(kmlock, code_slot_num, event_label)
 
-        self._fire_lock_state_changed(kmlock, code_slot_num, source, event_label, action_code)
+        fire_lock_state_changed(
+            self.hass,
+            kmlock,
+            code_slot_num=code_slot_num,
+            source=source,
+            event_label=event_label,
+            action_code=action_code,
+        )
 
     async def _door_opened(self, kmlock: KeymasterLock) -> None:
         if not self._throttle.is_allowed(

--- a/custom_components/keymaster/helpers.py
+++ b/custom_components/keymaster/helpers.py
@@ -228,3 +228,56 @@ async def dismiss_persistent_notification(hass: HomeAssistant, notification_id: 
     """Clear or dismisss a persistent notification."""
     _LOGGER.debug("[dismiss_persistent_notification] notification_id: %s", notification_id)
     persistent_notification.async_dismiss(hass=hass, notification_id=notification_id)
+
+
+def format_slot_message(
+    kmlock: KeymasterLock,
+    code_slot_num: int,
+    event_label: str | None,
+) -> str | None:
+    """Append code slot details to a notification message."""
+    if code_slot_num <= 0:
+        return event_label
+    slot = kmlock.code_slots.get(code_slot_num) if kmlock.code_slots else None
+    if slot and slot.name:
+        return f"{event_label} by {slot.name} [{code_slot_num}]"
+    return f"{event_label} by Code Slot {code_slot_num}"
+
+
+def global_notification_superseded(
+    kmlock: KeymasterLock,
+    code_slot_num: int,
+) -> bool:
+    """Return whether per-slot notification should replace global lock/unlock text."""
+    if not kmlock.code_slots:
+        return False
+
+    if code_slot_num > 0:
+        slot = kmlock.code_slots.get(code_slot_num)
+        return bool(slot and slot.notifications)
+
+    return False
+
+
+def should_defer_keypad_unlock_notification(
+    kmlock: KeymasterLock,
+    code_slot_num: int,
+    event_label: str | None,
+) -> bool:
+    """Return whether a slot=0 keypad unlock may be superseded by slot details."""
+    if code_slot_num != 0 or event_label != "Keypad Unlock" or not kmlock.code_slots:
+        return False
+
+    return any(slot.notifications for slot in kmlock.code_slots.values())
+
+
+def should_defer_keypad_lock_notification(
+    kmlock: KeymasterLock,
+    code_slot_num: int,
+    event_label: str | None,
+) -> bool:
+    """Return whether a slot=0 keypad lock may be superseded by slot details."""
+    if code_slot_num != 0 or event_label != "Keypad Lock" or not kmlock.code_slots:
+        return False
+
+    return any(slot.notifications for slot in kmlock.code_slots.values())

--- a/custom_components/keymaster/serialization.py
+++ b/custom_components/keymaster/serialization.py
@@ -1,0 +1,338 @@
+"""Serialization helpers for keymaster locks."""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import MutableMapping
+import contextlib
+from dataclasses import fields, is_dataclass
+from datetime import datetime as dt, time as dt_time
+import functools
+import json
+import logging
+from pathlib import Path
+from typing import Any, Union, get_args, get_origin
+
+from .lock import KeymasterLock, keymasterlock_type_lookup
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+@functools.cache
+def _serializable_dataclass_fields(cls: type) -> tuple[Any, ...]:
+    """Return dataclass fields that are persisted."""
+    return tuple(field for field in fields(cls) if field.init)
+
+
+def migrate_legacy_json(
+    json_file: Path,
+    json_folder: str,
+) -> MutableMapping[str, KeymasterLock]:
+    """Load legacy JSON file, clean it up, and return processed data.
+
+    This is a synchronous function that performs file I/O. Must be called
+    via async_add_executor_job.
+    """
+    config: MutableMapping[str, KeymasterLock] = {}
+    try:
+        with json_file.open(encoding="utf-8") as f:
+            config = process_loaded_data(json.load(f))
+    except (OSError, json.JSONDecodeError) as e:
+        _LOGGER.warning(
+            "[migrate_legacy_json] Error reading legacy JSON file: %s: %s",
+            e.__class__.__qualname__,
+            e,
+        )
+
+    # Always clean up the legacy file (regardless of load success)
+    try:
+        json_file.unlink()
+        _LOGGER.info("[migrate_legacy_json] Legacy JSON file deleted")
+    except OSError as e:
+        _LOGGER.warning(
+            "[migrate_legacy_json] Could not delete legacy JSON file: %s: %s",
+            e.__class__.__qualname__,
+            e,
+        )
+        return config
+
+    # Try to remove the folder if empty
+    try:
+        Path(json_folder).rmdir()
+        _LOGGER.debug("[migrate_legacy_json] Legacy JSON folder removed")
+    except OSError:
+        # Folder not empty or other issue - that's fine
+        pass
+
+    return config
+
+
+def process_loaded_data(config: dict) -> MutableMapping[str, KeymasterLock]:
+    """Process loaded config data into KeymasterLock objects."""
+    for lock in config.values():
+        lock["autolock_timer"] = None
+        lock["listeners"] = []
+        for kmslot in (lock.get("code_slots") or {}).values():
+            if isinstance(kmslot.get("pin", None), str):
+                kmslot["pin"] = decode_pin(
+                    kmslot["pin"],
+                    lock["keymaster_config_entry_id"],
+                )
+
+    kmlocks: MutableMapping = {
+        key: dict_to_kmlocks(value, KeymasterLock) for key, value in config.items()
+    }
+
+    _LOGGER.debug("[load_data] Loaded kmlocks: %s", kmlocks)
+    return kmlocks
+
+
+def sanitized_lock_dict(lock: object) -> dict[str, Any]:
+    """Remove runtime-only lock fields from a serialized lock dictionary."""
+    sanitized = dict(lock) if isinstance(lock, dict) else {}
+    sanitized.pop("zwave_js_lock_device", None)
+    sanitized.pop("zwave_js_lock_node", None)
+    sanitized.pop("autolock_timer", None)
+    sanitized.pop("listeners", None)
+    sanitized.pop("provider", None)
+    return sanitized
+
+
+def encode_pin(pin: str, unique_id: str) -> str:
+    """Encode a PIN with the lock config entry ID as a salt."""
+    salted_pin: bytes = unique_id.encode("utf-8") + pin.encode("utf-8")
+    encoded_pin: str = base64.b64encode(salted_pin).decode("utf-8")
+    return encoded_pin
+
+
+def decode_pin(encoded_pin: str, unique_id: str) -> str:
+    """Decode a PIN that was encoded with the lock config entry ID as a salt."""
+    decoded_pin_with_salt: bytes = base64.b64decode(encoded_pin)
+    salt_length: int = len(unique_id.encode("utf-8"))
+    original_pin: str = decoded_pin_with_salt[salt_length:].decode("utf-8")
+    return original_pin
+
+
+def dict_to_kmlocks(data: dict, cls: type) -> Any:
+    """Recursively convert a dictionary to a dataclass instance."""
+    if hasattr(cls, "__dataclass_fields__"):
+        field_values: MutableMapping = {}
+
+        for field in _serializable_dataclass_fields(cls):
+            field_values[field.name] = _kmlock_field_from_dict(data, field)
+
+        return cls(**field_values)
+
+    return data
+
+
+def _kmlock_field_type_from_dict(field_name: str, field_type: Any) -> Any:
+    """Resolve the stored type metadata for a Keymaster lock field."""
+    resolved_type = keymasterlock_type_lookup.get(field_name)
+    if not resolved_type and isinstance(field_type, type):
+        resolved_type = field_type
+    return resolved_type
+
+
+def _kmlock_field_from_dict(data: dict, field: Any) -> Any:
+    """Convert one serialized dataclass field to its runtime value."""
+    field_name: str = field.name
+    field_type = _kmlock_field_type_from_dict(field_name, field.type)
+    field_value: Any = data.get(field_name)
+
+    origin_type = get_origin(field_type)
+    type_args = get_args(field_type)
+
+    # _LOGGER.debug(
+    #     f"[dict_to_kmlocks] field_name: {field_name}, field_type: {field_type}, "
+    #     f"origin_type: {origin_type}, type_args: {type_args}, "
+    #     f"field_value_type: {type(field_value)}, field_value: {field_value}"
+    # )
+
+    field_type, origin_type, type_args = _kmlock_optional_type_from_dict(
+        field_name,
+        field_type,
+        origin_type,
+        type_args,
+    )
+    field_value = _kmlock_temporal_value_from_dict(field_name, field_value, field_type)
+    return _kmlock_collection_value_from_dict(
+        field_name,
+        field_value,
+        field_type,
+        origin_type,
+        type_args,
+    )
+
+
+def _kmlock_optional_type_from_dict(
+    field_name: str,
+    field_type: Any,
+    origin_type: Any,
+    type_args: tuple[Any, ...],
+) -> tuple[Any, Any, tuple[Any, ...]]:
+    """Unwrap Optional fields while preserving existing Union handling."""
+    # Handle optional types (Union)
+    if origin_type is not Union:
+        return field_type, origin_type, type_args
+
+    non_optional_types = [t for t in type_args if t is not type(None)]
+    if len(non_optional_types) != 1:
+        return field_type, origin_type, type_args
+
+    field_type = non_optional_types[0]
+    origin_type = get_origin(field_type)
+    type_args = get_args(field_type)
+    # _LOGGER.debug(
+    #     f"[dict_to_kmlocks] Updated for Union: "
+    #     f"field_name: {field_name}, field_type: {field_type}, "
+    #     f"origin_type: {origin_type}, type_args: {type_args}"
+    # )
+    return field_type, origin_type, type_args
+
+
+def _kmlock_temporal_value_from_dict(
+    field_name: str,
+    field_value: Any,
+    field_type: Any,
+) -> Any:
+    """Convert serialized temporal strings while preserving fallback behavior."""
+    # Convert datetime string to datetime object
+    if isinstance(field_value, str) and field_type == dt:
+        # _LOGGER.debug(f"[dict_to_kmlocks] field_name: {field_name}: Converting to datetime")
+        with contextlib.suppress(ValueError):
+            field_value = dt.fromisoformat(field_value)
+
+    # Convert time string to time object
+    elif isinstance(field_value, str) and field_type == dt_time:
+        # _LOGGER.debug(f"[dict_to_kmlocks] field_name: {field_name}: Converting to time")
+        with contextlib.suppress(ValueError):
+            field_value = dt_time.fromisoformat(field_value)
+
+    return field_value
+
+
+def _kmlock_key_from_dict(key: Any, key_type: Any) -> Any:
+    """Convert serialized dictionary keys to their runtime type when required."""
+    if key_type is int and isinstance(key, str) and key.isdigit():
+        return int(key)
+    return key
+
+
+def _kmlock_collection_value_from_dict(
+    field_name: str,
+    field_value: Any,
+    field_type: Any,
+    origin_type: Any,
+    type_args: tuple[Any, ...],
+) -> Any:
+    """Convert serialized collection and nested dataclass values."""
+    # _LOGGER.debug(f"[dict_to_kmlocks] isinstance(origin_type, type): {isinstance(origin_type, type)}")
+    # if isinstance(origin_type, type):
+    # _LOGGER.debug(f"[dict_to_kmlocks] issubclass(origin_type, MutableMapping): {issubclass(origin_type, MutableMapping)}, origin_type == dict: {origin_type == dict}")
+
+    # Handle MutableMapping types: when origin_type is MutableMapping
+    if isinstance(origin_type, type) and (
+        issubclass(origin_type, MutableMapping) or origin_type is dict
+    ):
+        return _kmlock_mapping_value_from_dict(field_name, field_value, type_args)
+
+    if isinstance(field_value, dict) and is_dataclass(field_type) and isinstance(field_type, type):
+        # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting nested dataclass: {field_name}")
+        return dict_to_kmlocks(field_value, field_type)
+
+    if isinstance(field_value, list) and type_args:
+        return _kmlock_list_value_from_dict(field_name, field_value, type_args)
+
+    return field_value
+
+
+def _kmlock_mapping_value_from_dict(
+    field_name: str,
+    field_value: Any,
+    type_args: tuple[Any, ...],
+) -> Any:
+    """Convert serialized mapping values without falling through to other branches."""
+    if len(type_args) != 2:
+        return field_value
+
+    key_type, value_type = type_args
+    # _LOGGER.debug(
+    #     f"[dict_to_kmlocks] field_name: {field_name}: Is MutableMapping or dict. key_type: {key_type}, "
+    #     f"value_type: {value_type}, isinstance(field_value, dict): {isinstance(field_value, dict)}, "
+    #     f"is_dataclass(value_type): {is_dataclass(value_type)}"
+    # )
+    if not isinstance(field_value, dict):
+        return field_value
+
+    # If the value_type is a dataclass, recursively process it
+    if is_dataclass(value_type) and isinstance(value_type, type):
+        # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting dict items for {field_name}")
+        return {
+            _kmlock_key_from_dict(k, key_type): dict_to_kmlocks(v, value_type)
+            for k, v in field_value.items()
+        }
+
+    # If value_type is not a dataclass, just copy the value
+    return {_kmlock_key_from_dict(k, key_type): v for k, v in field_value.items()}
+
+
+def _kmlock_list_value_from_dict(
+    field_name: str,
+    field_value: list,
+    type_args: tuple[Any, ...],
+) -> Any:
+    """Convert serialized lists containing nested dataclass dictionaries."""
+    list_type = type_args[0]
+    if not (is_dataclass(list_type) and isinstance(list_type, type)):
+        return field_value
+
+    # _LOGGER.debug(f"[dict_to_kmlocks] Recursively converting list of dataclasses: {field_name}")
+    return [
+        dict_to_kmlocks(item, list_type) if isinstance(item, dict) else item for item in field_value
+    ]
+
+
+def kmlocks_to_dict(instance: object) -> object:
+    """Recursively convert a dataclass instance to a dictionary for JSON export."""
+    if is_dataclass(instance):
+        result: MutableMapping = {}
+        for field in _serializable_dataclass_fields(instance.__class__):
+            field_name: str = field.name
+            result[field_name] = _kmlock_field_to_dict(getattr(instance, field_name))
+        return result
+    return instance
+
+
+def _kmlock_field_to_dict(field_value: Any) -> Any:
+    """Convert a dataclass field value to a JSON-compatible value."""
+    field_value = _kmlock_temporal_value_to_dict(field_value)
+    return _kmlock_collection_value_to_dict(field_value)
+
+
+def _kmlock_temporal_value_to_dict(field_value: Any) -> Any:
+    """Convert temporal field values while preserving existing ordered checks."""
+    if isinstance(field_value, dt):
+        field_value = field_value.isoformat()
+
+    if isinstance(field_value, dt_time):
+        field_value = field_value.isoformat()
+
+    return field_value
+
+
+def _kmlock_collection_value_to_dict(field_value: Any) -> Any:
+    """Convert collection field values while preserving existing recursive behavior."""
+    if isinstance(field_value, list):
+        return [
+            kmlocks_to_dict(item) if hasattr(item, "__dataclass_fields__") else item
+            for item in field_value
+        ]
+
+    if isinstance(field_value, dict):
+        return {
+            k: (kmlocks_to_dict(v) if hasattr(v, "__dataclass_fields__") else v)
+            for k, v in field_value.items()
+        }
+
+    return field_value

--- a/tests/test_bus_events.py
+++ b/tests/test_bus_events.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import Any
 
-import pytest
-
+from custom_components.keymaster.bus_events import (
+    fire_lock_state_changed,
+    fire_unlock_state_changed,
+)
 from custom_components.keymaster.const import (
     ATTR_ACTION_CODE,
     ATTR_ACTION_TEXT,
@@ -21,15 +22,8 @@ from homeassistant.components.lock.const import LockState
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_STATE
 
 
-@pytest.mark.xfail(
-    raises=ImportError,
-    reason="extracted in the following commit; refs #768",
-    strict=True,
-)
 async def test_fire_unlock_state_changed_fires_expected_bus_event(hass) -> None:
     """Unlock helper emits the existing keymaster lock state changed event payload."""
-    bus_events = import_module("custom_components.keymaster.bus_events")
-
     events: list[Any] = []
     hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, events.append)
     lock = KeymasterLock(
@@ -39,13 +33,13 @@ async def test_fire_unlock_state_changed_fires_expected_bus_event(hass) -> None:
         code_slots={1: KeymasterCodeSlot(number=1, name="Guest")},
     )
 
-    bus_events.fire_unlock_state_changed(
+    fire_unlock_state_changed(
         hass,
         lock,
-        1,
-        "event",
-        "Keypad Unlock",
-        6,
+        code_slot_num=1,
+        source="event",
+        event_label="Keypad Unlock",
+        action_code=6,
     )
     await hass.async_block_till_done()
 
@@ -62,15 +56,8 @@ async def test_fire_unlock_state_changed_fires_expected_bus_event(hass) -> None:
     }
 
 
-@pytest.mark.xfail(
-    raises=ImportError,
-    reason="extracted in the following commit; refs #768",
-    strict=True,
-)
 async def test_fire_lock_state_changed_omits_slot_name_for_slot_zero(hass) -> None:
     """Lock helper preserves the legacy empty slot name for slot zero events."""
-    bus_events = import_module("custom_components.keymaster.bus_events")
-
     events: list[Any] = []
     hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, events.append)
     lock = KeymasterLock(
@@ -80,7 +67,14 @@ async def test_fire_lock_state_changed_omits_slot_name_for_slot_zero(hass) -> No
         code_slots={0: KeymasterCodeSlot(number=0, name="Manual")},
     )
 
-    bus_events.fire_lock_state_changed(hass, lock, 0, None, "Manual Lock", None)
+    fire_lock_state_changed(
+        hass,
+        lock,
+        code_slot_num=0,
+        source=None,
+        event_label="Manual Lock",
+        action_code=None,
+    )
     await hass.async_block_till_done()
 
     assert len(events) == 1

--- a/tests/test_bus_events.py
+++ b/tests/test_bus_events.py
@@ -1,0 +1,89 @@
+"""Tests for Keymaster Home Assistant bus event helpers."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+import pytest
+
+from custom_components.keymaster.const import (
+    ATTR_ACTION_CODE,
+    ATTR_ACTION_TEXT,
+    ATTR_CODE_SLOT,
+    ATTR_CODE_SLOT_NAME,
+    ATTR_NAME,
+    ATTR_NOTIFICATION_SOURCE,
+    EVENT_KEYMASTER_LOCK_STATE_CHANGED,
+)
+from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
+from homeassistant.components.lock.const import LockState
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_STATE
+
+
+@pytest.mark.xfail(
+    raises=ImportError,
+    reason="extracted in the following commit; refs #768",
+    strict=True,
+)
+async def test_fire_unlock_state_changed_fires_expected_bus_event(hass) -> None:
+    """Unlock helper emits the existing keymaster lock state changed event payload."""
+    bus_events = import_module("custom_components.keymaster.bus_events")
+
+    events: list[Any] = []
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, events.append)
+    lock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry-one",
+        code_slots={1: KeymasterCodeSlot(number=1, name="Guest")},
+    )
+
+    bus_events.fire_unlock_state_changed(
+        hass,
+        lock,
+        1,
+        "event",
+        "Keypad Unlock",
+        6,
+    )
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data == {
+        ATTR_NOTIFICATION_SOURCE: "event",
+        ATTR_NAME: "Front Door",
+        ATTR_ENTITY_ID: "lock.front_door",
+        ATTR_STATE: LockState.UNLOCKED,
+        ATTR_ACTION_CODE: 6,
+        ATTR_ACTION_TEXT: "Keypad Unlock",
+        ATTR_CODE_SLOT: 1,
+        ATTR_CODE_SLOT_NAME: "Guest",
+    }
+
+
+@pytest.mark.xfail(
+    raises=ImportError,
+    reason="extracted in the following commit; refs #768",
+    strict=True,
+)
+async def test_fire_lock_state_changed_omits_slot_name_for_slot_zero(hass) -> None:
+    """Lock helper preserves the legacy empty slot name for slot zero events."""
+    bus_events = import_module("custom_components.keymaster.bus_events")
+
+    events: list[Any] = []
+    hass.bus.async_listen(EVENT_KEYMASTER_LOCK_STATE_CHANGED, events.append)
+    lock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry-one",
+        code_slots={0: KeymasterCodeSlot(number=0, name="Manual")},
+    )
+
+    bus_events.fire_lock_state_changed(hass, lock, 0, None, "Manual Lock", None)
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data[ATTR_STATE] == LockState.LOCKED
+    assert events[0].data[ATTR_CODE_SLOT] == 0
+    assert events[0].data[ATTR_CODE_SLOT_NAME] == ""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,11 +7,12 @@ from datetime import datetime as dt, time as dt_time, timedelta
 import json
 import random
 import typing
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from custom_components.keymaster.bus_events import fire_unlock_state_changed
 from custom_components.keymaster.const import (
     BACKOFF_FAILURE_THRESHOLD,
     BACKOFF_MAX_SECONDS,
@@ -25,6 +26,14 @@ from custom_components.keymaster.lock import (
     KeymasterLock,
 )
 from custom_components.keymaster.providers import CodeSlot
+from custom_components.keymaster.serialization import (
+    decode_pin,
+    dict_to_kmlocks,
+    encode_pin,
+    kmlocks_to_dict,
+    migrate_legacy_json,
+    process_loaded_data,
+)
 from homeassistant.components.lock.const import LockState
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
@@ -1299,7 +1308,14 @@ class TestLockStateEventHandlers:
         """Test unnamed slots emit '' (not None) as code_slot_name on unlock."""
         mock_kmlock.code_slots = {2: Mock()}
         mock_kmlock.code_slots[2].name = None
-        mock_coordinator._fire_unlock_state_changed(mock_kmlock, 2, "event", "Keypad Unlock", 6)
+        fire_unlock_state_changed(
+            mock_coordinator.hass,
+            mock_kmlock,
+            code_slot_num=2,
+            source="event",
+            event_label="Keypad Unlock",
+            action_code=6,
+        )
         assert mock_coordinator.hass.bus.fire.call_args.kwargs["event_data"]["code_slot_name"] == ""
 
     async def test_lock_locked_supersede_sequence_no_duplicate_side_effects(
@@ -2654,7 +2670,7 @@ class TestPinEncodeDecode:
         pin = "1234"
         unique_id = "test_entry_123"
 
-        encoded = KeymasterCoordinator._encode_pin(pin, unique_id)
+        encoded = encode_pin(pin, unique_id)
 
         # Result should be base64 encoded
         assert encoded is not None
@@ -2667,8 +2683,8 @@ class TestPinEncodeDecode:
         pin = "1234"
         unique_id = "test_entry_123"
 
-        encoded = KeymasterCoordinator._encode_pin(pin, unique_id)
-        decoded = KeymasterCoordinator._decode_pin(encoded, unique_id)
+        encoded = encode_pin(pin, unique_id)
+        decoded = decode_pin(encoded, unique_id)
 
         assert decoded == pin
 
@@ -2682,16 +2698,16 @@ class TestPinEncodeDecode:
         ]
 
         for pin, unique_id in test_cases:
-            encoded = KeymasterCoordinator._encode_pin(pin, unique_id)
-            decoded = KeymasterCoordinator._decode_pin(encoded, unique_id)
+            encoded = encode_pin(pin, unique_id)
+            decoded = decode_pin(encoded, unique_id)
             assert decoded == pin, f"Failed for pin={pin}, unique_id={unique_id}"
 
     def test_encode_different_unique_ids_produce_different_results(self):
         """Test that different unique IDs produce different encodings."""
         pin = "1234"
 
-        encoded1 = KeymasterCoordinator._encode_pin(pin, "id_1")
-        encoded2 = KeymasterCoordinator._encode_pin(pin, "id_2")
+        encoded1 = encode_pin(pin, "id_1")
+        encoded2 = encode_pin(pin, "id_2")
 
         assert encoded1 != encoded2
 
@@ -2807,7 +2823,7 @@ class TestDictToKmlocksConversion:
 
     def test_dict_to_kmlocks_non_dataclass_returns_data(self, coordinator_for_conversion):
         """Test that non-dataclass data is returned as-is."""
-        result = coordinator_for_conversion._dict_to_kmlocks({"key": "value"}, str)
+        result = dict_to_kmlocks({"key": "value"}, str)
 
         assert result == {"key": "value"}
 
@@ -2823,7 +2839,7 @@ class TestDictToKmlocksConversion:
             "time_end": None,
         }
 
-        result = coordinator_for_conversion._dict_to_kmlocks(data, KeymasterCodeSlotDayOfWeek)
+        result = dict_to_kmlocks(data, KeymasterCodeSlotDayOfWeek)
 
         assert isinstance(result, KeymasterCodeSlotDayOfWeek)
         assert result.day_of_week_num == 0
@@ -2836,7 +2852,7 @@ class TestDictToKmlocksConversion:
             "lock_entity_id": "lock.test",
             "keymaster_config_entry_id": "entry_1",
         }
-        result = coordinator_for_conversion._dict_to_kmlocks(data, KeymasterLock)
+        result = dict_to_kmlocks(data, KeymasterLock)
 
         assert isinstance(result, KeymasterLock)
         # masked_code_slots is init=False, so gets its default (empty set)
@@ -2853,7 +2869,7 @@ class TestDictToKmlocksConversion:
             "keymaster_config_entry_id": "entry_1",
             "code_slots": {},
         }
-        old_lock = coordinator_for_conversion._dict_to_kmlocks(stored_lock, KeymasterLock)
+        old_lock = dict_to_kmlocks(stored_lock, KeymasterLock)
         new_lock = KeymasterLock(
             lock_name="Test",
             lock_entity_id="lock.test",
@@ -2876,8 +2892,8 @@ class TestDictToKmlocksConversion:
             "time_start": "08:30:00",
         }
 
-        slot = coordinator_for_conversion._dict_to_kmlocks(data, KeymasterCodeSlot)
-        day = coordinator_for_conversion._dict_to_kmlocks(data, KeymasterCodeSlotDayOfWeek)
+        slot = dict_to_kmlocks(data, KeymasterCodeSlot)
+        day = dict_to_kmlocks(data, KeymasterCodeSlotDayOfWeek)
 
         assert slot.accesslimit_date_range_start == dt(2025, 1, 15, 12, 30, 0)
         assert day.time_start == dt_time(8, 30, 0)
@@ -2889,7 +2905,7 @@ class TestDictToKmlocksConversion:
         """Malformed temporal strings remain unchanged instead of raising."""
         data = {"number": 1, "accesslimit_date_range_start": "not-a-datetime"}
 
-        result = coordinator_for_conversion._dict_to_kmlocks(data, KeymasterCodeSlot)
+        result = dict_to_kmlocks(data, KeymasterCodeSlot)
 
         assert result.accesslimit_date_range_start == "not-a-datetime"
 
@@ -2913,7 +2929,7 @@ class TestDictToKmlocksConversion:
             },
         }
 
-        result = coordinator_for_conversion._dict_to_kmlocks(data, KeymasterCodeSlot)
+        result = dict_to_kmlocks(data, KeymasterCodeSlot)
 
         assert isinstance(result.accesslimit_day_of_week[0], KeymasterCodeSlotDayOfWeek)
         assert result.accesslimit_day_of_week[0].dow_enabled is False
@@ -2935,10 +2951,10 @@ class TestDictToKmlocksConversion:
         data = {"values": {"1": 1, "two": 2}}
 
         with patch.dict(
-            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            "custom_components.keymaster.serialization.keymasterlock_type_lookup",
             {"values": MutableMapping[str, int]},
         ):
-            result = coordinator_for_conversion._dict_to_kmlocks(data, PlainMapping)
+            result = dict_to_kmlocks(data, PlainMapping)
 
         assert result.values == {"1": 1, "two": 2}
 
@@ -2959,10 +2975,10 @@ class TestDictToKmlocksConversion:
         data = {"ambiguous": [{"value": 1}, "plain"]}
 
         with patch.dict(
-            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            "custom_components.keymaster.serialization.keymasterlock_type_lookup",
             {"ambiguous": MutableMapping[Inner, str]},
         ):
-            result = coordinator_for_conversion._dict_to_kmlocks(data, MappingWithListValue)
+            result = dict_to_kmlocks(data, MappingWithListValue)
 
         assert result.ambiguous == [{"value": 1}, "plain"]
 
@@ -2979,10 +2995,10 @@ class TestDictToKmlocksConversion:
         data = {"ambiguous": {"1": "one"}}
 
         with patch.dict(
-            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            "custom_components.keymaster.serialization.keymasterlock_type_lookup",
             {"ambiguous": typing.MutableMapping},
         ):
-            result = coordinator_for_conversion._dict_to_kmlocks(data, BareMapping)
+            result = dict_to_kmlocks(data, BareMapping)
 
         assert result.ambiguous == {"1": "one"}
 
@@ -3003,10 +3019,10 @@ class TestDictToKmlocksConversion:
         data = {"inner": {"value": 1}}
 
         with patch.dict(
-            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            "custom_components.keymaster.serialization.keymasterlock_type_lookup",
             {"inner": Inner},
         ):
-            result = coordinator_for_conversion._dict_to_kmlocks(data, Outer)
+            result = dict_to_kmlocks(data, Outer)
 
         assert result.inner == Inner(value=1)
 
@@ -3023,10 +3039,10 @@ class TestDictToKmlocksConversion:
         data = {"items": [{"value": 1}, "plain"]}
 
         with patch.dict(
-            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            "custom_components.keymaster.serialization.keymasterlock_type_lookup",
             {"items": list[int]},
         ):
-            result = coordinator_for_conversion._dict_to_kmlocks(data, ListContainer)
+            result = dict_to_kmlocks(data, ListContainer)
 
         assert result.items == [{"value": 1}, "plain"]
 
@@ -3043,10 +3059,10 @@ class TestDictToKmlocksConversion:
         data = {"maybe_timestamp": "2025-01-15T12:30:00"}
 
         with patch.dict(
-            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            "custom_components.keymaster.serialization.keymasterlock_type_lookup",
             {"maybe_timestamp": typing.Union[dt, None]},  # noqa: UP007
         ):
-            result = coordinator_for_conversion._dict_to_kmlocks(data, OptionalDate)
+            result = dict_to_kmlocks(data, OptionalDate)
 
         assert result.maybe_timestamp == dt(2025, 1, 15, 12, 30, 0)
 
@@ -3064,10 +3080,10 @@ class TestDictToKmlocksConversion:
         data = {"maybe_timestamp": timestamp}
 
         with patch.dict(
-            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            "custom_components.keymaster.serialization.keymasterlock_type_lookup",
             {"maybe_timestamp": typing.Union[dt, str, None]},  # noqa: UP007
         ):
-            result = coordinator_for_conversion._dict_to_kmlocks(data, MultiTypeUnion)
+            result = dict_to_kmlocks(data, MultiTypeUnion)
 
         assert result.maybe_timestamp == timestamp
 
@@ -3088,10 +3104,10 @@ class TestDictToKmlocksConversion:
         data = {"items": [{"value": 1}, "plain"]}
 
         with patch.dict(
-            "custom_components.keymaster.coordinator.keymasterlock_type_lookup",
+            "custom_components.keymaster.serialization.keymasterlock_type_lookup",
             {"items": list[Inner]},
         ):
-            result = coordinator_for_conversion._dict_to_kmlocks(data, ListContainer)
+            result = dict_to_kmlocks(data, ListContainer)
 
         assert result.items == [Inner(value=1), "plain"]
 
@@ -3119,8 +3135,8 @@ class TestDictToKmlocksConversion:
             },
         )
 
-        stored = coordinator_for_conversion._kmlocks_to_dict(lock)
-        result = coordinator_for_conversion._dict_to_kmlocks(stored, KeymasterLock)
+        stored = cast(dict[str, Any], kmlocks_to_dict(lock))
+        result = dict_to_kmlocks(stored, KeymasterLock)
 
         assert isinstance(result, KeymasterLock)
         assert result.code_slots is not None
@@ -3148,7 +3164,7 @@ class TestKmlocksToDict:
 
     def test_kmlocks_to_dict_non_dataclass(self, coordinator_for_dict):
         """Test that non-dataclass is returned as-is."""
-        result = coordinator_for_dict._kmlocks_to_dict("just a string")
+        result = kmlocks_to_dict("just a string")
 
         assert result == "just a string"
 
@@ -3161,7 +3177,7 @@ class TestKmlocksToDict:
         )
         lock.masked_code_slots.add(1)
 
-        result = coordinator_for_dict._kmlocks_to_dict(lock)
+        result = kmlocks_to_dict(lock)
 
         assert isinstance(result, dict)
         assert "masked_code_slots" not in result
@@ -3175,7 +3191,7 @@ class TestKmlocksToDict:
 
         instance = TestClass(timestamp=dt(2025, 1, 15, 12, 30, 0))
 
-        result = coordinator_for_dict._kmlocks_to_dict(instance)
+        result = kmlocks_to_dict(instance)
 
         assert isinstance(result, dict)
         assert result["timestamp"] == "2025-01-15T12:30:00"
@@ -3189,7 +3205,7 @@ class TestKmlocksToDict:
 
         instance = TestClass(start_time=dt_time(8, 30, 0))
 
-        result = coordinator_for_dict._kmlocks_to_dict(instance)
+        result = kmlocks_to_dict(instance)
 
         assert isinstance(result, dict)
         assert result["start_time"] == "08:30:00"
@@ -3209,7 +3225,7 @@ class TestKmlocksToDict:
         inner2 = Inner(value=2)
         instance = Outer(items=[inner1, inner2])
 
-        result = coordinator_for_dict._kmlocks_to_dict(instance)
+        result = kmlocks_to_dict(instance)
 
         assert isinstance(result, dict)
         assert len(result["items"]) == 2
@@ -3229,7 +3245,7 @@ class TestKmlocksToDict:
 
         instance = Outer(slots={1: Inner(name="slot1"), 2: Inner(name="slot2")})
 
-        result = coordinator_for_dict._kmlocks_to_dict(instance)
+        result = kmlocks_to_dict(instance)
 
         assert isinstance(result, dict)
         assert result["slots"][1]["name"] == "slot1"
@@ -3260,7 +3276,7 @@ class TestKmlocksToDict:
             name="plain-scalar",
         )
 
-        result = coordinator_for_dict._kmlocks_to_dict(instance)
+        result = kmlocks_to_dict(instance)
 
         assert isinstance(result, dict)
         assert result["timestamp"] == timestamp.isoformat()
@@ -3438,7 +3454,7 @@ class TestStorageAndMigration:
         with json_file.open("w") as f:
             json.dump(sample_lock_dict, f)
 
-        result = coordinator_for_storage._migrate_legacy_json(json_file, str(json_folder))
+        result = migrate_legacy_json(json_file, str(json_folder))
 
         # File should be deleted
         assert not json_file.exists()
@@ -3457,7 +3473,7 @@ class TestStorageAndMigration:
         with json_file.open("w") as f:
             json.dump({}, f)
 
-        result = coordinator_for_storage._migrate_legacy_json(json_file, str(json_folder))
+        result = migrate_legacy_json(json_file, str(json_folder))
 
         # File should be deleted
         assert not json_file.exists()
@@ -3473,7 +3489,7 @@ class TestStorageAndMigration:
         with json_file.open("w") as f:
             f.write("not valid json {{{")
 
-        result = coordinator_for_storage._migrate_legacy_json(json_file, str(json_folder))
+        result = migrate_legacy_json(json_file, str(json_folder))
 
         # File should still be deleted
         assert not json_file.exists()
@@ -3495,7 +3511,7 @@ class TestStorageAndMigration:
             json.dump({}, f)
         other_file.write_text("some content")
 
-        coordinator_for_storage._migrate_legacy_json(json_file, str(json_folder))
+        migrate_legacy_json(json_file, str(json_folder))
 
         # JSON file should be deleted
         assert not json_file.exists()
@@ -3508,7 +3524,7 @@ class TestStorageAndMigration:
     def test_process_loaded_data_decodes_pins(self, coordinator_for_storage):
         """Test that encoded PINs are decoded when loading."""
         # Encode a PIN the same way _async_save_data would
-        encoded_pin = KeymasterCoordinator._encode_pin("1234", "entry1")
+        encoded_pin = encode_pin("1234", "entry1")
 
         config = {
             "entry1": {
@@ -3524,8 +3540,9 @@ class TestStorageAndMigration:
             },
         }
 
-        result = coordinator_for_storage._process_loaded_data(config)
+        result = process_loaded_data(config)
 
+        assert result["entry1"].code_slots is not None
         assert result["entry1"].code_slots[1].pin == "1234"
 
     def test_process_loaded_data_adds_runtime_fields(self, coordinator_for_storage):
@@ -3539,7 +3556,7 @@ class TestStorageAndMigration:
             },
         }
 
-        result = coordinator_for_storage._process_loaded_data(config)
+        result = process_loaded_data(config)
 
         assert result["entry1"].autolock_timer is None
         assert result["entry1"].listeners == []
@@ -3568,10 +3585,11 @@ class TestStorageAndMigration:
         saved_data = coordinator_for_storage._store.async_save.call_args[0][0]
 
         # Simulate reload by processing the saved data
-        reloaded = coordinator_for_storage._process_loaded_data(saved_data)
+        reloaded = process_loaded_data(saved_data)
 
         # Verify the data matches
         assert reloaded["entry1"].lock_name == "Test Lock"
+        assert reloaded["entry1"].code_slots is not None
         assert reloaded["entry1"].code_slots[1].name == "User 1"
         assert reloaded["entry1"].code_slots[1].pin == "5678"
         assert reloaded["entry1"].code_slots[1].enabled is True

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -28,7 +28,6 @@ def mock_coordinator(hass):
     with (
         patch("custom_components.keymaster.coordinator.dr.async_get"),
         patch("custom_components.keymaster.coordinator.er.async_get"),
-        patch("custom_components.keymaster.coordinator.Path"),
     ):
         coord = KeymasterCoordinator(hass)
 
@@ -355,7 +354,6 @@ def coordinator_for_unlock_test(hass):
     with (
         patch("custom_components.keymaster.coordinator.dr.async_get"),
         patch("custom_components.keymaster.coordinator.er.async_get"),
-        patch("custom_components.keymaster.coordinator.Path"),
     ):
         coord = KeymasterCoordinator(hass)
 

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -32,6 +32,7 @@ from custom_components.keymaster.lock import (
 )
 from custom_components.keymaster.number import KeymasterNumber, KeymasterNumberEntityDescription
 from custom_components.keymaster.providers._base import BaseLockProvider
+from custom_components.keymaster.serialization import kmlocks_to_dict
 from custom_components.keymaster.switch import KeymasterSwitch, KeymasterSwitchEntityDescription
 from custom_components.keymaster.text import KeymasterText, KeymasterTextEntityDescription
 from custom_components.keymaster.time import KeymasterTime, KeymasterTimeEntityDescription
@@ -584,13 +585,11 @@ class TestSerializationExclusion:
     """Test that last_code_set_at is excluded from storage serialization."""
 
     async def test_kmlocks_to_dict_excludes_last_code_set_at(self, hass: HomeAssistant):
-        """_kmlocks_to_dict should not include last_code_set_at."""
-        coordinator = KeymasterCoordinator(hass)
-
+        """kmlocks_to_dict should not include last_code_set_at."""
         slot = KeymasterCodeSlot(number=1, enabled=True, pin="1234")
         slot.last_code_set_at = utcnow()
 
-        result = coordinator._kmlocks_to_dict(slot)
+        result = kmlocks_to_dict(slot)
 
         assert isinstance(result, dict)
         assert "last_code_set_at" not in result

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,9 +1,6 @@
 """Test keymaster helpers."""
 
-from importlib import import_module
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from custom_components.keymaster.const import COORDINATOR, DOMAIN
 from custom_components.keymaster.helpers import (
@@ -12,8 +9,12 @@ from custom_components.keymaster.helpers import (
     call_hass_service,
     delete_code_slot_entities,
     dismiss_persistent_notification,
+    format_slot_message,
+    global_notification_superseded,
     send_manual_notification,
     send_persistent_notification,
+    should_defer_keypad_lock_notification,
+    should_defer_keypad_unlock_notification,
 )
 from custom_components.keymaster.large_lock_repairs import _get_kmlock_for_entry
 from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
@@ -297,18 +298,8 @@ async def test_dismiss_persistent_notification(hass):
     mock_dismiss.assert_called_once_with(hass=hass, notification_id="test_notification_id")
 
 
-@pytest.mark.xfail(
-    raises=ImportError,
-    reason="extracted in the following commit; refs #768",
-    strict=True,
-)
 def test_format_slot_message_uses_slot_name_when_available():
     """Slot notification messages include configured slot names."""
-    helpers = import_module("custom_components.keymaster.helpers")
-    try:
-        format_slot_message = helpers.format_slot_message
-    except AttributeError as exc:
-        raise ImportError("format_slot_message is not extracted yet") from exc
     lock = KeymasterLock(
         lock_name="Front Door",
         lock_entity_id="lock.front_door",
@@ -319,18 +310,8 @@ def test_format_slot_message_uses_slot_name_when_available():
     assert format_slot_message(lock, 3, "Keypad Unlock") == "Keypad Unlock by Guest [3]"
 
 
-@pytest.mark.xfail(
-    raises=ImportError,
-    reason="extracted in the following commit; refs #768",
-    strict=True,
-)
 def test_global_notification_superseded_only_for_notifying_slot():
     """Global notifications are superseded only when the slot sends its own notification."""
-    helpers = import_module("custom_components.keymaster.helpers")
-    try:
-        global_notification_superseded = helpers.global_notification_superseded
-    except AttributeError as exc:
-        raise ImportError("global_notification_superseded is not extracted yet") from exc
     lock = KeymasterLock(
         lock_name="Front Door",
         lock_entity_id="lock.front_door",
@@ -346,19 +327,8 @@ def test_global_notification_superseded_only_for_notifying_slot():
     assert global_notification_superseded(lock, 0) is False
 
 
-@pytest.mark.xfail(
-    raises=ImportError,
-    reason="extracted in the following commit; refs #768",
-    strict=True,
-)
 def test_should_defer_keypad_notifications_for_slot_zero_keypad_events():
     """Keypad slot-zero events defer when any slot notification can supersede them."""
-    helpers = import_module("custom_components.keymaster.helpers")
-    try:
-        should_defer_keypad_lock_notification = helpers.should_defer_keypad_lock_notification
-        should_defer_keypad_unlock_notification = helpers.should_defer_keypad_unlock_notification
-    except AttributeError as exc:
-        raise ImportError("keypad notification predicates are not extracted yet") from exc
     lock = KeymasterLock(
         lock_name="Front Door",
         lock_entity_id="lock.front_door",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,9 @@
 """Test keymaster helpers."""
 
+from importlib import import_module
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from custom_components.keymaster.const import COORDINATOR, DOMAIN
 from custom_components.keymaster.helpers import (
@@ -13,6 +16,7 @@ from custom_components.keymaster.helpers import (
     send_persistent_notification,
 )
 from custom_components.keymaster.large_lock_repairs import _get_kmlock_for_entry
+from custom_components.keymaster.lock import KeymasterCodeSlot, KeymasterLock
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 
@@ -291,3 +295,78 @@ async def test_dismiss_persistent_notification(hass):
         await dismiss_persistent_notification(hass, "test_notification_id")
 
     mock_dismiss.assert_called_once_with(hass=hass, notification_id="test_notification_id")
+
+
+@pytest.mark.xfail(
+    raises=ImportError,
+    reason="extracted in the following commit; refs #768",
+    strict=True,
+)
+def test_format_slot_message_uses_slot_name_when_available():
+    """Slot notification messages include configured slot names."""
+    helpers = import_module("custom_components.keymaster.helpers")
+    try:
+        format_slot_message = helpers.format_slot_message
+    except AttributeError as exc:
+        raise ImportError("format_slot_message is not extracted yet") from exc
+    lock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry-one",
+        code_slots={3: KeymasterCodeSlot(number=3, name="Guest")},
+    )
+
+    assert format_slot_message(lock, 3, "Keypad Unlock") == "Keypad Unlock by Guest [3]"
+
+
+@pytest.mark.xfail(
+    raises=ImportError,
+    reason="extracted in the following commit; refs #768",
+    strict=True,
+)
+def test_global_notification_superseded_only_for_notifying_slot():
+    """Global notifications are superseded only when the slot sends its own notification."""
+    helpers = import_module("custom_components.keymaster.helpers")
+    try:
+        global_notification_superseded = helpers.global_notification_superseded
+    except AttributeError as exc:
+        raise ImportError("global_notification_superseded is not extracted yet") from exc
+    lock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry-one",
+        code_slots={
+            1: KeymasterCodeSlot(number=1, notifications=True),
+            2: KeymasterCodeSlot(number=2, notifications=False),
+        },
+    )
+
+    assert global_notification_superseded(lock, 1) is True
+    assert global_notification_superseded(lock, 2) is False
+    assert global_notification_superseded(lock, 0) is False
+
+
+@pytest.mark.xfail(
+    raises=ImportError,
+    reason="extracted in the following commit; refs #768",
+    strict=True,
+)
+def test_should_defer_keypad_notifications_for_slot_zero_keypad_events():
+    """Keypad slot-zero events defer when any slot notification can supersede them."""
+    helpers = import_module("custom_components.keymaster.helpers")
+    try:
+        should_defer_keypad_lock_notification = helpers.should_defer_keypad_lock_notification
+        should_defer_keypad_unlock_notification = helpers.should_defer_keypad_unlock_notification
+    except AttributeError as exc:
+        raise ImportError("keypad notification predicates are not extracted yet") from exc
+    lock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry-one",
+        code_slots={1: KeymasterCodeSlot(number=1, notifications=True)},
+    )
+
+    assert should_defer_keypad_unlock_notification(lock, 0, "Keypad Unlock") is True
+    assert should_defer_keypad_lock_notification(lock, 0, "Keypad Lock") is True
+    assert should_defer_keypad_unlock_notification(lock, 1, "Keypad Unlock") is False
+    assert should_defer_keypad_lock_notification(lock, 0, "Manual Lock") is False

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,139 @@
+"""Tests for Keymaster serialization helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime as dt, time as dt_time
+from importlib import import_module
+import json
+
+import pytest
+
+from custom_components.keymaster.lock import (
+    KeymasterCodeSlot,
+    KeymasterCodeSlotDayOfWeek,
+    KeymasterLock,
+)
+
+
+@pytest.mark.xfail(
+    raises=ImportError,
+    reason="extracted in the following commit; refs #768",
+    strict=True,
+)
+def test_pin_encode_decode_roundtrip() -> None:
+    """PIN helpers encode salted data and decode it back to the original PIN."""
+    serialization = import_module("custom_components.keymaster.serialization")
+
+    encoded = serialization.encode_pin("1234", "entry-one")
+
+    assert encoded != "1234"
+    assert serialization.decode_pin(encoded, "entry-one") == "1234"
+
+
+@pytest.mark.xfail(
+    raises=ImportError,
+    reason="extracted in the following commit; refs #768",
+    strict=True,
+)
+def test_kmlock_round_trip_preserves_temporal_collections() -> None:
+    """Lock dataclasses round-trip through JSON-safe dictionaries."""
+    serialization = import_module("custom_components.keymaster.serialization")
+
+    lock = KeymasterLock(
+        lock_name="Front Door",
+        lock_entity_id="lock.front_door",
+        keymaster_config_entry_id="entry-one",
+        code_slots={
+            1: KeymasterCodeSlot(
+                number=1,
+                name="Guest",
+                pin="1357",
+                accesslimit_date_range_start=dt(2026, 1, 2, 3, 4, 5),
+                accesslimit_day_of_week={
+                    0: KeymasterCodeSlotDayOfWeek(
+                        day_of_week_num=0,
+                        day_of_week_name="monday",
+                        time_start=dt_time(8, 30),
+                    )
+                },
+            )
+        },
+    )
+
+    stored = serialization.kmlocks_to_dict(lock)
+    restored = serialization.dict_to_kmlocks(stored, KeymasterLock)
+
+    assert stored["code_slots"][1]["accesslimit_date_range_start"] == "2026-01-02T03:04:05"
+    assert stored["code_slots"][1]["accesslimit_day_of_week"][0]["time_start"] == "08:30:00"
+    assert isinstance(restored, KeymasterLock)
+    assert restored.code_slots is not None
+    assert restored.code_slots[1].accesslimit_day_of_week is not None
+    assert isinstance(restored.code_slots[1], KeymasterCodeSlot)
+    assert restored.code_slots[1].accesslimit_date_range_start == dt(2026, 1, 2, 3, 4, 5)
+    assert restored.code_slots[1].accesslimit_day_of_week[0].time_start == dt_time(8, 30)
+
+
+@pytest.mark.xfail(
+    raises=ImportError,
+    reason="extracted in the following commit; refs #768",
+    strict=True,
+)
+def test_process_loaded_data_decodes_pins_and_adds_runtime_fields() -> None:
+    """Stored lock dictionaries are restored with decoded PINs and runtime fields."""
+    serialization = import_module("custom_components.keymaster.serialization")
+
+    config = {
+        "entry-one": {
+            "lock_name": "Front Door",
+            "lock_entity_id": "lock.front_door",
+            "keymaster_config_entry_id": "entry-one",
+            "code_slots": {
+                "1": {"number": 1, "pin": serialization.encode_pin("8642", "entry-one")}
+            },
+        }
+    }
+
+    result = serialization.process_loaded_data(config)
+
+    lock = result["entry-one"]
+    assert isinstance(lock, KeymasterLock)
+    assert lock.autolock_timer is None
+    assert lock.listeners == []
+    assert lock.code_slots is not None
+    assert lock.code_slots[1].pin == "8642"
+
+
+@pytest.mark.xfail(
+    raises=ImportError,
+    reason="extracted in the following commit; refs #768",
+    strict=True,
+)
+def test_migrate_legacy_json_processes_and_removes_file(tmp_path) -> None:
+    """Legacy JSON migration loads data, deletes the file, and removes an empty folder."""
+    serialization = import_module("custom_components.keymaster.serialization")
+
+    legacy_dir = tmp_path / "keymaster"
+    legacy_dir.mkdir()
+    legacy_file = legacy_dir / "keymaster_kmlocks.json"
+    legacy_file.write_text(
+        json.dumps(
+            {
+                "entry-one": {
+                    "lock_name": "Front Door",
+                    "lock_entity_id": "lock.front_door",
+                    "keymaster_config_entry_id": "entry-one",
+                    "code_slots": {
+                        "1": {"number": 1, "pin": serialization.encode_pin("2468", "entry-one")}
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = serialization.migrate_legacy_json(legacy_file, str(legacy_dir))
+
+    assert result["entry-one"].code_slots is not None
+    assert result["entry-one"].code_slots[1].pin == "2468"
+    assert not legacy_file.exists()
+    assert not legacy_dir.exists()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -3,42 +3,35 @@
 from __future__ import annotations
 
 from datetime import datetime as dt, time as dt_time
-from importlib import import_module
 import json
-
-import pytest
+from typing import Any, cast
+from unittest.mock import patch
 
 from custom_components.keymaster.lock import (
     KeymasterCodeSlot,
     KeymasterCodeSlotDayOfWeek,
     KeymasterLock,
 )
-
-
-@pytest.mark.xfail(
-    raises=ImportError,
-    reason="extracted in the following commit; refs #768",
-    strict=True,
+from custom_components.keymaster.serialization import (
+    decode_pin,
+    dict_to_kmlocks,
+    encode_pin,
+    kmlocks_to_dict,
+    migrate_legacy_json,
+    process_loaded_data,
 )
+
+
 def test_pin_encode_decode_roundtrip() -> None:
     """PIN helpers encode salted data and decode it back to the original PIN."""
-    serialization = import_module("custom_components.keymaster.serialization")
-
-    encoded = serialization.encode_pin("1234", "entry-one")
+    encoded = encode_pin("1234", "entry-one")
 
     assert encoded != "1234"
-    assert serialization.decode_pin(encoded, "entry-one") == "1234"
+    assert decode_pin(encoded, "entry-one") == "1234"
 
 
-@pytest.mark.xfail(
-    raises=ImportError,
-    reason="extracted in the following commit; refs #768",
-    strict=True,
-)
 def test_kmlock_round_trip_preserves_temporal_collections() -> None:
     """Lock dataclasses round-trip through JSON-safe dictionaries."""
-    serialization = import_module("custom_components.keymaster.serialization")
-
     lock = KeymasterLock(
         lock_name="Front Door",
         lock_entity_id="lock.front_door",
@@ -60,8 +53,8 @@ def test_kmlock_round_trip_preserves_temporal_collections() -> None:
         },
     )
 
-    stored = serialization.kmlocks_to_dict(lock)
-    restored = serialization.dict_to_kmlocks(stored, KeymasterLock)
+    stored = cast(dict[str, Any], kmlocks_to_dict(lock))
+    restored = dict_to_kmlocks(stored, KeymasterLock)
 
     assert stored["code_slots"][1]["accesslimit_date_range_start"] == "2026-01-02T03:04:05"
     assert stored["code_slots"][1]["accesslimit_day_of_week"][0]["time_start"] == "08:30:00"
@@ -73,27 +66,18 @@ def test_kmlock_round_trip_preserves_temporal_collections() -> None:
     assert restored.code_slots[1].accesslimit_day_of_week[0].time_start == dt_time(8, 30)
 
 
-@pytest.mark.xfail(
-    raises=ImportError,
-    reason="extracted in the following commit; refs #768",
-    strict=True,
-)
 def test_process_loaded_data_decodes_pins_and_adds_runtime_fields() -> None:
     """Stored lock dictionaries are restored with decoded PINs and runtime fields."""
-    serialization = import_module("custom_components.keymaster.serialization")
-
     config = {
         "entry-one": {
             "lock_name": "Front Door",
             "lock_entity_id": "lock.front_door",
             "keymaster_config_entry_id": "entry-one",
-            "code_slots": {
-                "1": {"number": 1, "pin": serialization.encode_pin("8642", "entry-one")}
-            },
+            "code_slots": {"1": {"number": 1, "pin": encode_pin("8642", "entry-one")}},
         }
     }
 
-    result = serialization.process_loaded_data(config)
+    result = process_loaded_data(config)
 
     lock = result["entry-one"]
     assert isinstance(lock, KeymasterLock)
@@ -103,15 +87,8 @@ def test_process_loaded_data_decodes_pins_and_adds_runtime_fields() -> None:
     assert lock.code_slots[1].pin == "8642"
 
 
-@pytest.mark.xfail(
-    raises=ImportError,
-    reason="extracted in the following commit; refs #768",
-    strict=True,
-)
 def test_migrate_legacy_json_processes_and_removes_file(tmp_path) -> None:
     """Legacy JSON migration loads data, deletes the file, and removes an empty folder."""
-    serialization = import_module("custom_components.keymaster.serialization")
-
     legacy_dir = tmp_path / "keymaster"
     legacy_dir.mkdir()
     legacy_file = legacy_dir / "keymaster_kmlocks.json"
@@ -122,18 +99,45 @@ def test_migrate_legacy_json_processes_and_removes_file(tmp_path) -> None:
                     "lock_name": "Front Door",
                     "lock_entity_id": "lock.front_door",
                     "keymaster_config_entry_id": "entry-one",
-                    "code_slots": {
-                        "1": {"number": 1, "pin": serialization.encode_pin("2468", "entry-one")}
-                    },
+                    "code_slots": {"1": {"number": 1, "pin": encode_pin("2468", "entry-one")}},
                 }
             }
         ),
         encoding="utf-8",
     )
 
-    result = serialization.migrate_legacy_json(legacy_file, str(legacy_dir))
+    result = migrate_legacy_json(legacy_file, str(legacy_dir))
 
     assert result["entry-one"].code_slots is not None
     assert result["entry-one"].code_slots[1].pin == "2468"
     assert not legacy_file.exists()
     assert not legacy_dir.exists()
+
+
+def test_migrate_legacy_json_returns_loaded_data_when_unlink_fails(tmp_path) -> None:
+    """Legacy JSON migration keeps loaded data when file cleanup fails."""
+    legacy_dir = tmp_path / "keymaster"
+    legacy_dir.mkdir()
+    legacy_file = legacy_dir / "keymaster_kmlocks.json"
+    legacy_file.write_text(
+        json.dumps(
+            {
+                "entry-one": {
+                    "lock_name": "Front Door",
+                    "lock_entity_id": "lock.front_door",
+                    "keymaster_config_entry_id": "entry-one",
+                    "code_slots": {"1": {"number": 1, "pin": encode_pin("9753", "entry-one")}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with patch.object(type(legacy_file), "unlink", side_effect=OSError("busy")) as unlink:
+        result = migrate_legacy_json(legacy_file, str(legacy_dir))
+
+    unlink.assert_called_once_with()
+    assert result["entry-one"].code_slots is not None
+    assert result["entry-one"].code_slots[1].pin == "9753"
+    assert legacy_file.exists()
+    assert legacy_dir.exists()


### PR DESCRIPTION
# Summary

Extracts three cohesive helper clusters from the oversized Keymaster coordinator:
serialization helpers, lock state bus event helpers, and notification predicates.

## Proposed change

- Move Keymaster lock serialization and legacy JSON migration to `serialization.py`.
- Move lock state changed event firing to `bus_events.py`.
- Move notification predicate/message helpers to `helpers.py`.
- Add TDD coverage for the extracted module APIs and update existing tests to call the new helpers directly.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #768
